### PR TITLE
Update the size of the icons in the global nav

### DIFF
--- a/libs/ui/src/lib/layout/global-nav/GlobalNav.tsx
+++ b/libs/ui/src/lib/layout/global-nav/GlobalNav.tsx
@@ -18,7 +18,7 @@ const StyledGlobalNav = styled.div`
 `
 
 const StyledIcon = styled(Icon)`
-  width: ${({ theme }) => theme.spacing(7)};
+  width: ${({ theme }) => theme.spacing(6)};
 `
 
 const Link = styled.a`
@@ -83,7 +83,7 @@ export const GlobalNav: FC<GlobalNavProps> = () => {
         <StyledIcon name="notifications" />
       </Button>
       <Button>
-        <Avatar isPerson size="sm" name="Some User" />
+        <Avatar isPerson size="xs" name="Some User" />
       </Button>
     </StyledGlobalNav>
   )


### PR DESCRIPTION
This PR updates the size of the iconz in the global nav...

### Before
<img width="1025" alt="Screen Shot 2021-03-24 at 12 49 21 PM" src="https://user-images.githubusercontent.com/24152/112349768-64935d00-8c9f-11eb-8e20-c4d3d9d8d011.png">

### After
<img width="1025" alt="Screen Shot 2021-03-24 at 12 48 58 PM" src="https://user-images.githubusercontent.com/24152/112349780-665d2080-8c9f-11eb-8dd4-66403c09153e.png">
