### PR TITLE
Browserslist tweaks

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -5,12 +5,14 @@
 # For additional information regarding the format and rule options, please see:
 # https://github.com/browserslist/browserslist#queries
 #
-# If you need to support different browsers in production, you may tweak the list below.
+# to see the actual set of browsers this produces, run
+#
+#   npx browserslists --config=.browserslistrc
 
-last 1 Chrome version
-last 1 Firefox version
-last 2 Edge major versions
-last 2 Safari major version
-last 2 iOS major versions
+# equivalent to 'defaults'
+> 0.5%
+last 2 versions
 Firefox ESR
-not IE 9-11 # For IE 9-11 support, remove 'not'.
+not dead
+
+not IE 9-11


### PR DESCRIPTION
Closes #89 

The immediate purpose of this PR is to establish more or less firmly that we are not supporting IE. This is relevant because we are wondering in #229 whether we need to worry about [non-standard `event.key` values](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values) that only show up in IE 11. It is a plausible choice because MS is [dropping](https://techcommunity.microsoft.com/t5/microsoft-365-blog/microsoft-365-apps-say-farewell-to-internet-explorer-11-and/ba-p/1591666) IE support for all MS 365 apps and services in August 2021. @jessfraz can't think of a reason why we would need to support IE.

This also shrinks our production bundle from 385 KB to 326 KB — pretty good.

### Changes

- Move `.browserslist` to top level so it gets picked up by Webpack. Having it inside `web-console` probably worked in Nx world because everything had its own webpack config, but it wasn't working now.
-  Change the set of browsers supported to the browserslist default plus no IE, following [best practices](https://github.com/browserslist/browserslist/tree/209adf9e0051fa39a2b25354cffd493300f34b02#best-practices) from the Browserslist readme:

> If you want to change the default set of browsers, we recommend combining last 2 versions, not dead with a usage number like > 0.2%. This is because last n versions on its own does not add popular old versions, while only using a percentage above 0.2% will in the long run make popular browsers even more popular.
>
> Select browsers directly (last 2 Chrome versions) only if you are making a web app for a kiosk with one browser. There are a lot of browsers on the market. If you are making general web app you should respect browsers diversity.


<details>
<summary>Diff of resulting lists of supported browsers</summary>

```diff
+and_chr 89
+and_ff 86
+and_qq 10.4
+and_uc 12.12
+android 89
+baidu 7.12
 chrome 89
+chrome 88
+chrome 87
 edge 89
 edge 88
 firefox 87
+firefox 86
 firefox 78
 ios_saf 14.0-14.5
 ios_saf 13.4-13.7
-ios_saf 13.3
-ios_saf 13.2
-ios_saf 13.0-13.1
+kaios 2.5
+op_mini all
+op_mob 62
+opera 73
+opera 72
 safari 14
 safari 13.1
-safari 13
+samsung 13.0
+samsung 12.0
```
</details>