### PR TITLE
Toast on project create success, speed up animations

### DIFF
--- a/apps/web-console/src/hooks/use-toast/ToastStack.tsx
+++ b/apps/web-console/src/hooks/use-toast/ToastStack.tsx
@@ -7,14 +7,14 @@ import { css } from 'twin.macro'
 
 const toastAnimations = css`
   .toast-enter {
-    transform: translateY(100%);
+    transform: translateY(80%);
     opacity: 0;
   }
 
   .toast-enter-active {
     transform: none;
     opacity: 1;
-    transition: transform 600ms ease-in-out, opacity 600ms ease-in-out;
+    transition: transform 300ms ease-in-out, opacity 300ms ease-in-out;
   }
 
   .toast-exit {
@@ -23,9 +23,9 @@ const toastAnimations = css`
   }
 
   .toast-exit-active {
-    transform: translateX(100%);
+    transform: scale(95%, 95%);
     opacity: 0;
-    transition: transform 600ms ease-in-out, opacity 600ms ease-in-out;
+    transition: transform 200ms ease-in-out, opacity 200ms ease-in-out;
   }
 `
 

--- a/apps/web-console/src/pages/projects/ProjectCreatePage.tsx
+++ b/apps/web-console/src/pages/projects/ProjectCreatePage.tsx
@@ -11,7 +11,7 @@ import {
   TextInputGroup,
 } from '@oxide/ui'
 import { useApiMutation, useApiQueryClient } from '@oxide/api'
-import { useBreadcrumbs } from '../../hooks'
+import { useBreadcrumbs, useToast } from '../../hooks'
 import { getServerError } from '../../util/errors'
 
 const ERROR_CODES = {
@@ -27,6 +27,7 @@ const ProjectCreatePage = () => {
   const [description, setDescription] = useState('')
 
   const queryClient = useApiQueryClient()
+  const addToast = useToast()
 
   const createProject = useApiMutation('apiProjectsPost', {
     onSuccess: (data) => {
@@ -38,6 +39,13 @@ const ProjectCreatePage = () => {
         { projectName: data.name },
         data
       )
+      addToast({
+        type: 'default',
+        title: 'Success!',
+        content: 'Your project has been created.',
+        icon: 'checkO',
+        timeout: 5000,
+      })
       history.push(`/projects/${data.name}`)
     },
   })


### PR DESCRIPTION
Closes #336 

Gets part of the way there on #356 but doesn't fix the pop in.

We may not end up actually wanting this particular toast, but as you can see, it's trivial to add to the page and trivial to remove.

![project-toast](https://user-images.githubusercontent.com/3612203/118722013-38a0dd80-b7f1-11eb-97b7-fc30bb84de9a.gif)
