### PR TITLE
no longer rely on github token for pushing

### DIFF
--- a/.github/workflows/deploy-vm.yml
+++ b/.github/workflows/deploy-vm.yml
@@ -31,8 +31,8 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.GLOBAL_GITHUB_TOKEN }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v2
         with:


### PR DESCRIPTION
Trying to get rid of using my personal token places