### PR TITLE
Extract SideModal styling, make modal body scroll

### DIFF
--- a/app/pages/ProjectAccessPage.tsx
+++ b/app/pages/ProjectAccessPage.tsx
@@ -3,6 +3,7 @@ import type { Row } from 'react-table'
 import { useTable, useRowSelect } from 'react-table'
 import { Dialog } from '@reach/dialog'
 import { Menu, MenuList, MenuButton, MenuItem } from '@reach/menu-button'
+import { v4 as uuid } from 'uuid'
 
 import {
   Avatar,
@@ -107,6 +108,8 @@ const ProjectPage = () => {
   const [modalIsOpen, setModalIsOpen] = useState(false)
   const closeModal = () => setModalIsOpen(false)
 
+  const modalTitleId = React.useMemo(() => uuid(), [])
+
   return (
     <>
       <PageHeader>
@@ -114,29 +117,48 @@ const ProjectPage = () => {
       </PageHeader>
 
       <Dialog
-        className="absolute right-0 top-0 bottom-0 !bg-gray-500 !w-[32rem] !p-0 !m-0 border-l border-gray-400 flex flex-col justify-between"
+        className="SideModal"
         isOpen={modalIsOpen}
         onDismiss={closeModal}
-        aria-label="Add user"
+        aria-labelledby={modalTitleId}
       >
-        {/* this div is so we can use justify-between to get the footer to sit at the bottom */}
-        <div>
+        <div className="modal-body">
           <div className="p-8">
             <div className="flex justify-between mt-2 mb-14">
-              <h2 className="text-display-xl">Manage project access</h2>
+              <h2 className="text-display-xl" id={modalTitleId}>
+                Manage project access
+              </h2>
               <Button variant="link" onClick={closeModal}>
                 <Icon name="close" />
               </Button>
             </div>
             <h3 className="font-medium">Choose members</h3>
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+              eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+              enim ad minim veniam, quis nostrud exercitation ullamco laboris
+              nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
+              reprehenderit in voluptate velit esse cillum dolore eu fugiat
+              nulla pariatur. Excepteur sint occaecat cupidatat non proident,
+              sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </p>
             <h3 className="font-medium">Select roles</h3>
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+              eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+              enim ad minim veniam, quis nostrud exercitation ullamco laboris
+              nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
+              reprehenderit in voluptate velit esse cillum dolore eu fugiat
+              nulla pariatur. Excepteur sint occaecat cupidatat non proident,
+              sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </p>
           </div>
           <hr className="border-gray-400" />
           <div className="p-8">
             <h3 className="font-medium">Relevant docs</h3>
           </div>
         </div>
-        <footer className="p-6 border-t border-gray-400 flex justify-end">
+        <footer className="modal-footer">
           {/* TODO: not supposed to be a ghost button */}
           <Button variant="ghost" className="mr-2.5" onClick={closeModal}>
             Cancel

--- a/libs/ui/styles/index.css
+++ b/libs/ui/styles/index.css
@@ -6,6 +6,7 @@
 
 /* the tabs component is just @reach/tabs plus custom CSS */
 @import '../lib/tabs/Tabs.css';
+@import './side-modal.css';
 
 @tailwind base;
 @tailwind components;

--- a/libs/ui/styles/side-modal.css
+++ b/libs/ui/styles/side-modal.css
@@ -1,0 +1,21 @@
+/* The side modal is just a set of styles on @reach/dialog and children. 
+ *
+ * Usage:
+ *   Have a body and a footer. Don't forget to put either aria-label or
+ *   aria-labelledby on Dialog (see https://reach.tech/dialog/#labeling).
+ */
+
+[data-reach-dialog-content].SideModal {
+  @apply absolute right-0 top-0 bottom-0 w-[32rem] p-0 m-0 
+    flex flex-col justify-between
+    bg-gray-500 border-l border-gray-400;
+
+  & .modal-body {
+    max-height: calc(100vw - 5rem);
+    overflow-y: auto;
+  }
+
+  & .modal-footer {
+    @apply flex h-20 p-6 border-t border-gray-400 items-center justify-end;
+  }
+}


### PR DESCRIPTION
Setup for having several of these modals on the instance create form. Using actual CSS classes is unusual for this app since we generally prefer to pass around React elements or even strings of Tailwind classes. But this way is very simple and makes clear that the only thing we're doing is styling.

![modal-scroll](https://user-images.githubusercontent.com/3612203/130270532-e72bf22b-4437-4988-a363-51e17be5b3be.gif)
