### PR TITLE
Export the Text styled component directly

### DIFF
--- a/libs/ui/src/lib/text/Text.tsx
+++ b/libs/ui/src/lib/text/Text.tsx
@@ -133,5 +133,10 @@ export const Text = styled.span<TextProps>`
 
   ${(props) => getSizeStyles(props.size)};
 `
+Text.defaultProps = {
+  font: 'sans',
+  size: 'base',
+  weight: 400,
+}
 
 export default Text


### PR DESCRIPTION
This is so things like `as` work properly. Also making it so `Text` doesn't have defaults and overwrite existing styles when nested inside each other