### PR TITLE
Basic instance stop and delete, root redirect is to /projects

### DIFF
--- a/apps/web-console/src/app/app.spec.tsx
+++ b/apps/web-console/src/app/app.spec.tsx
@@ -2,15 +2,14 @@ import React from 'react'
 import { render } from '../test-utils'
 import fetchMock from 'fetch-mock'
 
-import { instance, projects } from '@oxide/api-mocks'
+import { projects } from '@oxide/api-mocks'
 
 import App from './app'
 
 describe('App', () => {
   it('should render successfully', async () => {
     fetchMock.mock('/api/projects', projects)
-    fetchMock.mock('/api/projects/prod-online/instances/db1', instance)
-    const { findByText } = render(<App />)
-    await findByText(projects.items[0].name)
+    const { findAllByText } = render(<App />)
+    await findAllByText(projects.items[0].name)
   })
 })

--- a/apps/web-console/src/app/app.tsx
+++ b/apps/web-console/src/app/app.tsx
@@ -20,7 +20,7 @@ const App = () => {
       <AppLayout>
         <Switch>
           <Route path="/" exact>
-            <Redirect to="/projects/prod-online/instances/db1" />
+            <Redirect to="/projects" />
           </Route>
           <Route path="/projects" exact>
             <ProjectsPage />

--- a/apps/web-console/src/pages/projects/ProjectsPage.tsx
+++ b/apps/web-console/src/pages/projects/ProjectsPage.tsx
@@ -19,6 +19,7 @@ const ProjectsPage = () => {
       <PageHeader>
         <PageTitle icon="projects">Projects</PageTitle>
       </PageHeader>
+      {data.items.length === 0 && <div tw="mt-4">No projects yet!</div>}
       <ul css={{ listStyleType: 'disc', margin: '1rem' }}>
         {data.items.map((item) => (
           <li key={item.id}>


### PR DESCRIPTION
Quick improvements for 5/28 demo

- Redirect to `/projects` on root route instead of the far too specific `/projects/prod-online/db1`
- Can stop instances if they're running and can delete instances if they're stopped
- Use toasts as a janky global error bar (will probably want to revisit)

![instance-delete](https://user-images.githubusercontent.com/3612203/119567444-f25bf900-bd71-11eb-9d53-bcbd70d66d76.gif)