### PR TITLE
Make VSCode aware of tailwind at-rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+!.vscode/css.json
 
 # misc
 /.sass-cache

--- a/.vscode/css.json
+++ b/.vscode/css.json
@@ -1,0 +1,46 @@
+{
+  "//": "https://gist.github.com/gigawatson/5b87e972da3362f8a42c587b3a5957dc",
+  "version": 1.1,
+  "atDirectives": [
+    {
+      "name": "@tailwind",
+      "description": "Use the @tailwind directive to insert Tailwind’s `base`, `components`, `utilities`, and `screens` styles into your CSS.",
+      "references": [
+        {
+          "name": "See Documentation",
+          "url": "https://tailwindcss.com/docs/functions-and-directives#tailwind"
+        }
+      ]
+    },
+    {
+      "name": "@layer",
+      "description": "Use the @layer directive to tell Tailwind which 'bucket' a set of custom styles belong to. Valid layers are a base, components, and utilities.",
+      "references": [
+        {
+          "name": "See Documentation",
+          "url": "https://tailwindcss.com/docs/functions-and-directives#layer"
+        }
+      ]
+    },
+    {
+      "name": "@variants",
+      "description": "You can generate responsive, hover, focus, active, and other variants of your own utilities by wrapping their definitions in the @variants directive.",
+      "references": [
+        {
+          "name": "See Documentation",
+          "url": "https://tailwindcss.com/docs/functions-and-directives#variants"
+        }
+      ]
+    },
+    {
+      "name": "@apply",
+      "description": "Use @apply to inline any existing utility classes into your own custom CSS. This is useful when you find a common utility pattern in your HTML that you’d like to extract to a new component.",
+      "references": [
+        {
+          "name": "See Documentation",
+          "url": "https://tailwindcss.com/docs/functions-and-directives#apply"
+        }
+      ]
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,6 @@
   "typescript.tsdk": "node_modules/typescript/lib",
   "editor.formatOnSave": true,
   "eslint.format.enable": true,
-  "tailwindCSS.experimental.classRegex": ["classed.[a-z]+`([^`]*)`"]
+  "tailwindCSS.experimental.classRegex": ["classed.[a-z]+`([^`]*)`"],
+  "css.customData": ["./.vscode/css.json"]
 }


### PR DESCRIPTION
VSCode's built in css validator complains about tailwind's @-rules given they aren't valid CSS.
This change utilizies [VSCode's custom data](https://code.visualstudio.com/api/extension-guides/custom-data-extension) functionality to describe those @-rules as valid to
the underlying language server.