### PR TITLE
Mock API approach 1: simple mock module

### DIFF
--- a/apps/web-console/src/app/app.spec.tsx
+++ b/apps/web-console/src/app/app.spec.tsx
@@ -1,16 +1,12 @@
 import React from 'react'
-import { render } from '../test-utils'
+import { render, screen } from '../test-utils'
 
 import App from './app'
 
 describe('App', () => {
-  it('should render successfully', () => {
+  it('should render successfully', async () => {
     const { baseElement } = render(<App />)
     expect(baseElement).toBeTruthy()
-  })
-
-  it('should have a greeting as the title', () => {
-    const { getByText } = render(<App />)
-    expect(getByText('Maze War')).toBeTruthy()
+    await screen.findByText('Attached Disks')
   })
 })

--- a/apps/web-console/src/pages/instance/InstancePage.tsx
+++ b/apps/web-console/src/pages/instance/InstancePage.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { useParams } from 'react-router-dom'
 import styled from 'styled-components'
 
-// import { useApiData, api } from '@oxide/api'
+import { useApiData, api } from '@oxide/api'
 
 import {
   Breadcrumbs,
@@ -88,20 +88,20 @@ type Params = {
 }
 
 const InstancePage = () => {
-  const { /* projectName, */ instanceName } = useParams<Params>()
+  const { projectName, instanceName } = useParams<Params>()
 
-  // const { data } = useApiData(api.apiProjectInstancesGetInstance, {
-  //   instanceName,
-  //   projectName,
-  // })
+  const { data } = useApiData(api.apiProjectInstancesGetInstance, {
+    instanceName,
+    projectName,
+  })
 
-  // if (!data) return <div>loading</div>
+  if (!data) return <div>loading</div>
 
   return (
     <Wrapper>
       <Breadcrumbs data={breadcrumbs} />
       <Header>
-        <Title>{instanceName}</Title>
+        <Title>{data.name}</Title>
         <Actions>
           <InstanceAction>
             <TextWithIcon icon={{ name: 'pen' }}>Edit</TextWithIcon>

--- a/libs/api/index.ts
+++ b/libs/api/index.ts
@@ -2,25 +2,27 @@ export * from './generated'
 export * from './hooks'
 
 import { DefaultApi, Configuration } from './generated'
+import mockApi from './mock'
 
-const prodConfig = new Configuration({ basePath: '/api' })
-const devConfig = new Configuration({ basePath: '/api' })
+function getDevApi() {
+  const config = new Configuration({ basePath: '/api' })
+  const api = new DefaultApi(config)
 
-const api =
-  process.env.NODE_ENV === 'production'
-    ? new DefaultApi(prodConfig)
-    : new DefaultApi(devConfig)
+  // the API methods rely on `this` being bound to the API object. in order to
+  // pass the methods around as arguments without explicitly calling .bind(this)
+  // every time, we just bind them all right here. TS doesn't like this, so we throw
+  // an `any` in there, but it's all above board.
+  Object.getOwnPropertyNames(DefaultApi.prototype)
+    .filter((prop) => prop.startsWith('api'))
+    .forEach((prop) => {
+      const key = prop as keyof DefaultApi
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(api as any)[key] = api[key].bind(api)
+    })
 
-export { api }
+  return api
+}
 
-// the API methods rely on `this` being bound to the API object. in order to
-// pass the methods around as arguments without explicitly calling .bind(this)
-// every time, we just bind them all right here. TS doesn't like this, so we throw
-// an `any` in there, but it's all above board.
-Object.getOwnPropertyNames(DefaultApi.prototype)
-  .filter((prop) => prop.startsWith('api'))
-  .forEach((prop) => {
-    const key = prop as keyof DefaultApi
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ;(api as any)[key] = api[key].bind(api)
-  })
+const env = process.env.NODE_ENV
+export const api =
+  env === 'production' || env === 'test' ? mockApi : getDevApi()

--- a/libs/api/mock/index.ts
+++ b/libs/api/mock/index.ts
@@ -1,0 +1,26 @@
+import { ApiInstanceState } from '../generated'
+import type {
+  ApiProjectInstancesGetInstanceRequest,
+  ApiInstanceView1,
+} from '../generated'
+
+export default {
+  apiProjectInstancesGetInstance(
+    params: ApiProjectInstancesGetInstanceRequest
+  ): Promise<ApiInstanceView1> {
+    return Promise.resolve({
+      id: '96507040-23f1-4a2d-90d5-4d195f25a7d1',
+      name: params.instanceName,
+      description: `an instance called ${params.instanceName}`,
+      timeCreated: new Date(),
+      timeModified: new Date(),
+      projectId: '6a7f3faa-df71-4255-8b37-362a91809f6e',
+      ncpus: 1,
+      memory: 256,
+      bootDiskSize: 1,
+      hostname: 'prod-online',
+      runState: ApiInstanceState.Running,
+      timeRunStateUpdated: new Date(),
+    })
+  },
+}

--- a/libs/ui/src/test-utils.tsx
+++ b/libs/ui/src/test-utils.tsx
@@ -4,9 +4,12 @@ import type { RenderOptions } from '@testing-library/react'
 import { render } from '@testing-library/react'
 import { ThemeProvider } from 'styled-components'
 import { defaultTheme } from '@oxide/theme'
+import { SWRConfig } from 'swr'
 
 const Providers: FC = ({ children }) => (
-  <ThemeProvider theme={defaultTheme}>{children}</ThemeProvider>
+  <SWRConfig value={{ dedupingInterval: 0 }}>
+    <ThemeProvider theme={defaultTheme}>{children}</ThemeProvider>
+  </SWRConfig>
 )
 
 const customRender = (


### PR DESCRIPTION
The idea here would be that for local dev, we expect the API to be running. In "production" we use a mock API object with the same interface. As you can see on Vercel, it does work.

### Advantages

- Same for both tests and production
- Simple, it's just a module. No weird service worker stuff

### Disadvantages

- Different environments in production and development mean we'll often see something work great in dev and then break in production because we didn't update the mocks or whatever
- This only lasts as long as we don't need to do POSTs and see them reflected in the actual data. At that point it seems we would want a real API. That point could be very soon.
- We have to spend the effort of building mock API endpoints. This isn't bad, at least for GETs, because they can be very simple, but the simpler they are, the less useful they are. On the other hand, we have to have a lot of mock data no matter what, because we will have plenty of unit tests for components that do not have API calls in them.