### PR TITLE
Prevent entire page scrolling on chrome and safari

### DIFF
--- a/libs/ui/styles/index.css
+++ b/libs/ui/styles/index.css
@@ -12,7 +12,7 @@
 
 @layer base {
   body {
-    @apply bg-black text-gray-50 font-sans;
+    @apply bg-black text-gray-50 font-sans overflow-y-hidden;
   }
 
   /* https://github.com/tailwindlabs/tailwindcss/blob/v2.2.4/src/plugins/css/preflight.css#L57 */


### PR DESCRIPTION
Fixes #452 

I'll start by saying the fix here isn't usually the first thing I reach for. Hiding overflow is often ignoring the underlying cause of whatever is causing the overflow to begin with. 

That said, this one is tricky. Given that it behaves different on firefox than it does on chrome/safari it points to differences in handling the spec. 

Interesting notes:
- The body scroll doesn't extend down even half as far as the total form. That means while elements of the create instance column contribute to the grid track blowout not _everything_ does.
- `body`, `#root`, and `grid` all have the same calculated height even though the body is scrollable. The total scrollable area is greater than the size of the body. 
- I found an [article](https://daverupert.com/2017/09/breaking-the-grid/) from 2017 that suggests the intrinsic sizing that browsers apply to form elements causes grid blowouts. I expect this is closer to the root cause. 
  > In order to fix elements spilling out of the grid track in a cross-browser way, we have to override this intrinsic sizing of replaced elements.
  - I explored this for a while but ultimately wasn't able to resolve the issue via a similar strategy.

There's extra rigor that could be applied here to ferret out deeper understanding of cross platform grid layout behaviors but I'm going to pause on this for now. 