### PR TITLE
Bug: Add box-sizing CSS

### DIFF
--- a/libs/theme/src/lib/global/index.ts
+++ b/libs/theme/src/lib/global/index.ts
@@ -4,8 +4,13 @@ import { normalize } from './normalize'
 import './fonts.css'
 
 const globalStyles = css`
+  * {
+    box-sizing: inherit;
+  }
   html,
   body {
+    box-sizing: border-box;
+
     background-color: ${(props) => props.theme.themeColors.gray900};
     color: ${(props) => props.theme.themeColors.gray300};
     font-family: ${(props) => props.theme.fonts.mono};


### PR DESCRIPTION
This PR: 
- Add a global CSS selector with `box-sizing: inherit;` 
- Set the default box-sizing to `border-box` on `html` and `body` elements 