### PR TITLE
Feature: Sticky sidebar

### DIFF
--- a/apps/web-console/src/app-layout/AppLayout.tsx
+++ b/apps/web-console/src/app-layout/AppLayout.tsx
@@ -38,49 +38,42 @@ const Wrapper = styled.div`
   grid-template-columns: 14rem auto;
   grid-template-rows: 3.5rem auto;
   grid-template-areas:
-    'sidebar topnav'
+    'logo globalnav'
     'sidebar content';
   height: 100vh;
+
+  background-color: ${({ theme }) => theme.color('gray800')};
 `
 
 const Sidebar = styled.div`
   grid-area: sidebar;
+  margin-left: ${({ theme }) => theme.spacing(4)};
+  margin-right: ${({ theme }) => theme.spacing(4)};
+  margin-bottom: ${({ theme }) => theme.spacing(6)};
   overflow: auto;
-  padding-left: ${({ theme }) => theme.spacing(4)};
-  padding-right: ${({ theme }) => theme.spacing(4)};
 
-  background-color: ${({ theme }) => theme.color('gray800')};
+  ${({ theme }) => theme.spaceBetweenY(6)};
 `
 
 const WordmarkWrapper = styled.div`
-  z-index: 1;
-  position: sticky;
-  top: 0;
-
-  display: flex;
   align-items: center;
+  grid-area: logo;
+  display: flex;
   height: ${({ theme }) => theme.spacing(14)};
-
-  background-color: ${({ theme }) => theme.color('gray800')};
-`
-
-const SidebarLists = styled.div`
-  ${({ theme }) => theme.spaceBetweenY(6)};
+  padding-left: ${({ theme }) => theme.spacing(4)};
 `
 
 const Content = styled.main`
   grid-area: content;
   overflow: auto;
-
   padding: ${({ theme }) => `${theme.spacing(2)} ${theme.spacing(6)};`};
+
+  background-color: ${({ theme }) => theme.color('gray900')};
 `
 
 const GlobalNavContainer = styled.header`
-  position: sticky;
-  top: 0;
-
   align-self: center;
-  grid-area: topnav;
+  grid-area: globalnav;
   padding: ${({ theme }) => `${theme.spacing(4)} ${theme.spacing(6)};`};
 
   background-color: ${({ theme }) => theme.color('gray900')};
@@ -89,18 +82,16 @@ const GlobalNavContainer = styled.header`
 export default ({ children }: AppLayoutProps) => {
   return (
     <Wrapper>
+      <WordmarkWrapper>
+        <Wordmark />
+      </WordmarkWrapper>
       <Sidebar>
-        <WordmarkWrapper>
-          <Wordmark />
-        </WordmarkWrapper>
-        <SidebarLists>
-          <ProjectList
-            projects={projects}
-            onProjectSelect={() => null}
-            onProjectCreate={() => null}
-          />
-          <OperationList />
-        </SidebarLists>
+        <ProjectList
+          projects={projects}
+          onProjectSelect={() => null}
+          onProjectCreate={() => null}
+        />
+        <OperationList />
       </Sidebar>
       <GlobalNavContainer>
         <GlobalNav />


### PR DESCRIPTION
This PR resolves #149 
- Set height to 100vh for Layout 
- Allow Sidebar and Content to scroll independently 
- Add sticky behavior to Wordmark

We are treading into `z-index` waters, which are always treacherous. The notification badge uses `position: relative;` which creates its own [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context), and Wordmark’s `position: sticky` creates its own stacking context as well. With equal z-indices, whatever element that is last in the DOM 'wins'. So this PR fixes the bug seen below with `z-index: 1;`. There may be a point when the badge’s `z-index` needs to be increased in the future, which will cause this bug to pop up again.  

screenshot of bug (fixed): 
<img width="224" alt="Screen Shot 2021-03-29 at 11 42 04 AM" src="https://user-images.githubusercontent.com/768965/112884299-338ea000-9084-11eb-83d9-38cf31031ae8.png">
