### PR TITLE
Configure babel-env-preset and delete unused polyfills.ts

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,12 @@
 {
   "presets": [
-    "@babel/preset-env",
+    [
+      "@babel/preset-env",
+      {
+        "corejs": "3.11",
+        "useBuiltIns": "usage"
+      }
+    ],
     "@babel/preset-react",
     "@babel/preset-typescript"
   ],

--- a/apps/web-console/src/polyfills.ts
+++ b/apps/web-console/src/polyfills.ts
@@ -1,7 +1,0 @@
-/**
- * Polyfill stable language features. These imports will be optimized by `@babel/preset-env`.
- *
- * See: https://github.com/zloirock/core-js#babel
- */
-import 'core-js/stable'
-import 'regenerator-runtime/runtime'

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "private": true,
   "dependencies": {
     "@popperjs/core": "^2.9.2",
-    "core-js": "^3.6.5",
+    "core-js": "^3.11.0",
     "document-register-element": "1.13.1",
     "downshift": "^6.1.2",
     "filesize": "^6.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5627,6 +5627,11 @@ core-js@^3.0.4, core-js@^3.8.2:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.10.0.tgz#9a020547c8b6879f929306949e31496bbe2ae9b3"
   integrity sha512-MQx/7TLgmmDVamSyfE+O+5BHvG1aUGj/gHhLn1wVtm2B5u1eVIPvh7vkfjwWKNCjrTJB8+He99IntSQ1qP+vYQ==
 
+core-js@^3.11.0:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.11.0.tgz#05dac6aa70c0a4ad842261f8957b961d36eb8926"
+  integrity sha512-bd79DPpx+1Ilh9+30aT5O1sgpQd4Ttg8oqkqi51ZzhedMM1omD2e6IOF48Z/DzDCZ2svp49tN/3vneTK6ZBkXw==
+
 core-js@^3.6.5:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.8.3.tgz#c21906e1f14f3689f93abcc6e26883550dd92dd0"


### PR DESCRIPTION
We had a `polyfills.ts` file that was sitting around but not imported anywhere. I fixed the Babel env preset config to do this the right way. By using `useBuiltIns: usage` ([docs](https://babeljs.io/docs/en/babel-preset-env#usebuiltins-usage)), Babel automatically includes the polyfills we need (based on our browserslist) without us having to manually import anything.

Something very handy I learned while doing this: you can add [`debug: true`](https://babeljs.io/docs/en/babel-preset-env#debug) to the env preset config and see exactly what is getting polyfilled for every file in the app. You can use this to confirm that when you, e.g., turn on IE 11 in the browserslist, you get way more polyfills.

Unfortunately this PR increases the production bundle from 340KB to 379KB, but we definitely need the polyfills. We can fine-tune bundle size later.