### PR TITLE
Update global focus style

### DIFF
--- a/libs/theme/src/lib/global/index.ts
+++ b/libs/theme/src/lib/global/index.ts
@@ -43,6 +43,11 @@ const globalStyles = css`
     color: inherit;
     text-decoration: none;
   }
+
+  &:focus {
+    outline: 1px solid ${(props) => props.theme.themeColors.green500};
+    outline-offset: 2px;
+  }
 `
 
 export const GlobalStyle = createGlobalStyle`

--- a/libs/ui/src/lib/layout/sidebar-navigation/operation-list/OperationList.tsx
+++ b/libs/ui/src/lib/layout/sidebar-navigation/operation-list/OperationList.tsx
@@ -34,10 +34,6 @@ const BaseLink = styled.a`
   :hover {
     background-color: ${({ theme }) => theme.color('gray700')};
   }
-
-  :focus {
-    outline: 1px solid ${({ theme }) => theme.color('blue500')};
-  }
 `
 
 const ListItemLink = styled(BaseLink)`

--- a/libs/ui/src/lib/layout/sidebar-navigation/project-list/ProjectList.tsx
+++ b/libs/ui/src/lib/layout/sidebar-navigation/project-list/ProjectList.tsx
@@ -63,10 +63,6 @@ const ListItem = styled(Row).attrs({ as: 'li' })`
   :hover {
     background-color: ${({ theme }) => theme.color('gray700')};
   }
-
-  :focus {
-    outline: 1px solid ${({ theme }) => theme.color('blue500')};
-  }
 `
 
 const StyledLink = styled(NavLink)`


### PR DESCRIPTION
This PR introduces a draft for a global focus style. It removes the blue focus previously on the sidebar nav items. This also somehow kinda fixes that weird focus issue around content in the main content area. 

<img width="1247" alt="Screen Shot 2021-04-20 at 4 12 36 PM" src="https://user-images.githubusercontent.com/24152/115458063-40219680-a1f3-11eb-9213-493d9d581628.png">

Noticed an issue where the list items in the sidebar don't focus correctly.
<img width="216" alt="Screen Shot 2021-04-20 at 4 11 38 PM" src="https://user-images.githubusercontent.com/24152/115457999-2a13d600-a1f3-11eb-9203-d965fe9fe647.png">

PS The projects list items in the sidebar require 2 clicks to move to the next item. This isn't true of the operations section.