### PR TITLE
Feature: Add Breadcrumbs component

### DIFF
--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -1,3 +1,4 @@
+export * from './lib/breadcrumbs/Breadcrumbs'
 export * from './lib/button/Button'
 export * from './lib/icon/Icon'
 export * from './lib/text/Text'

--- a/libs/ui/src/lib/breadcrumbs/Breadcrumbs.spec.tsx
+++ b/libs/ui/src/lib/breadcrumbs/Breadcrumbs.spec.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+
+import Breadcrumbs from './Breadcrumbs'
+
+describe('Breadcrumbs', () => {
+  it('should render successfully', () => {
+    const { baseElement } = render(<Breadcrumbs />)
+    expect(baseElement).toBeTruthy()
+  })
+})

--- a/libs/ui/src/lib/breadcrumbs/Breadcrumbs.stories.tsx
+++ b/libs/ui/src/lib/breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { Story, Meta } from '@storybook/react'
+import { Breadcrumbs, BreadcrumbsProps } from './Breadcrumbs'
+
+// Follow https://github.com/storybookjs/storybook/issues/12078
+// for allowing better controls for objects
+export default {
+  component: Breadcrumbs,
+  title: 'Components/Breadcrumbs',
+  argTypes: {
+    data: {
+      control: { type: 'object' },
+    },
+  },
+} as Meta
+
+const Template: Story<BreadcrumbsProps> = (args) => <Breadcrumbs {...args} />
+
+export const Default = Template.bind({})
+Default.args = {
+  data: [
+    { href: '/', label: 'Home' },
+    { href: '/first', label: 'First page' },
+    { href: '/second', label: 'Second page' },
+  ],
+}

--- a/libs/ui/src/lib/breadcrumbs/Breadcrumbs.tsx
+++ b/libs/ui/src/lib/breadcrumbs/Breadcrumbs.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+
+import { Text } from '../text/Text'
+import styled from 'styled-components'
+
+export interface BreadcrumbsProps {
+  /**
+   * Render an ordered list using this 'data' prop. Each item in the array is an object with the keys 'href' and 'label'. Links will render if an 'href' is present. The name of the breadcrumb will be the corresponding 'label'.
+   */
+  data?: { href?: string; label: string }[]
+}
+
+const StyledList = styled.ol`
+  text-transform: uppercase;
+`
+
+const StyledListItem = styled.li`
+  position: relative;
+  display: inline-block;
+  margin-left: ${({ theme }) => theme.spacing(2)};
+  padding-left: ${({ theme }) => theme.spacing(3)};
+  &:first-child {
+    margin-left: 0;
+    padding-left: 0;
+  }
+  &:not(:first-child):before {
+    content: '/';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+  }
+`
+
+export const Breadcrumbs: React.FC<BreadcrumbsProps> = ({ data, ...rest }) => {
+  if (data && !!data.length) {
+    return (
+      <StyledList {...rest}>
+        {data.map((item, index) => {
+          if (item.href) {
+            return (
+              <StyledListItem key={`breadcrumbs-${index}`}>
+                <a href={item.href}>
+                  <Text size="sm">{item.label}</Text>
+                </a>
+              </StyledListItem>
+            )
+          }
+          return (
+            <StyledListItem key={`breadcrumbs-${index}`}>
+              <Text size="sm">{item.label}</Text>
+            </StyledListItem>
+          )
+        })}
+      </StyledList>
+    )
+  }
+  return null
+}
+
+export default Breadcrumbs

--- a/libs/ui/src/lib/button/Button.stories.tsx
+++ b/libs/ui/src/lib/button/Button.stories.tsx
@@ -4,7 +4,7 @@ import { Button, ButtonProps, sizes, variants } from './Button'
 
 export default {
   component: Button,
-  title: 'Button',
+  title: 'Components/Button',
   argTypes: {
     disabled: {
       table: {


### PR DESCRIPTION
This PR: 
- Pull out `<Breadcrumbs />` component from #19 
- Add comment linking to storybook issue about better controls for object props 
- Add 'Components' heading to storybook