### PR TITLE
Live polling status on instance detail

### DIFF
--- a/apps/web-console/src/components/StatusBadge.tsx
+++ b/apps/web-console/src/components/StatusBadge.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
 
-import type { BadgeColor } from '@oxide/ui'
+import type { BadgeColor, BadgeProps } from '@oxide/ui'
 import { Badge } from '@oxide/ui'
 import type { ApiInstanceState } from '@oxide/api'
 
-interface Props {
+type Props = {
   status: ApiInstanceState
   className?: string
-}
+} & Pick<BadgeProps, 'size'>
 
 const COLORS: Record<ApiInstanceState, BadgeColor> = {
   creating: 'yellow',
@@ -20,11 +20,11 @@ const COLORS: Record<ApiInstanceState, BadgeColor> = {
   destroyed: 'gray',
 }
 
-export const StatusBadge = ({ status, className }: Props) => (
+export const StatusBadge = ({ status, className, size }: Props) => (
   <Badge
     color={COLORS[status]}
     variant="notification"
-    size="sm"
+    size={size}
     className={className}
   >
     {status}

--- a/apps/web-console/src/components/instance-details/InstanceDetails.tsx
+++ b/apps/web-console/src/components/instance-details/InstanceDetails.tsx
@@ -3,7 +3,8 @@ import { styled } from 'twin.macro'
 import filesize from 'filesize'
 
 import type { ApiInstanceView } from '@oxide/api'
-import { Badge, Icon } from '@oxide/ui'
+import { Icon } from '@oxide/ui'
+import { StatusBadge } from '../StatusBadge'
 
 export interface InstanceDetailsProps {
   instance: ApiInstanceView
@@ -17,9 +18,7 @@ const Cell = styled.span`
 
 export const InstanceDetails = ({ instance }: InstanceDetailsProps) => (
   <div tw="text-sm flex items-center">
-    <Badge tw="mr-3" variant="notification" color="green">
-      {instance.runState}
-    </Badge>
+    <StatusBadge tw="mr-3" status={instance.runState} />
     <span>
       <Cell>{instance.ncpus} vCPU</Cell>
       <Cell>{filesize(instance.memory)} RAM</Cell>

--- a/apps/web-console/src/pages/instance/InstancePage.tsx
+++ b/apps/web-console/src/pages/instance/InstancePage.tsx
@@ -45,7 +45,8 @@ const InstancePage = () => {
     {
       instanceName,
       projectName,
-    }
+    },
+    { refetchInterval: 5000 }
   )
 
   if (error) {

--- a/apps/web-console/src/pages/instance/InstancesPage.tsx
+++ b/apps/web-console/src/pages/instance/InstancesPage.tsx
@@ -51,8 +51,8 @@ const InstancesPage = () => {
             ),
             size: `${i.ncpus} vCPUs, ${filesize(i.memory)}`,
             runState: (
-              <span>
-                <StatusBadge tw="mr-2" status={i.runState} />
+              <span tw="inline-flex">
+                <StatusBadge tw="mr-2" size="sm" status={i.runState} />
                 <abbr
                   tw="text-xs no-underline!"
                   title={i.timeRunStateUpdated.toLocaleString()}


### PR DESCRIPTION
* Poll instance endpoint every 5s on instance page
* Status badge on instance detail uses `StatusBadge` for correct color
* Add `size` to `StatusBadge` so we can have it small in the table but big on the instance page
* Fix alignment in status cell on table (very briefly visible in gif)

![status-badge](https://user-images.githubusercontent.com/3612203/118703241-7e52ab80-b7db-11eb-8834-369ed9f32c15.gif)
