### PR TITLE
Mock *.svg files in test so they still work

### DIFF
--- a/jest.preset.js
+++ b/jest.preset.js
@@ -1,3 +1,8 @@
 const nxPreset = require('@nrwl/jest/preset')
 
-module.exports = { ...nxPreset }
+module.exports = {
+  ...nxPreset,
+  moduleNameMapper: {
+    '\\.(svg)$': '<rootDir>/__mocks__/svgMock.tsx',
+  },
+}

--- a/libs/ui/__mocks__/svgMock.tsx
+++ b/libs/ui/__mocks__/svgMock.tsx
@@ -1,0 +1,4 @@
+import React from 'react'
+
+export default 'svg-file-stub'
+export const ReactComponent = ({ title }) => <div>Icon: {title}</div>

--- a/libs/ui/src/lib/icon/Icon.spec.tsx
+++ b/libs/ui/src/lib/icon/Icon.spec.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render } from '../../test-utils'
 
 import Icon from './Icon'
 
 describe('Icon', () => {
-  it.skip('should render successfully', () => {
+  it('should render successfully', () => {
     // See: https://github.com/nrwl/nx/issues/4565
-    // const { baseElement } = render(<Icon name="bookmark" />)
-    // expect(baseElement).toBeTruthy()
+    const { baseElement } = render(<Icon name="bookmark" />)
+    expect(baseElement).toBeTruthy()
   })
 })


### PR DESCRIPTION
Extracted from #37 

Mocking out the SVG files so tests which rely on rendering components with Icons don't fail.

N.B. this only fixes tests in the UI package. More exploration is required for making App work