### PR TITLE
Use avatar in global nav, make feedback button instead of link

### DIFF
--- a/libs/ui/src/lib/layout/global-nav/GlobalNav.tsx
+++ b/libs/ui/src/lib/layout/global-nav/GlobalNav.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components'
 
 import { Text } from '../../text/Text'
 import { Icon } from '../../icon/Icon'
+import { Avatar } from '../../avatar/Avatar'
 
 /* eslint-disable-next-line */
 export interface GlobalNavProps {}
@@ -34,8 +35,6 @@ const StyledText = styled(Text).attrs({
   weight: 400,
 })`
   text-transform: uppercase;
-  margin-left: ${({ theme }) => theme.spacing(8)};
-  margin-right: ${({ theme }) => theme.spacing(5)};
 `
 
 const TickBar = styled.div`
@@ -62,13 +61,18 @@ const Button = styled.button.attrs({ type: 'button' })`
   }
 `
 
+const FeedbackButton = styled(Button)`
+  margin-left: ${({ theme }) => theme.spacing(10)};
+  margin-right: ${({ theme }) => theme.spacing(4)};
+`
+
 export const GlobalNav: FC<GlobalNavProps> = () => {
   return (
     <StyledGlobalNav>
       <TickBar />
-      <Link href="#">
+      <FeedbackButton>
         <StyledText>Feedback?</StyledText>
-      </Link>
+      </FeedbackButton>
       <Button>
         <StyledIcon name="theme" />
       </Button>
@@ -82,8 +86,7 @@ export const GlobalNav: FC<GlobalNavProps> = () => {
         <StyledIcon name="notifications" />
       </Button>
       <Button>
-        {/* placeholder for profile photo? where would we get that */}
-        <StyledIcon name="profile" />
+        <Avatar isPerson size="sm" name="Some User" />
       </Button>
     </StyledGlobalNav>
   )


### PR DESCRIPTION
Resolves #105
Resolves #109

I noticed when I hover on the icon, the tooltip says Profile and not the name I passed in. Not sure if that's intended or not. `name` is [passed to `Icon`](https://github.com/oxidecomputer/console/blob/01265571327cb0d03edc75307e1d1ed734884355/libs/ui/src/lib/avatar/Avatar.tsx#L104) as `title` in `svgProps`, but it's mysteriously being dropped as a prop from the Icon component itself.

<img width="680" alt="Screen Shot 2021-03-23 at 10 51 41 AM" src="https://user-images.githubusercontent.com/3612203/112166258-d9926400-8bc5-11eb-9732-72088e2e6b23.png">

<img width="679" alt="Screen Shot 2021-03-23 at 10 51 53 AM" src="https://user-images.githubusercontent.com/3612203/112166271-dbf4be00-8bc5-11eb-8df4-1ec1d10118e0.png">
