### PR TITLE
Update color chip layout

### DIFF
--- a/libs/ui/src/lib/__stories__/Colors.stories.tsx
+++ b/libs/ui/src/lib/__stories__/Colors.stories.tsx
@@ -18,8 +18,8 @@ const ColorVisualizer = styled.div<{ value: string }>`
   border: 1px solid ${({ theme }) => theme.color('gray800')};
 `
 const ColorInfo = styled(Text).attrs({ as: 'code', font: 'mono' })`
-display: flex;
-:first-of-type {
+  display: flex;
+  :first-of-type {
     margin-bottom: ${({ theme }) => theme.spacing(3)};
   }
 `
@@ -30,10 +30,12 @@ const ColorComponent: React.FC<{ name: Color; value: string }> = ({
 }) => (
   <ColorContainer>
     <ColorVisualizer value={value} />
-    <div style={{
-      display: 'flex',
-      flexDirection: 'column'
-      }}>
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
       <ColorInfo>{name}</ColorInfo>
       <ColorInfo>{value}</ColorInfo>
     </div>


### PR DESCRIPTION
Minor update to color story layout to make it easier to see colors and read metadata.

Todo: click to copy color name.

### Before
<img width="1020" alt="Screen Shot 2021-03-24 at 1 35 25 PM" src="https://user-images.githubusercontent.com/24152/112357371-d79fd200-8ca5-11eb-8c50-31fce3129f60.png">

### After
<img width="1034" alt="Screen Shot 2021-03-24 at 1 34 57 PM" src="https://user-images.githubusercontent.com/24152/112357353-d373b480-8ca5-11eb-8d93-21962d15cdf3.png">
