### PR TITLE
Dark mode toggle in storybook

### DIFF
--- a/libs/theme/src/lib/global/index.ts
+++ b/libs/theme/src/lib/global/index.ts
@@ -11,8 +11,8 @@ const globalStyles = css`
   body {
     box-sizing: border-box;
 
-    background-color: ${(props) => props.theme.themeColors.gray900};
-    color: ${(props) => props.theme.themeColors.gray300};
+    background-color: var(--bg-primary);
+    color: var(--text-primary);
     font-family: ${(props) => props.theme.fonts.mono};
     font-weight: 500;
   }
@@ -53,6 +53,21 @@ const globalStyles = css`
   }
   a:active {
     color: ${(props) => props.theme.themeColors.gray300};
+  }
+
+  .light {
+    --bg-primary: ${({ theme }) => theme.themeColors.gray50};
+    --bg-secondary: ${({ theme }) => theme.themeColors.gray100};
+    --text-primary: ${({ theme }) => theme.themeColors.gray900};
+    --text-secondary: ${({ theme }) => theme.themeColors.green900};
+    --color-primary: ${({ theme }) => theme.themeColors.green600};
+  }
+  .dark {
+    --bg-primary: ${({ theme }) => theme.themeColors.gray900};
+    --bg-secondary: ${({ theme }) => theme.themeColors.gray900};
+    --text-primary: ${({ theme }) => theme.themeColors.green50};
+    --text-secondary: ${({ theme }) => theme.themeColors.green500};
+    --color-primary: ${({ theme }) => theme.themeColors.green400};
   }
 `
 

--- a/libs/ui/.storybook/main.js
+++ b/libs/ui/.storybook/main.js
@@ -10,6 +10,7 @@ module.exports = {
     '@storybook/addon-essentials',
     '@storybook/addon-a11y',
     '@storybook/addon-links',
+    'storybook-dark-mode',
   ],
   typescript: {
     reactDocgen: 'react-docgen-typescript',

--- a/libs/ui/.storybook/preview.js
+++ b/libs/ui/.storybook/preview.js
@@ -2,25 +2,13 @@ import React from 'react'
 import { DocsContainer } from '@storybook/addon-docs/blocks'
 import { darkUI } from './theme'
 import { ThemeProvider, createGlobalStyle } from 'styled-components'
-import { colorPalette, defaultTheme, GlobalStyle } from '@oxide/theme'
+import { useDarkMode } from 'storybook-dark-mode'
+import { themes } from '@storybook/theming'
+import { defaultTheme, GlobalStyle } from '@oxide/theme'
 
 // Bug: https://github.com/storybookjs/storybook/issues/14029
 const DocsStyleOverrides = createGlobalStyle`
-  table.sbdocs tr {
-    background-color: inherit;
-    color: inherit;
-  }
-
-  table.sbdocs tr:nth-of-type(2n) {
-    background-color: inherit;
-    color: inherit;
-  }
-
-  .sbdocs-wrapper {
-    padding-top: 1.5rem;
-  }
-
-  h1.sbdocs, h2.sbdocs, h3.sbdocs, h4.sbdocs, h5.sbdocs, h6.sbdocs, p.sbdocs {
+  h2.sbdocs, h3.sbdocs, h4.sbdocs, h5.sbdocs, h6.sbdocs, p.sbdocs {
     /* Use single direction margins only */
     margin: 1.25em 0 0 0 !important;
   }
@@ -30,32 +18,42 @@ const DocsStyleOverrides = createGlobalStyle`
   }
 `
 
-const getBackgroundColors = (colors) =>
-  Object.keys(colors).map((key) => {
-    return { name: key, value: colors[key] }
-  })
+const darkTheme = {
+  ...themes.dark,
+  appContentBg: defaultTheme.themeColors.gray900,
+  textColor: defaultTheme.themeColors.green50,
+}
+
+const lightTheme = {
+  ...themes.light,
+  appContentBg: defaultTheme.themeColors.gray50,
+  barBg: defaultTheme.themeColors.gray100,
+}
+
+const updateTheme = (context, dark) => {
+  context.parameters.docs.theme = dark ? darkTheme : lightTheme
+  return context
+}
 
 // Global Parameters
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
-  backgrounds: {
-    // Bug: background selector is broken for stories written in MDX
-    // See: https://github.com/storybookjs/storybook/issues/7978#issuecomment-726797915
-    default: 'gray900',
-    // Add background color selector with these color options
-    values: getBackgroundColors(colorPalette),
+  darkMode: {
+    stylePreview: true,
   },
   docs: {
-    // Default background does not apply to docs
-    container: ({ children, context }) => (
-      <DocsContainer context={context}>
-        <ThemeProvider theme={defaultTheme}>
-          <GlobalStyle />
-          <DocsStyleOverrides />
-          {children}
-        </ThemeProvider>
-      </DocsContainer>
-    ),
+    container: ({ children, context }) => {
+      const dark = useDarkMode()
+      return (
+        <DocsContainer context={updateTheme(context, dark)}>
+          <ThemeProvider theme={defaultTheme}>
+            <GlobalStyle />
+            <DocsStyleOverrides />
+            {children}
+          </ThemeProvider>
+        </DocsContainer>
+      )
+    },
     theme: darkUI,
   },
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "e2e": "echo 'to be implemented'",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "storybook": "NODE_ENV=production start-storybook -c libs/ui/.storybook -p 4400",
+    "storybook": "NODE_ENV=production start-storybook -c libs/ui/.storybook -p 4400 --ci",
     "typecheck": "tsc --noEmit",
     "plop": "plop"
   },
@@ -75,6 +75,7 @@
     "jest": "26.2.2",
     "plop": "^2.7.4",
     "prettier": "2.2.1",
+    "storybook-dark-mode": "^1.0.7",
     "style-loader": "^2.0.0",
     "ts-jest": "26.4.0",
     "ts-node": "^9.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7134,7 +7134,7 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-fast-deep-equal@^3.1.1:
+fast-deep-equal@^3.0.0, fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -13151,6 +13151,14 @@ store2@^2.7.1:
   resolved "https://registry.yarnpkg.com/store2/-/store2-2.12.0.tgz#e1f1b7e1a59b6083b2596a8d067f6ee88fd4d3cf"
   integrity sha512-7t+/wpKLanLzSnQPX8WAcuLCCeuSHoWdQuh9SB3xD0kNOM38DNf+0Oa+wmvxmYueRzkmh6IcdKFtvTa+ecgPDw==
 
+storybook-dark-mode@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/storybook-dark-mode/-/storybook-dark-mode-1.0.7.tgz#d2fbd7c1669fc394a9b73ca18fcb6db649a8394b"
+  integrity sha512-RcTTk26Irr+2AP7nNU+v11LXkpbcnNjpfuk3gaxQ57BqTS6mbr0hmE7H1dIW6t1ipckUz6fH3YOWp9Pe0LqJSQ==
+  dependencies:
+    fast-deep-equal "^3.0.0"
+    memoizerific "^1.11.3"
+
 stream-browserify@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.2.tgz#87521d38a44aa7ee91ce1cd2a47df0cb49dd660b"
@@ -14375,10 +14383,8 @@ watchpack@^1.7.4:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
-    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
-    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"


### PR DESCRIPTION
This is extracted from #107. It's meant to fix #35, but I don't think it satisfies requirements yet.

This initial version is done with CSS vars just to get it out quick (try it out on Vercel), but I will comment inline about how it can be pretty easily updated to pass dark and light `theme` objects to the `ThemeProvider` instead, which I think is how we really intend to do theming.

You can see in this version it looks ok but still has some issues:

![toggle](https://user-images.githubusercontent.com/3612203/112066895-8b398280-8b3d-11eb-9907-ceffce143e84.gif)
