### PR TITLE
Spinner component

### DIFF
--- a/libs/ui/.storybook/main.js
+++ b/libs/ui/.storybook/main.js
@@ -7,7 +7,7 @@ module.exports = {
   },
   stories: [
     '../src/lib/**/__stories__/*.stories.mdx',
-    '../src/lib/**/!(__stories__/)*.stories.@(ts|tsx)',
+    '../src/lib/**/!(__stories__/)*.stories.@(ts|tsx|mdx)',
   ],
   addons: [
     '@storybook/addon-essentials',

--- a/libs/ui/src/lib/hooks/use-interval.ts
+++ b/libs/ui/src/lib/hooks/use-interval.ts
@@ -1,0 +1,17 @@
+import { useEffect, useRef } from 'react'
+
+// use null delay to prevent the interval from firing
+export default (callback: () => void, delay: number | null) => {
+  const callbackRef = useRef<() => void>()
+
+  useEffect(() => {
+    callbackRef.current = callback
+  }, [callback])
+
+  useEffect(() => {
+    if (delay !== null) {
+      const intervalId = setInterval(() => callbackRef.current?.(), delay)
+      return () => clearInterval(intervalId)
+    }
+  }, [delay])
+}

--- a/libs/ui/src/lib/spinner/Spinner.tsx
+++ b/libs/ui/src/lib/spinner/Spinner.tsx
@@ -1,0 +1,22 @@
+import React, { useState } from 'react'
+import 'twin.macro'
+
+import useInterval from '../hooks/use-interval'
+
+const FRAMES = ['|', '/', '—', '\\']
+
+type Props = { className?: string }
+
+export default ({ className }: Props) => {
+  const [index, setIndex] = useState(0)
+
+  useInterval(() => {
+    setIndex((index + 1) % FRAMES.length)
+  }, 150)
+
+  return (
+    <span tw="font-mono text-green" className={className}>
+      {FRAMES[index]}
+    </span>
+  )
+}

--- a/libs/ui/src/lib/spinner/__stories__/Spinner.stories.mdx
+++ b/libs/ui/src/lib/spinner/__stories__/Spinner.stories.mdx
@@ -1,0 +1,20 @@
+<!-- Spinner.stories.mdx -->
+
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks'
+import { Default, Styled } from './Spinner.stories'
+
+<Meta title="Components/Spinner" />
+
+# Spinner
+
+<Canvas>
+  <Story story={Default} />
+</Canvas>
+
+## Styling
+
+Styling gets passed through, so you can use the `tw` or `css` props to style as desired.
+
+<Canvas>
+  <Story name="Styled with tw=" story={Styled} />
+</Canvas>

--- a/libs/ui/src/lib/spinner/__stories__/Spinner.stories.tsx
+++ b/libs/ui/src/lib/spinner/__stories__/Spinner.stories.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import 'twin.macro'
+
+import Spinner from '../Spinner'
+
+export const Default = () => <Spinner />
+
+export const Styled = () => <Spinner tw="text-yellow text-5xl" />

--- a/libs/ui/src/lib/timeout-indicator/TimeoutIndicator.tsx
+++ b/libs/ui/src/lib/timeout-indicator/TimeoutIndicator.tsx
@@ -1,6 +1,7 @@
-import { useRef } from 'react'
 import React, { useEffect, useState } from 'react'
 import { styled } from 'twin.macro'
+
+import useInterval from '../hooks/use-interval'
 
 const TimerContent = styled.span`
   position: absolute;
@@ -23,22 +24,6 @@ const TimerPathRemaining = styled.path`
   fill-rule: nonzero;
   stroke: white;
 `
-
-// use null delay to prevent the interval from firing
-const useInterval = (callback: () => void, delay: number | null) => {
-  const callbackRef = useRef<() => void>()
-
-  useEffect(() => {
-    callbackRef.current = callback
-  }, [callback])
-
-  useEffect(() => {
-    if (delay !== null) {
-      const intervalId = setInterval(() => callbackRef.current?.(), delay)
-      return () => clearInterval(intervalId)
-    }
-  }, [delay])
-}
 
 // r = 45 (see `r` on TimerPathRemaining)
 const FULL_DASH = 2 * Math.PI * 45


### PR DESCRIPTION
Closes #380. Based off the one on oxide.computer ([source](https://github.com/oxidecomputer/oxide.computer/blob/af0616c5cc064df21c892e99abfc5e69132b1185/web/components/loader.js)).

Green by default, but styling can be overridden.

![spinner](https://user-images.githubusercontent.com/3612203/123132315-3c3d0b00-d414-11eb-88d4-0f7a82200977.gif)
