### PR TITLE
Task: Begin theme setup

### DIFF
--- a/packages/ui/src/stories/Text.stories.tsx
+++ b/packages/ui/src/stories/Text.stories.tsx
@@ -4,62 +4,70 @@ import React from 'react'
 import { Story, Meta } from '@storybook/react'
 import { Text, TextProps } from '../Text'
 
-export const Default = () => (
-  <Text>Text will render as a 'span' by default.</Text>
-)
+// Create a placeholder component of how args map to rendering
+const Template: Story<TextProps> = (args) => <Text {...args} />
 
-export const RenderAsAParagraphTag = () => (
-  <Text as="p">
+export const Default = Template.bind({})
+Default.args = {
+  children: `Text will render as a 'span' by default.`,
+}
+
+export const RenderAsAParagraphTag = (args) => (
+  <Text as="p" {...args}>
     Text can be rendered as another element, but please be sure to use the
-    correct semantic element to maintain an <a href="https://www.w3.org/WAI/WCAG21/Understanding/headings-and-labels.html">accessible Document Outline</a> and rely on styles for changing the appearance.
-    This message brought to you by the <a href="https://www.w3.org/WAI/standards-guidelines/wcag/">WCAG</a>. Thank you.
+    correct semantic element to maintain an{' '}
+    <a href="https://www.w3.org/WAI/WCAG21/Understanding/headings-and-labels.html">
+      accessible Document Outline
+    </a>{' '}
+    and rely on styles for changing the appearance. This message brought to you
+    by the <a href="https://www.w3.org/WAI/standards-guidelines/wcag/">WCAG</a>.
+    Thank you.
   </Text>
 )
 
-// Create a placeholder component of how args map to rendering
-const Template: Story<TextProps> = (args) => <Text {...args}>Example text</Text>
-
 export const XSmall = Template.bind({})
-XSmall.args = { size: 'xs' }
+XSmall.args = { size: 'xs', children: `Example text` }
 
 export const Small = Template.bind({})
-Small.args = { size: 'sm' }
+Small.args = { size: 'sm', children: `Example text` }
 
 export const Base = Template.bind({})
-Base.args = { size: 'base' }
+Base.args = { size: 'base', children: `Example text` }
 
 export const Large = Template.bind({})
-Large.args = { size: 'lg' }
+Large.args = { size: 'lg', children: `Example text` }
 
 export const XLarge = Template.bind({})
-XLarge.args = { size: 'xl' }
+XLarge.args = { size: 'xl', children: `Example text` }
 
 export const XXLarge = Template.bind({})
-XXLarge.args = { size: '2xl' }
+XXLarge.args = { size: '2xl', children: `Example text` }
 
 export const XXXLarge = Template.bind({})
-XXXLarge.args = { size: '3xl' }
+XXXLarge.args = { size: '3xl', children: `Example text` }
 
 export const XXXXLarge = Template.bind({})
-XXXXLarge.args = { size: '4xl' }
+XXXXLarge.args = { size: '4xl', children: `Example text` }
 
 export const XXXXXLarge = Template.bind({})
-XXXXXLarge.args = { size: '5xl' }
+XXXXXLarge.args = { size: '5xl', children: `Example text` }
 
 export const XXXXXXLarge = Template.bind({})
-XXXXXXLarge.args = { size: '6xl' }
+XXXXXXLarge.args = { size: '6xl', children: `Example text` }
 
 export const XXXXXXXLarge = Template.bind({})
-XXXXXXXLarge.args = { size: '7xl' }
+XXXXXXXLarge.args = { size: '7xl', children: `Example text` }
 
 export const XXXXXXXXLarge = Template.bind({})
-XXXXXXXXLarge.args = { size: '8xl' }
+XXXXXXXXLarge.args = { size: '8xl', children: `Example text` }
 
 export const XXXXXXXXXLarge = Template.bind({})
-XXXXXXXXXLarge.args = { size: '9xl' }
-
+XXXXXXXXXLarge.args = { size: '9xl', children: `Example text` }
 
 export default {
   title: 'Styles/Text',
   component: Text,
+  argTypes: {
+    children: { control: 'text' },
+  },
 } as Meta


### PR DESCRIPTION
This PR: 
- Add `spacing` function to `theme`. The spacing function matches the naming used on [Spacing page in Figma](https://www.figma.com/file/EUf6YnFJx0AKE8GGYDAoRO/Oxide-Design-System?node-id=5%3A5), which will enable designers and developers to speak the same language. yay. 
- Add `colors` that will primarily be used by the light and dark mode themes and nothing else. The `gray` palette and two of the `greens` are somewhat settled for now. Certainly more will get added and some colors will be tweaked. I recommend using `hsl` values as they are the most human-friendly (and designer-friendly) and will allow easy opacity manipulation via `hsla(theme.colors.example, 0.5)`.
- Setup `theme` for handling both light and dark modes and default to dark mode. Add temporary color names for each mode. These need more thought as they will be the same across each mode and should refer to the element they'll be manipulating, such as: `mainElementText`, `mainElementTextDimmed`, `buttonLabel`, `buttonBg`, but better and more thoughtful!
- Add `Text` component that follows the sizing on the [Typography page in Figma](https://www.figma.com/file/EUf6YnFJx0AKE8GGYDAoRO/Oxide-Design-System?node-id=3%3A4207). These scales may change when the font-family changes. Both the sans-serif and monospace font follow the same size scale, so `Text` can be used for either. 
- Add `fonts` to `theme`

