### PR TITLE
Use real instance data on instance page

### DIFF
--- a/apps/web-console/src/pages/instance/InstancePage.tsx
+++ b/apps/web-console/src/pages/instance/InstancePage.tsx
@@ -74,7 +74,7 @@ const InstancePage = () => {
   const breadcrumbs = useBreadcrumbs()
   const { projectName, instanceName } = useParams<Params>()
 
-  const { data, error } = useApi('apiProjectInstancesGetInstance', {
+  const { data: instance, error } = useApi('apiProjectInstancesGetInstance', {
     instanceName,
     projectName,
   })
@@ -86,13 +86,13 @@ const InstancePage = () => {
       return <div>loading</div>
     }
   }
-  if (!data) return <div>loading</div>
+  if (!instance) return <div>loading</div>
 
   return (
     <Wrapper>
       <Breadcrumbs data={breadcrumbs} />
       <PageHeader>
-        <Title>{instanceName}</Title>
+        <Title>{instance.name}</Title>
         <Actions>
           <InstanceAction>
             <TextWithIcon icon={{ name: 'pen' }}>Edit</TextWithIcon>
@@ -116,14 +116,7 @@ const InstancePage = () => {
         </Actions>
       </PageHeader>
       <Metadata>
-        <InstanceDetails
-          cpu="2"
-          memory="8 GB"
-          storage="100 GB"
-          vm={{ os: 'Debian', version: '9.12', arch: 'x64' }}
-          hostname="db1.useast1.inst"
-          ip="10.10.16.7"
-        />
+        <InstanceDetails instance={instance} />
       </Metadata>
       <StyledTabs
         fullWidth

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,14 @@
 const { compilerOptions } = require('./tsconfig')
 
-const mapValues = (obj, f) =>
-  Object.fromEntries(Object.entries(obj).map(([k, v]) => [k, f(v)]))
+const mapObj = (obj, kf, vf) =>
+  Object.fromEntries(Object.entries(obj).map(([k, v]) => [kf(k), vf(v)]))
 
-const libs = mapValues(compilerOptions.paths, ([path]) => `<rootDir>/${path}`)
+const libs = mapObj(
+  compilerOptions.paths,
+  // need full matches, otherwise @oxide/api matches @oxide/api-mocks
+  (moduleName) => `^${moduleName}$`,
+  (paths) => `<rootDir>/${paths[0]}`
+)
 
 module.exports = {
   moduleNameMapper: {

--- a/libs/api-mocks/index.ts
+++ b/libs/api-mocks/index.ts
@@ -1,0 +1,1 @@
+export { instance } from './instance'

--- a/libs/api-mocks/instance.ts
+++ b/libs/api-mocks/instance.ts
@@ -1,0 +1,16 @@
+import type { ApiInstanceView } from '@oxide/api'
+import { ApiInstanceState } from '@oxide/api'
+
+export const instance: ApiInstanceView = {
+  ncpus: 7,
+  memory: 1024 * 1024 * 256,
+  name: 'db1',
+  description: 'an instance',
+  id: 'abc123',
+  hostname: 'oxide.com',
+  projectId: 'def456',
+  runState: ApiInstanceState.Running,
+  timeCreated: new Date(),
+  timeModified: new Date(),
+  timeRunStateUpdated: new Date(),
+}

--- a/libs/ui/src/lib/instance-details/InstanceDetails.spec.tsx
+++ b/libs/ui/src/lib/instance-details/InstanceDetails.spec.tsx
@@ -3,18 +3,13 @@ import { render } from '../../test-utils'
 
 import { InstanceDetails } from './InstanceDetails'
 
+import { instance } from '@oxide/api-mocks'
+
 describe('InstanceDetails', () => {
   it('should render successfully', () => {
-    const { container } = render(
-      <InstanceDetails
-        cpu="2"
-        memory="8 GB"
-        storage="100 GB"
-        vm={{ os: 'Debian', version: '9.12', arch: 'x64' }}
-        hostname="db1.useast1.inst"
-        ip="10.10.16.7"
-      />
-    )
-    expect(container).toBeTruthy()
+    const { getByText } = render(<InstanceDetails instance={instance} />)
+    expect(getByText('7 vCPU')).toBeTruthy()
+    expect(getByText('256 MB RAM')).toBeTruthy()
+    expect(getByText('running')).toBeTruthy()
   })
 })

--- a/libs/ui/src/lib/instance-details/InstanceDetails.stories.tsx
+++ b/libs/ui/src/lib/instance-details/InstanceDetails.stories.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
+
 import { InstanceDetails } from './InstanceDetails'
+import { instance } from '@oxide/api-mocks'
 
 export default {
   component: InstanceDetails,
@@ -7,14 +9,5 @@ export default {
 }
 
 export const primary = () => {
-  return (
-    <InstanceDetails
-      cpu="2"
-      memory="8 GB"
-      storage="100 GB"
-      vm={{ os: 'Debian', version: '9.12', arch: 'x64' }}
-      hostname="db1.useast1.inst"
-      ip="10.10.16.7"
-    />
-  )
+  return <InstanceDetails instance={instance} />
 }

--- a/libs/ui/src/lib/instance-details/InstanceDetails.tsx
+++ b/libs/ui/src/lib/instance-details/InstanceDetails.tsx
@@ -1,24 +1,14 @@
 import React from 'react'
-
 import styled from 'styled-components'
+import filesize from 'filesize'
+
+import type { ApiInstanceView } from '@oxide/api'
 import { Text } from '../text/Text'
 import { Icon } from '../icon/Icon'
 import { Badge } from '../badge/Badge'
 
-// TODO: a lot of these will be numbers in the PAI, and we will have a presentation
-// layer that makes them human readable. since we don't know the format yet,
-// assume they're strings
 export interface InstanceDetailsProps {
-  cpu: string
-  memory: string
-  storage: string
-  vm: {
-    os: string
-    version: string
-    arch: string
-  }
-  hostname: string
-  ip: string
+  instance: ApiInstanceView
 }
 
 const Cell = styled.span`
@@ -39,23 +29,21 @@ const StyledBadge = styled(Badge)`
   margin-right: ${({ theme }) => theme.spacing(3)};
 `
 
-export const InstanceDetails = (props: InstanceDetailsProps) => {
+export const InstanceDetails = ({ instance }: InstanceDetailsProps) => {
   return (
     <Text size="sm">
       <StyledBadge variant="notification" color="green">
-        running
+        {instance.runState}
       </StyledBadge>
       <span>
-        <Cell>{props.cpu} vCPU</Cell>
-        <Cell>{props.memory} RAM</Cell>
-        <Cell style={{ textTransform: 'uppercase' }}>{props.storage} Disk</Cell>
+        <Cell>{instance.ncpus} vCPU</Cell>
+        <Cell>{filesize(instance.memory)} RAM</Cell>
+        <Cell style={{ textTransform: 'uppercase' }}>100 GB Disk</Cell>
+        <Cell>Debian 9.12 x64</Cell>
         <Cell>
-          {props.vm.os} {props.vm.version} {props.vm.arch}
-        </Cell>
-        <Cell>
-          {props.hostname}
+          {instance.hostname}
           <StyledIcon name="copy" />
-          {props.ip}
+          10.10.16.7
         </Cell>
       </span>
     </Text>

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "core-js": "^3.6.5",
     "document-register-element": "1.13.1",
     "downshift": "^6.1.2",
+    "filesize": "^6.3.0",
     "framer-motion": "^4.1.3",
     "react": "17.0.1",
     "react-dom": "17.0.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,8 @@
     "paths": {
       "@oxide/ui": ["libs/ui/src/index.ts"],
       "@oxide/theme": ["libs/theme/src/index.ts"],
-      "@oxide/api": ["libs/api/index.ts"]
+      "@oxide/api": ["libs/api/index.ts"],
+      "@oxide/api-mocks": ["libs/api-mocks/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp", "apps/web-console-e2e"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -7300,6 +7300,11 @@ filesize@6.1.0:
   resolved "https://registry.yarnpkg.com/filesize/-/filesize-6.1.0.tgz#e81bdaa780e2451d714d71c0d7a4f3238d37ad00"
   integrity sha512-LpCHtPQ3sFx67z+uh2HnSyWSLLu5Jxo21795uRDuar/EOuYWXib5EmPaGIBuSnRqH2IODiKA2k5re/K9OnN/Yg==
 
+filesize@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/filesize/-/filesize-6.3.0.tgz#dff53cfb3f104c9e422f346d53be8dbcc971bf11"
+  integrity sha512-ytx0ruGpDHKWVoiui6+BY/QMNngtDQ/pJaFwfBpQif0J63+E8DLdFyqS3NkKQn7vIruUEpoGD9JUJSg7Kp+I0g==
+
 fill-range@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"


### PR DESCRIPTION
Closes #214 
Closes #288 

- Simplify interface to `InstanceDetails`, it just takes an `ApiInstanceView` now
- Add [`filesize`](https://github.com/avoidwork/filesize.js) lib — very small and nice
- Add `libs/api-mocks`
  - We definitely need something like this, but the name and location are provisional. Ideas welcome
  - Thought about putting it in `@oxide/api`, but I don't know how to avoid it ending up in the client side bundle