### PR TITLE
Put icons in grid on docs page, bump size

### DIFF
--- a/libs/ui/src/lib/icon/__stories__/Icon.stories.mdx
+++ b/libs/ui/src/lib/icon/__stories__/Icon.stories.mdx
@@ -41,6 +41,25 @@ Icons are rendered as inline SVGS using the [SVGR loader](https://react-svgr.com
 
 <ArgsTable of={Icon} story="^" />
 
+## All icons
+
+<div style={{ display: 'flex', flexWrap: 'wrap', marginTop: '1rem' }}>
+  {Object.keys(icons).map((key) => (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        padding: '0.5rem',
+        fontSize: '2rem',
+        width: 200,
+      }}
+    >
+      <Icon name={key} style={{ marginRight: '1rem' }} />
+      <code>{key}</code>
+    </div>
+  ))}
+</div>
+
 ## Accessibility
 
 Each `.svg` icon should follow [accessibility best practices](https://www.deque.com/blog/creating-accessible-svgs/). In this case, it means making sure of the following:
@@ -93,30 +112,3 @@ The `<Icon />` component takes two props.
 <Canvas>
   <Story story={CustomTitle} />
 </Canvas>
-
-## All icons
-
-<table>
-  <tr>
-    <th>SVG</th>
-    <th>Name</th>
-  </tr>
-  {Object.keys(icons).map((key) => {
-    return (
-      <tr>
-        <td
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            padding: '1rem',
-          }}
-        >
-          <Icon name={key} size="3xl" />
-        </td>
-        <td>
-          <code>{key}</code>
-        </td>
-      </tr>
-    )
-  })}
-</table>


### PR DESCRIPTION
Jared uses the all icons view a lot and was being unduly burdened by the long table.

<img width="1046" alt="image" src="https://user-images.githubusercontent.com/3612203/112322634-7537d900-8c87-11eb-96f5-4720a27072c1.png">
