### PR TITLE
Contextual sidebar nav

### DIFF
--- a/app/app.tsx
+++ b/app/app.tsx
@@ -14,18 +14,21 @@ import ProjectCreatePage from './pages/ProjectCreatePage'
 import ProjectsPage from './pages/ProjectsPage'
 import ToastTestPage from './pages/ToastTestPage'
 
-import AppLayout from './components/AppLayout'
+import AppLayout from './layouts/AppLayout'
+import ProjectLayout from './layouts/ProjectLayout'
 import QuickMenu from './components/QuickMenu'
 
 const App = () => (
   <Router>
     <QuickMenu />
     <Routes>
-      <Route path="/" element={<Navigate to="/projects" />} />
-      <Route path="projects" element={<AppLayout />}>
-        <Route path="/" element={<ProjectsPage />} />
+      <Route path="/" element={<Navigate to="/projects" replace={true} />} />
+      <Route path="projects">
+        <Route path="/" element={<AppLayout />}>
+          <ProjectsPage />
+        </Route>
         <Route path="new" element={<ProjectCreatePage />} />
-        <Route path=":projectName">
+        <Route path=":projectName" element={<ProjectLayout />}>
           <Route path="/" element={<ProjectPage />} />
           <Route path="access" element={<ProjectAccessPage />} />
           <Route path="instances">

--- a/app/components/OperationList.tsx
+++ b/app/components/OperationList.tsx
@@ -1,38 +1,37 @@
 import React from 'react'
+import { NavLink } from 'react-router-dom'
 
 import type { IconName } from '@oxide/ui'
 import { Icon } from '@oxide/ui'
 
 type ItemProps = {
   label: string
-  href?: string
+  to?: string
   icon: IconName
-  children?: React.ReactNode
 }
 
-const listItem = 'flex items-center space-x-2 p-1 hover:bg-gray-400'
+const linkStyle = 'flex items-center space-x-2 p-1 hover:bg-gray-400'
 
-const ListItem = ({ label, icon, href = '#', children }: ItemProps) => (
+const ListItem = ({ label, icon, to = '#' }: ItemProps) => (
   <li>
-    <a href={href} className={listItem}>
+    <NavLink to={to} className={linkStyle} activeClassName="text-white" end>
       <Icon name={icon} className="mr-3" />
       {label}
-    </a>
-    {children}
+    </NavLink>
   </li>
 )
 
 export const OperationList = (props: { className?: string }) => (
   <nav className={props.className}>
-    <header className="p-1 text-xs text-green-500 uppercase font-mono">
-      Operations
-    </header>
-    <ul className="mt-2 space-y-1 text-sm text-gray-100">
-      <ListItem label="System" icon="dashboard" />
-      <ListItem label="Resources" icon="resources" />
-      <ListItem label="Organizations" icon="organization" />
-      <ListItem label="Projects" icon="projects" />
-      <ListItem label="IAM" icon="users" />
+    <ul className="mt-2 space-y-0.5 text-sm text-gray-100 font-light">
+      <ListItem label="Overview" icon="dashboard" to="" />
+      <ListItem label="Instances" icon="instances" to="instances" />
+      <ListItem label="Networking" icon="networking" to="networking" />
+      <ListItem label="Storage" icon="storage" to="storage" />
+      <ListItem label="Metrics" icon="stopwatch" to="metrics" />
+      <ListItem label="Audit log" icon="file" to="audit" />
+      <ListItem label="Access & IAM" icon="users" to="access" />
+      <ListItem label="Settings" icon="pen" to="settings" />
     </ul>
   </nav>
 )

--- a/app/components/ProjectList.tsx
+++ b/app/components/ProjectList.tsx
@@ -17,9 +17,9 @@ export const ProjectList = (props: ProjectListProps) => {
       <header className="p-1 space-x-2 uppercase text-xs font-mono text-green-500">
         Projects
       </header>
-      <ul className="flex flex-col space-y-1 text-gray-200">
+      <ul className="space-y-0.5 text-gray-200 font-light text-sm">
         {projects?.items.map((p) => (
-          <li className="text-sm hover:bg-gray-400" key={p.id}>
+          <li className="hover:bg-gray-400" key={p.id}>
             <NavLink
               className="inline-flex w-full p-1"
               to={`/projects/${p.name}`}

--- a/app/layouts/AppLayout.tsx
+++ b/app/layouts/AppLayout.tsx
@@ -1,9 +1,8 @@
 import React from 'react'
 import { Link, Outlet } from 'react-router-dom'
 
-import { GlobalNav } from './GlobalNav'
-import { ProjectList } from './ProjectList'
-import { OperationList } from './OperationList'
+import { GlobalNav } from '../components/GlobalNav'
+import { ProjectList } from '../components/ProjectList'
 import Wordmark from '../assets/wordmark.svg'
 
 export default () => (
@@ -18,8 +17,6 @@ export default () => (
     </header>
     <div className="pb-6 overflow-auto bg-gray-500">
       <ProjectList className="mt-4 px-3" />
-      <hr className="border-gray-400 mt-6" />
-      <OperationList className="mt-6 px-3" />
     </div>
     <main className="overflow-auto py-2 px-6">
       <Outlet />

--- a/app/layouts/ProjectLayout.tsx
+++ b/app/layouts/ProjectLayout.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { Link, Outlet, useParams } from 'react-router-dom'
+
+import { GlobalNav } from '../components/GlobalNav'
+import { OperationList } from '../components/OperationList'
+
+export default () => {
+  const { projectName } = useParams()
+  return (
+    <div className="grid h-screen grid-cols-[14rem,auto] grid-rows-[4rem,auto]">
+      <div className="p-5 bg-gray-500 text-green-500 flex items-center">
+        <Link to="/">
+          <span className="mr-4" style={{ fontSize: '.625rem' }}>
+            &#9664;
+          </span>
+          <span className="text-xs font-mono font-light uppercase">Back</span>
+        </Link>
+      </div>
+      <header className="py-4 px-6 self-center">
+        <GlobalNav />
+      </header>
+      <div className="pb-6 pt-1 overflow-auto bg-gray-500">
+        <div className="px-5 mb-4">
+          <div className="uppercase text-xs font-mono font-light text-green-500">
+            Project
+          </div>
+          <div className="text-sm font-light">{projectName}</div>
+        </div>
+        <hr className="border-gray-400 mt-8" />
+        <OperationList className="mt-6 px-3" />
+      </div>
+      <main className="overflow-auto py-2 px-6">
+        <Outlet />
+      </main>
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #388

This makes the contents of the sidebar nav contingent on the route instead of global to the entire app. We can do this very cleanly thanks to the nested routing API in React Router v6 beta.

Things to work on later: the two layouts have almost the same structure but don't share code. What's supposed to be a project dropdown in the sidebar is fake. Also `AppLayout` is kind of useless because it's a list of projects, but it only shows up as the side nav for the project list page. The point is we are well-positioned to implement whatever sidebar logic we land on.

![sidebar](https://user-images.githubusercontent.com/3612203/126388950-d43c7ed4-94be-4014-8788-2d6405451b34.gif)
