### PR TITLE
Update story types to be more terse

### DIFF
--- a/libs/ui/lib/avatar-stack/AvatarStack.stories.tsx
+++ b/libs/ui/lib/avatar-stack/AvatarStack.stories.tsx
@@ -1,10 +1,12 @@
 import { AvatarStack } from './AvatarStack'
-import type { AvatarStackProps } from './AvatarStack'
 import type { StoryObj } from '@storybook/react'
+import type { ComponentProps } from 'react'
+
+type Story = StoryObj<ComponentProps<typeof AvatarStack>>
 
 export default {
   component: AvatarStack,
-} as StoryObj<AvatarStackProps>
+} as Story
 
 const AVATAR_DATA = [
   { name: 'Haley Clark', round: true },
@@ -12,6 +14,6 @@ const AVATAR_DATA = [
   { name: 'Gordon Clark', round: true },
 ]
 
-export const Default: StoryObj<AvatarStackProps> = {
+export const Default: Story = {
   args: { data: AVATAR_DATA },
 }

--- a/libs/ui/lib/avatar/Avatar.stories.tsx
+++ b/libs/ui/lib/avatar/Avatar.stories.tsx
@@ -1,12 +1,14 @@
 import { Avatar } from './Avatar'
-import type { AvatarProps } from './Avatar'
 import type { StoryObj } from '@storybook/react'
+import type { ComponentProps } from 'react'
+
+type Story = StoryObj<ComponentProps<typeof Avatar>>
 
 export default {
   component: Avatar,
-} as StoryObj<AvatarProps>
+} as Story
 
-export const Default: StoryObj<AvatarProps> = {
+export const Default: Story = {
   args: {
     name: 'Cameron Howe',
     round: true,

--- a/libs/ui/lib/badge/Badge.stories.tsx
+++ b/libs/ui/lib/badge/Badge.stories.tsx
@@ -1,12 +1,14 @@
 import { Badge } from './Badge'
-import type { BadgeProps } from './Badge'
 import type { StoryObj } from '@storybook/react'
+import type { ComponentProps } from 'react'
+
+type Story = StoryObj<ComponentProps<typeof Badge>>
 
 export default {
   component: Badge,
-} as StoryObj<BadgeProps>
+} as Story
 
-export const Default: StoryObj<BadgeProps> = {
+export const Default: Story = {
   args: {
     children: 'Badge',
   },

--- a/libs/ui/lib/breadcrumbs/Breadcrumbs.stories.tsx
+++ b/libs/ui/lib/breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,6 +1,8 @@
 import { Breadcrumbs } from './Breadcrumbs'
-import type { BreadcrumbsProps } from './Breadcrumbs'
 import type { StoryObj } from '@storybook/react'
+import type { ComponentProps } from 'react'
+
+type Story = StoryObj<ComponentProps<typeof Breadcrumbs>>
 
 // Follow https://github.com/storybookjs/storybook/issues/12078
 // for allowing better controls for objects
@@ -11,9 +13,9 @@ export default {
       control: { type: 'object' },
     },
   },
-} as StoryObj<BreadcrumbsProps>
+} as Story
 
-export const Default: StoryObj<BreadcrumbsProps> = {
+export const Default: Story = {
   args: {
     data: [
       { href: '/', label: 'Home' },

--- a/libs/ui/lib/button/Button.stories.tsx
+++ b/libs/ui/lib/button/Button.stories.tsx
@@ -1,6 +1,8 @@
 import { Button, buttonSizes, variants } from './Button'
-import type { ButtonProps } from './Button'
 import type { StoryObj } from '@storybook/react'
+import type { ComponentProps } from 'react'
+
+type Story = StoryObj<ComponentProps<typeof Button>>
 
 export default {
   component: Button,
@@ -18,9 +20,9 @@ export default {
       },
     },
   },
-} as StoryObj<ButtonProps>
+} as Story
 
-export const Default: StoryObj<ButtonProps> = {
+export const Default: Story = {
   args: {
     children: 'Button',
     disabled: false,

--- a/libs/ui/lib/checkbox/Checkbox.stories.tsx
+++ b/libs/ui/lib/checkbox/Checkbox.stories.tsx
@@ -1,6 +1,8 @@
 import { Checkbox } from './Checkbox'
-import type { CheckboxProps } from './Checkbox'
 import type { StoryObj } from '@storybook/react'
+import type { ComponentProps } from 'react'
+
+type Story = StoryObj<ComponentProps<typeof Checkbox>>
 
 export default {
   component: Checkbox,
@@ -9,17 +11,17 @@ export default {
     indeterminate: { control: 'boolean' },
     children: { control: 'text' },
   },
-} as StoryObj<CheckboxProps>
+} as Story
 
-export const Unchecked: StoryObj<CheckboxProps> = {
+export const Unchecked: Story = {
   args: { checked: false, indeterminate: false, children: 'Label' },
 }
-export const Checked: StoryObj<CheckboxProps> = {
+export const Checked: Story = {
   args: { checked: true, indeterminate: false, children: 'Label' },
 }
-export const Indeterminate: StoryObj<CheckboxProps> = {
+export const Indeterminate: Story = {
   args: { checked: false, indeterminate: true, children: 'Label' },
 }
-export const NoLabel: StoryObj<CheckboxProps> = {
+export const NoLabel: Story = {
   args: { checked: false, indeterminate: false },
 }

--- a/libs/ui/lib/dropdown/Dropdown.stories.tsx
+++ b/libs/ui/lib/dropdown/Dropdown.stories.tsx
@@ -1,10 +1,12 @@
 import { Dropdown } from './Dropdown'
-import type { DropdownProps } from './Dropdown'
 import type { StoryObj } from '@storybook/react'
+import type { ComponentProps } from 'react'
+
+type Story = StoryObj<ComponentProps<typeof Dropdown>>
 
 export default {
   component: Dropdown,
-} as StoryObj<DropdownProps>
+} as Story
 
 const SAMPLE_OPTIONS = [
   { value: 'de', label: 'Devon Edwards' },
@@ -18,14 +20,14 @@ const SAMPLE_OPTIONS = [
   { value: 'br', label: 'Bessie Robertson' },
 ]
 
-export const Default: StoryObj<DropdownProps> = {
+export const Default: Story = {
   args: {
     label: 'Choose an Operator',
     items: SAMPLE_OPTIONS,
   },
 }
 
-export const HideLabel: StoryObj<DropdownProps> = {
+export const HideLabel: Story = {
   args: {
     showLabel: false,
     label: 'Choose an Operator',
@@ -33,7 +35,7 @@ export const HideLabel: StoryObj<DropdownProps> = {
   },
 }
 
-export const WithDefaultValue: StoryObj<DropdownProps> = {
+export const WithDefaultValue: Story = {
   args: {
     defaultValue: 'de',
     label: 'Choose an Operator',
@@ -41,7 +43,7 @@ export const WithDefaultValue: StoryObj<DropdownProps> = {
   },
 }
 
-export const WithHint: StoryObj<DropdownProps> = {
+export const WithHint: Story = {
   args: {
     showLabel: false,
     label: 'Choose an Operator',

--- a/libs/ui/lib/empty-state/EmptyState.stories.tsx
+++ b/libs/ui/lib/empty-state/EmptyState.stories.tsx
@@ -1,11 +1,13 @@
+import type { ComponentProps } from 'react'
 import React from 'react'
 import { EmptyState } from './EmptyState'
-import type { EmptyStateProps } from './EmptyState'
 import type { StoryObj } from '@storybook/react'
+
+type Story = StoryObj<ComponentProps<typeof EmptyState>>
 
 export default {
   component: EmptyState,
-} as StoryObj<EmptyStateProps>
+} as Story
 
 export const Default = () => {
   const props = {

--- a/libs/ui/lib/icon/Icon.stories.tsx
+++ b/libs/ui/lib/icon/Icon.stories.tsx
@@ -1,13 +1,15 @@
 import { Icon } from './Icon'
-import type { IconProps } from './Icon'
 import type { StoryObj } from '@storybook/react'
+import type { ComponentProps } from 'react'
 
-export default { component: Icon } as StoryObj<IconProps>
+type Story = StoryObj<ComponentProps<typeof Icon>>
 
-export const Default: StoryObj<IconProps> = {
+export default { component: Icon } as Story
+
+export const Default: Story = {
   args: { name: 'bookmark' },
 }
 
-export const CustomTitle: StoryObj<IconProps> = {
+export const CustomTitle: Story = {
   args: { svgProps: { title: 'Cameron Howe' }, name: 'profile' },
 }

--- a/libs/ui/lib/multi-select/MultiSelect.stories.tsx
+++ b/libs/ui/lib/multi-select/MultiSelect.stories.tsx
@@ -1,10 +1,13 @@
 import { MultiSelect } from './MultiSelect'
-import type { MultiSelectProps } from './MultiSelect'
+
 import type { StoryObj } from '@storybook/react'
+import type { ComponentProps } from 'react'
+
+type Story = StoryObj<ComponentProps<typeof MultiSelect>>
 
 export default {
   component: MultiSelect,
-} as StoryObj<MultiSelectProps>
+} as Story
 
 const SAMPLE_OPTIONS = [
   { value: 'de', label: 'Devon Edwards' },
@@ -18,7 +21,7 @@ const SAMPLE_OPTIONS = [
   { value: 'br', label: 'Bessie Robertson' },
 ]
 
-export const Default: StoryObj<MultiSelectProps> = {
+export const Default: Story = {
   args: {
     items: SAMPLE_OPTIONS,
   },

--- a/libs/ui/lib/progress/Progress.stories.tsx
+++ b/libs/ui/lib/progress/Progress.stories.tsx
@@ -1,9 +1,11 @@
 import { Progress } from './Progress'
-import type { ProgressProps } from './Progress'
 import type { StoryObj } from '@storybook/react'
+import type { ComponentProps } from 'react'
+
+type Story = StoryObj<ComponentProps<typeof Progress>>
 
 export default {
   component: Progress,
-} as StoryObj<ProgressProps>
+} as Story
 
-export const Default: StoryObj<ProgressProps> = {}
+export const Default: Story = {}

--- a/libs/ui/lib/radio-group/RadioGroup.stories.tsx
+++ b/libs/ui/lib/radio-group/RadioGroup.stories.tsx
@@ -1,12 +1,16 @@
+import type { ComponentProps } from 'react'
 import React from 'react'
 
 import { FormikDecorator } from '../../util/formik-decorator'
 import { RadioGroup } from './RadioGroup'
 import { Radio, RadioCard } from '../radio/Radio'
+import type { StoryObj } from '@storybook/react'
+
+type Story = StoryObj<ComponentProps<typeof RadioGroup>>
 
 export default {
   component: RadioGroup,
-}
+} as Story
 
 export const Default = () => (
   <RadioGroup name="group1">

--- a/libs/ui/lib/radio/Radio.stories.tsx
+++ b/libs/ui/lib/radio/Radio.stories.tsx
@@ -1,7 +1,9 @@
 import { FormikDecorator } from '../../util/formik-decorator'
 import { Radio } from './Radio'
-import type { RadioProps } from './Radio'
 import type { StoryObj } from '@storybook/react'
+import type { ComponentProps } from 'react'
+
+type Story = StoryObj<ComponentProps<typeof Radio>>
 
 export default {
   component: Radio,
@@ -10,19 +12,19 @@ export default {
     children: { control: 'text' },
   },
   decorators: [FormikDecorator()],
-} as StoryObj<RadioProps>
+} as Story
 
-export const Unchecked: StoryObj<RadioProps> = {
+export const Unchecked: Story = {
   args: {
     checked: false,
     children: 'Label',
   },
 }
 
-export const Checked: StoryObj<RadioProps> = {
+export const Checked: Story = {
   args: { checked: true, children: 'Label' },
 }
 
-export const Disabled: StoryObj<RadioProps> = {
+export const Disabled: Story = {
   args: { checked: false, children: 'Label', disabled: true },
 }

--- a/libs/ui/lib/side-modal/SideModal.stories.tsx
+++ b/libs/ui/lib/side-modal/SideModal.stories.tsx
@@ -1,9 +1,11 @@
 import { SideModal } from './SideModal'
-import type { SideModalProps } from './SideModal'
 import type { StoryObj } from '@storybook/react'
+import type { ComponentProps } from 'react'
+
+type Story = StoryObj<ComponentProps<typeof SideModal>>
 
 export default {
   component: SideModal,
-} as StoryObj<SideModalProps>
+} as Story
 
-export const Default: StoryObj<SideModalProps> = {}
+export const Default: Story = {}

--- a/libs/ui/lib/skip-link/SkipLink.stories.tsx
+++ b/libs/ui/lib/skip-link/SkipLink.stories.tsx
@@ -1,9 +1,11 @@
 import { SkipLink } from './SkipLink'
-import type { SkipLinkProps } from './SkipLink'
 import type { StoryObj } from '@storybook/react'
+import type { ComponentProps } from 'react'
+
+type Story = StoryObj<ComponentProps<typeof SkipLink>>
 
 export default {
   component: SkipLink,
-} as StoryObj<SkipLinkProps>
+} as Story
 
-export const Default: StoryObj<SkipLinkProps> = {}
+export const Default: Story = {}

--- a/libs/ui/lib/spinner/Spinner.stories.tsx
+++ b/libs/ui/lib/spinner/Spinner.stories.tsx
@@ -1,9 +1,11 @@
 import { Spinner } from './Spinner'
-import type { SpinnerProps } from './Spinner'
 import type { StoryObj } from '@storybook/react'
+import type { ComponentProps } from 'react'
+
+type Story = StoryObj<ComponentProps<typeof Spinner>>
 
 export default {
   component: Spinner,
-} as StoryObj<SpinnerProps>
+} as Story
 
-export const Default: StoryObj<SpinnerProps> = {}
+export const Default: Story = {}

--- a/libs/ui/lib/table/Table.stories.tsx
+++ b/libs/ui/lib/table/Table.stories.tsx
@@ -1,11 +1,10 @@
 import React from 'react'
 import { useTable } from 'react-table'
 import { Table } from './Table'
-import type { FC, ReactElement } from 'react'
-import type { TableProps } from './Table'
+import type { FC, ReactElement, ComponentProps } from 'react'
 import type { StoryObj } from '@storybook/react'
 
-type Props = TableProps<Record<string, unknown>>
+type Story = StoryObj<ComponentProps<typeof Table>>
 
 const data = [
   {
@@ -45,6 +44,6 @@ export default {
       <Table {...args} />
     </TableProvider>
   ),
-} as StoryObj<Props>
+} as Story
 
-export const Default: StoryObj<Props> = {}
+export const Default: Story = {}

--- a/libs/ui/lib/tabs/Tabs.stories.tsx
+++ b/libs/ui/lib/tabs/Tabs.stories.tsx
@@ -1,7 +1,11 @@
+import type { StoryObj } from '@storybook/react'
+import type { ComponentProps } from 'react'
 import { TabListLine } from './Tabs'
+
+type Story = StoryObj<ComponentProps<typeof TabListLine>>
 
 export default {
   component: TabListLine,
-}
+} as Story
 
-export const Default = {}
+export const Default: Story = {}

--- a/libs/ui/lib/text-field/TextField.stories.tsx
+++ b/libs/ui/lib/text-field/TextField.stories.tsx
@@ -1,11 +1,13 @@
 import { FormikDecorator } from '../../util/formik-decorator'
 import { TextField } from './TextField'
-import type { TextFieldProps } from './TextField'
 import type { StoryObj } from '@storybook/react'
+import type { ComponentProps } from 'react'
+
+type Story = StoryObj<ComponentProps<typeof TextField>>
 
 export default {
   component: TextField,
   decorators: [FormikDecorator('')],
-} as StoryObj<TextFieldProps>
+} as Story
 
-export const Default: StoryObj<TextFieldProps> = {}
+export const Default: Story = {}

--- a/libs/ui/lib/timeout-indicator/TimeoutIndicator.stories.tsx
+++ b/libs/ui/lib/timeout-indicator/TimeoutIndicator.stories.tsx
@@ -1,13 +1,15 @@
 import { action } from '@storybook/addon-actions'
 import { TimeoutIndicator } from './TimeoutIndicator'
-import type { TimeoutIndicatorProps } from './TimeoutIndicator'
 import type { StoryObj } from '@storybook/react'
+import type { ComponentProps } from 'react'
+
+type Story = StoryObj<ComponentProps<typeof TimeoutIndicator>>
 
 export default {
   component: TimeoutIndicator,
-} as StoryObj<TimeoutIndicatorProps>
+} as Story
 
-export const Default: StoryObj<TimeoutIndicatorProps> = {
+export const Default: Story = {
   args: {
     timeout: 5000,
     onTimeoutEnd: action('onTimeoutEnd'),

--- a/libs/ui/lib/toast/Toast.stories.tsx
+++ b/libs/ui/lib/toast/Toast.stories.tsx
@@ -1,13 +1,15 @@
 import { action } from '@storybook/addon-actions'
 import { Toast } from './Toast'
-import type { ToastProps } from './Toast'
 import type { StoryObj } from '@storybook/react'
+import type { ComponentProps } from 'react'
+
+type Story = StoryObj<ComponentProps<typeof Toast>>
 
 export default {
   component: Toast,
-} as StoryObj<ToastProps>
+} as Story
 
-export const Default: StoryObj<ToastProps> = {
+export const Default: Story = {
   args: {
     icon: 'checkO',
     variant: 'success',

--- a/libs/ui/lib/tooltip/Tooltip.stories.tsx
+++ b/libs/ui/lib/tooltip/Tooltip.stories.tsx
@@ -1,15 +1,16 @@
+import type { ComponentProps } from 'react'
 import React from 'react'
 import { Tooltip } from './Tooltip'
-import type { TooltipProps } from './Tooltip'
 import type { StoryObj } from '@storybook/react'
-
 import { Icon } from '../icon/Icon'
+
+type Story = StoryObj<ComponentProps<typeof Tooltip>>
 
 export default {
   component: Tooltip,
-} as StoryObj<TooltipProps>
+} as Story
 
-export const Default: StoryObj<TooltipProps> = {
+export const Default: Story = {
   args: {
     isPrimaryLabel: true,
     children: <Icon name="filter" />,

--- a/templates/stories-csf.hbs
+++ b/templates/stories-csf.hbs
@@ -1,11 +1,13 @@
 import { {{ name }} } from './{{ name }}'
-import type { {{ name }}Props } from './{{ name }}'
+import type { ComponentProps } from 'react'
 import type { StoryObj } from '@storybook/react'
+
+type Story = StoryObj<ComponentProps<typeof {{ name }}>>
 
 export default {
   component: {{ name }},
-} as StoryObj<{{ name }}Props>
+} as Story 
 
-export const Default: StoryObj<{{ name }}Props> = {
+export const Default: Story = {
   args: {  },
 }


### PR DESCRIPTION
I ran into some issues where the exported props might not have all of the props (i.e. like `children` when using `FC`). Based off of it seemed like `ComponentProps` was really the best option. It's a bit verbose though, so I created a helper `Story` type in every sb file that'll type the story correctly. I also updated the plop file. 