### PR TITLE
Storybook needs a router for components with Links

### DIFF
--- a/libs/ui/.storybook/preview.js
+++ b/libs/ui/.storybook/preview.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import {BrowserRouter as Router} from 'react-router-dom'
 import { DocsContainer } from '@storybook/addon-docs/blocks'
 import { darkUI } from './theme'
 import { ThemeProvider, createGlobalStyle } from 'styled-components'
@@ -52,7 +53,9 @@ export const parameters = {
         <ThemeProvider theme={defaultTheme}>
           <GlobalStyle />
           <DocsStyleOverrides />
-          {children}
+          <Router>
+            {children}
+          </Router>
         </ThemeProvider>
       </DocsContainer>
     ),
@@ -64,7 +67,9 @@ export const decorators = [
   (Story) => (
     <ThemeProvider theme={defaultTheme}>
       <GlobalStyle />
-      <Story />
+      <Router>
+        <Story />
+      </Router>
     </ThemeProvider>
   ),
 ]


### PR DESCRIPTION
Breadcrumbs has a `Link` and `Link`s are not allowed to be rendered outside of a `Router`, so it breaks.

https://console-ui-storybook-git-main-oxidecomputer.vercel.app/?path=/story/components-breadcrumbs--default

I figured out a good trick to get around the `NODE_ENV=production` thing causing bad minified error messages — just take it out of the command for debugging purposes.