### PR TITLE
Fix typing of SVGs so they don't fail typechecking when props are added

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,8 +2,6 @@ type SvgrComponent = React.FC<React.SVGProps<SVGSVGElement>>
 
 declare module '*.svg' {
   const ReactComponent: SvgrComponent
-  const content: string
 
-  export { ReactComponent }
-  export default content
+  export default ReactComponent
 }


### PR DESCRIPTION
See here: https://github.com/oxidecomputer/console/pull/101/checks?check_run_id=2143297770