### PR TITLE
Use tsconfig paths plugin for webpack aliases

### DIFF
--- a/webpack.shared.config.ts
+++ b/webpack.shared.config.ts
@@ -1,5 +1,5 @@
-import path from 'path'
 import HtmlWebpackPlugin from 'html-webpack-plugin'
+import TsconfigPathsPlugin from 'tsconfig-paths-webpack-plugin'
 
 export default {
   entry: './apps/web-console/src/main.tsx',
@@ -46,11 +46,11 @@ export default {
   },
   resolve: {
     extensions: ['.tsx', '.ts', '.js'],
-    alias: {
-      '@oxide/theme': path.resolve(__dirname, 'libs/theme/src/'),
-      '@oxide/ui': path.resolve(__dirname, 'libs/ui/src/'),
-      '@oxide/api': path.resolve(__dirname, 'libs/api/'),
-    },
+    plugins: [
+      new TsconfigPathsPlugin({
+        configFile: './tsconfig.json',
+      }),
+    ],
   },
   plugins: [
     new HtmlWebpackPlugin({


### PR DESCRIPTION
Doesn't make sense to duplicate the set of package aliases for webpack and TS. I didn't do this originally because `webpack-merge` was being a jerk, rejecting the type on the plugin. It's fine now that I stopped using merge [here](https://github.com/oxidecomputer/console/commit/dc5e8dec82c0e48adb33f01bffaa2220c91ea403#diff-84ea831ecf7ddc4e4fb136d097f5cdc4bd49edc82d3ee8d578a47f7d905b7ffeL7-R6).