### PR TITLE
Adjust icon sizes for all buttons with icons

### DIFF
--- a/libs/ui/src/lib/button/Button.tsx
+++ b/libs/ui/src/lib/button/Button.tsx
@@ -4,6 +4,7 @@ import React, { forwardRef } from 'react'
 import styled, { css } from 'styled-components'
 import type { StyledComponentProps } from 'styled-components'
 import type { Theme } from '@oxide/theme'
+import { Icon } from '../icon/Icon'
 
 export const buttonSizes = ['xs', 'sm', 'base', 'lg', 'xl'] as const
 export const variants = ['ghost', 'link', 'outline', 'solid', 'subtle'] as const
@@ -13,13 +14,23 @@ export type Variant = typeof variants[number]
 
 const sizes: Record<
   ButtonSize,
-  { fontSize: number; lineHeight: number; padding: [number, number] }
+  {
+    iconSize: number
+    fontSize: number
+    lineHeight: number
+    padding: [number, number]
+  }
 > = {
-  xs: { fontSize: 3, lineHeight: 1 / 0.75, padding: [2, 3] }, // total height: 32px
-  sm: { fontSize: 3.5, lineHeight: 1.25 / 0.875, padding: [2, 3] }, // total height: 36px
-  base: { fontSize: 3.5, lineHeight: 1.25 / 0.875, padding: [2.5, 4] }, // total height: 40px
-  lg: { fontSize: 4, lineHeight: 1.5, padding: [2.25, 4.5] }, // total height: 42px
-  xl: { fontSize: 4, lineHeight: 1.5, padding: [3, 6] }, // total height: 48px
+  xs: { iconSize: 4, fontSize: 3, lineHeight: 1 / 0.75, padding: [2, 3] }, // total height: 32px
+  sm: { iconSize: 4, fontSize: 3.5, lineHeight: 1.25 / 0.875, padding: [2, 3] }, // total height: 36px
+  base: {
+    iconSize: 5,
+    fontSize: 3.5,
+    lineHeight: 1.25 / 0.875,
+    padding: [2.5, 4],
+  }, // total height: 40px
+  lg: { iconSize: 5, fontSize: 4, lineHeight: 1.5, padding: [2.25, 4.5] }, // total height: 42px
+  xl: { iconSize: 6, fontSize: 4, lineHeight: 1.5, padding: [3, 6] }, // total height: 48px
 }
 
 export type ButtonProps = StyledComponentProps<
@@ -49,6 +60,10 @@ const getSizeStyles = (size: ButtonSize) => {
       font-size: ${({ theme }) => theme.spacing(buttonSize.fontSize)};
       line-height: ${buttonSize.lineHeight};
       padding: ${getPadding(buttonSize.padding[0], buttonSize.padding[1])};
+
+      ${Icon} {
+        width: ${({ theme }) => theme.spacing(buttonSize.iconSize)};
+      }
     `
   }
 
@@ -164,6 +179,11 @@ const StyledButton = styled.button<ButtonProps>`
   border: none;
   border-radius: 0;
   text-transform: uppercase;
+
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  vertical-align: top;
 
   ${({ size }) => size && getSizeStyles(size)};
   ${({ variant }) => variant && getVariantStyles(variant)};

--- a/libs/ui/src/lib/button/__stories__/Button.stories.mdx
+++ b/libs/ui/src/lib/button/__stories__/Button.stories.mdx
@@ -2,6 +2,8 @@
 
 import { ArgsTable, Canvas, Story, Meta } from '@storybook/addon-docs/blocks'
 import { Button, buttonSizes, variants } from '../Button'
+import { Icon } from '../../icon/Icon'
+import { TextWithIcon } from '../../text-with-icon/TextWithIcon'
 import { Default, stories } from './Button.stories'
 
 <Meta
@@ -92,6 +94,35 @@ An affirmative action is something that takes the users further in their journey
   <Story story={stories.sizes.xl} />
 </Canvas>
 
+### Button with Icons
+
+<Canvas>
+  <Story name="with icon left">
+    <Button>
+      <Icon name="pen" align="left" />
+      Edit
+    </Button>
+  </Story>
+  <Story name="with icon right">
+    <Button>
+      Create new project
+      <Icon name="plus" align="right" />
+    </Button>
+  </Story>
+  <Story name="TextWithIcon left">
+    <Button>
+      <TextWithIcon icon={{ name: 'pen' }}>Edit</TextWithIcon>
+    </Button>
+  </Story>
+  <Story name="TextWithIcon right">
+    <Button>
+      <TextWithIcon icon={{ name: 'plus' }} align="right">
+        Create new project
+      </TextWithIcon>
+    </Button>
+  </Story>
+</Canvas>
+
 ### Button Variants
 
 #### Solid
@@ -104,6 +135,14 @@ An affirmative action is something that takes the users further in their journey
   <Story story={stories.variants.solid_xl} />
 </Canvas>
 
+<Canvas>
+  <Story story={stories.withIcons.icon_solid_xs} />
+  <Story story={stories.withIcons.icon_solid_sm} />
+  <Story story={stories.withIcons.icon_solid_base} />
+  <Story story={stories.withIcons.icon_solid_lg} />
+  <Story story={stories.withIcons.icon_solid_xl} />
+</Canvas>
+
 #### Subtle
 
 <Canvas>
@@ -112,6 +151,14 @@ An affirmative action is something that takes the users further in their journey
   <Story story={stories.variants.subtle_base} />
   <Story story={stories.variants.subtle_lg} />
   <Story story={stories.variants.subtle_xl} />
+</Canvas>
+
+<Canvas>
+  <Story story={stories.withIcons.icon_subtle_xs} />
+  <Story story={stories.withIcons.icon_subtle_sm} />
+  <Story story={stories.withIcons.icon_subtle_base} />
+  <Story story={stories.withIcons.icon_subtle_lg} />
+  <Story story={stories.withIcons.icon_subtle_xl} />
 </Canvas>
 
 #### Outline
@@ -124,6 +171,14 @@ An affirmative action is something that takes the users further in their journey
   <Story story={stories.variants.outline_xl} />
 </Canvas>
 
+<Canvas>
+  <Story story={stories.withIcons.icon_outline_xs} />
+  <Story story={stories.withIcons.icon_outline_sm} />
+  <Story story={stories.withIcons.icon_outline_base} />
+  <Story story={stories.withIcons.icon_outline_lg} />
+  <Story story={stories.withIcons.icon_outline_xl} />
+</Canvas>
+
 #### Ghost
 
 <Canvas>
@@ -134,6 +189,14 @@ An affirmative action is something that takes the users further in their journey
   <Story story={stories.variants.ghost_xl} />
 </Canvas>
 
+<Canvas>
+  <Story story={stories.withIcons.icon_ghost_xs} />
+  <Story story={stories.withIcons.icon_ghost_sm} />
+  <Story story={stories.withIcons.icon_ghost_base} />
+  <Story story={stories.withIcons.icon_ghost_lg} />
+  <Story story={stories.withIcons.icon_ghost_xl} />
+</Canvas>
+
 #### Link
 
 <Canvas>
@@ -142,4 +205,12 @@ An affirmative action is something that takes the users further in their journey
   <Story story={stories.variants.link_base} />
   <Story story={stories.variants.link_lg} />
   <Story story={stories.variants.link_xl} />
+</Canvas>
+
+<Canvas>
+  <Story story={stories.withIcons.icon_link_xs} />
+  <Story story={stories.withIcons.icon_link_sm} />
+  <Story story={stories.withIcons.icon_link_base} />
+  <Story story={stories.withIcons.icon_link_lg} />
+  <Story story={stories.withIcons.icon_link_xl} />
 </Canvas>

--- a/libs/ui/src/lib/button/__stories__/Button.stories.tsx
+++ b/libs/ui/src/lib/button/__stories__/Button.stories.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import type { Story } from '@storybook/react'
 import { Button, buttonSizes, variants } from '../Button'
 import type { ButtonProps, ButtonSize, Variant } from '../Button'
+import { Icon } from '../../icon/Icon'
 
 type ButtonStory = Story<PropsWithChildren<ButtonProps>>
 
@@ -38,8 +39,41 @@ const variantSizes = variants.reduce(
         ...allSizes,
         [`${variant}_${size}`]: (() => {
           const Story = Template.bind({})
-          Story.storyName = `${size} ${variant}`
-          Story.args = { ...Default.args, variant, size }
+          Story.storyName = `${variant} ${size}`
+          Story.args = {
+            ...Default.args,
+            variant,
+            size,
+          }
+          return Story
+        })(),
+      }),
+      {} as Record<VariantSize, Story<ButtonProps>>
+    ),
+  }),
+  {} as Record<Variant, Record<ButtonSize, Story<ButtonProps>>>
+)
+
+const withIcons = variants.reduce(
+  (allVariants, variant) => ({
+    ...allVariants,
+    ...buttonSizes.reduce(
+      (allSizes, size) => ({
+        ...allSizes,
+        [`icon_${variant}_${size}`]: (() => {
+          const Story = Template.bind({})
+          Story.storyName = `${variant} with icon ${size}`
+          Story.args = {
+            ...Default.args,
+            variant,
+            size,
+            children: (
+              <>
+                <Icon name="pen" align="left" />
+                Edit
+              </>
+            ),
+          }
           return Story
         })(),
       }),
@@ -52,4 +86,5 @@ const variantSizes = variants.reduce(
 export const stories = {
   sizes,
   variants: variantSizes,
+  withIcons: withIcons,
 }

--- a/libs/ui/src/lib/icon/Icon.tsx
+++ b/libs/ui/src/lib/icon/Icon.tsx
@@ -124,6 +124,10 @@ type Name = keyof typeof icons
 
 interface StyledIconProps {
   /**
+   * Add optional margin
+   */
+  align?: 'left' | 'right'
+  /**
    * Set the color using a theme color ("green500")
    */
   color?: Color
@@ -185,6 +189,14 @@ export const Icon = styled(SvgIcon).withConfig({
     color ? theme.themeColors[color] : 'currentColor'};
 
   ${({ rotate }) => rotate && `transform: rotate(${rotate})`};
+  ${({ align }) => {
+    if (align === 'left') {
+      return `margin-right: 0.5em;`
+    }
+    if (align === 'right') {
+      return `margin-left: 0.5em;`
+    }
+  }}
 `
 
 export default Icon


### PR DESCRIPTION
This PR resolves #161 
- Adjust icon sizes for all buttons
- Add story examples using `<Icon />` and `<TextWithIcon />` 
- Add `align` prop to `<Icon />` to control the margins 