### PR TITLE
Turn on typescript 3+ flag in api client generator

### DIFF
--- a/libs/api/__generated__/.openapi-generator/FILES
+++ b/libs/api/__generated__/.openapi-generator/FILES
@@ -1,4 +1,3 @@
-.openapi-generator-ignore
 apis/DefaultApi.ts
 apis/index.ts
 index.ts

--- a/libs/api/__generated__/runtime.ts
+++ b/libs/api/__generated__/runtime.ts
@@ -145,7 +145,7 @@ export const COLLECTION_FORMATS = {
   pipes: '|',
 }
 
-export type FetchAPI = GlobalFetch['fetch']
+export type FetchAPI = WindowOrWorkerGlobalScope['fetch']
 
 export interface ConfigurationParameters {
   basePath?: string // override base path

--- a/tools/generate_api_client.sh
+++ b/tools/generate_api_client.sh
@@ -7,6 +7,7 @@
 # prereq: brew install openapi-generator
 
 # couldn't get it to pipe directly with /dev/stdin. it really wants a filename
-openapi-generator generate -i omicron.json -o libs/api/__generated__ -g typescript-fetch
+openapi-generator generate -i omicron.json -o libs/api/__generated__ -g typescript-fetch \
+  --additional-properties=typescriptThreePlus=true
 rm omicron.json
 yarn format > /dev/null 2>&1


### PR DESCRIPTION
`GlobalFetch` used to be a global type built into TS, but it's not anymore. It's not causing a problem on main, but I was messing with TS on a branch and discovered that the only reason `GlobalFetch` in the generated code doesn't break is we're getting it from `@types/react-native`, which is pulled in by `@types/styled-components`. Turns out there's an official way to tell the generator to use `WindowOrWorkerGlobalScope` instead, which is the [official](https://devblogs.microsoft.com/typescript/announcing-typescript-3-6/#dom-updates) TS answer.

https://github.com/OpenAPITools/openapi-generator/issues/3798