### PR TITLE
Add dedicate tabs component api, touch up some UI updates, integrate new api, add stories, etc

### DIFF
--- a/app/pages/instances/create/index.tsx
+++ b/app/pages/instances/create/index.tsx
@@ -1,19 +1,17 @@
 import React, { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Tab, TabList, TabPanel, TabPanels, Tabs } from '@reach/tabs'
 import cn from 'classnames'
 import { Formik, Form } from 'formik'
 
 import {
   classed,
-  Badge,
   Button,
   PageHeader,
   PageTitle,
   RadioGroupHint,
   RadioGroup,
   RadioCard,
-  TabListLine,
+  Tabs,
   TextField,
   TextFieldHint,
   Instances24Icon,
@@ -109,109 +107,88 @@ export function InstanceCreateForm({
       <Form className="mt-4 mb-20">
         <Heading>Choose an image</Heading>
         <Tabs className="mt-1">
-          <TabListLine>
-            <TabList aria-label="Choose an image">
-              <Tab>Distributions</Tab>
-              <Tab>Custom Images</Tab>
-            </TabList>
-          </TabListLine>
-          <TabPanels>
-            <TabPanel>
-              <fieldset>
-                <legend className="sr-only">Choose a pre-built image</legend>
-                <RadioGroup name="disk-image">
-                  <RadioCard value="centos">CentOS</RadioCard>
-                  <RadioCard value="debian">Debian</RadioCard>
-                  <RadioCard value="fedora">Fedora</RadioCard>
-                  <RadioCard value="freeBsd">FreeBSD</RadioCard>
-                  <RadioCard value="ubuntu">Ubuntu</RadioCard>
-                  <RadioCard value="windows">Windows</RadioCard>
-                </RadioGroup>
-              </fieldset>
-            </TabPanel>
-            <TabPanel>
-              <fieldset>
-                <legend className="sr-only">Choose a custom image</legend>
-                <RadioGroup name="disk-image">
-                  <RadioCard value="custom-centos">Custom CentOS</RadioCard>
-                  <RadioCard value="custom-debian">Custom Debian</RadioCard>
-                  <RadioCard value="custom-fedora">Custom Fedora</RadioCard>
-                </RadioGroup>
-              </fieldset>
-            </TabPanel>
-          </TabPanels>
+          <Tabs.List aria-label="Choose an image">
+            <Tabs.Label>Distributions</Tabs.Label>
+            <Tabs.Label>Custom Images</Tabs.Label>
+          </Tabs.List>
+          <Tabs.Views>
+            <fieldset>
+              <legend className="sr-only">Choose a pre-built image</legend>
+              <RadioGroup name="disk-image">
+                <RadioCard value="centos">CentOS</RadioCard>
+                <RadioCard value="debian">Debian</RadioCard>
+                <RadioCard value="fedora">Fedora</RadioCard>
+                <RadioCard value="freeBsd">FreeBSD</RadioCard>
+                <RadioCard value="ubuntu">Ubuntu</RadioCard>
+                <RadioCard value="windows">Windows</RadioCard>
+              </RadioGroup>
+            </fieldset>
+            <fieldset>
+              <legend className="sr-only">Choose a custom image</legend>
+              <RadioGroup name="disk-image">
+                <RadioCard value="custom-centos">Custom CentOS</RadioCard>
+                <RadioCard value="custom-debian">Custom Debian</RadioCard>
+                <RadioCard value="custom-fedora">Custom Fedora</RadioCard>
+              </RadioGroup>
+            </fieldset>
+          </Tabs.Views>
         </Tabs>
         <Divider />
         <Heading>Choose CPUs and RAM</Heading>
         <Tabs className="mt-1">
-          <TabListLine>
-            <TabList aria-label="Choose CPUs and RAM">
-              <Tab>General purpose</Tab>
-              <Tab>CPU-optimized</Tab>
-              <Tab>Memory-optimized</Tab>
-              <Tab>
-                Custom{' '}
-                <Badge variant="dim" color="green">
-                  New
-                </Badge>
-              </Tab>
-            </TabList>
-          </TabListLine>
-          <TabPanels>
-            <TabPanel>
-              <fieldset aria-describedby="general-instance-hint">
-                <legend className="sr-only">
-                  Choose a general purpose instance
-                </legend>
-                <RadioGroupHint id="general-instance-hint">
-                  General purpose instances provide a good balance of CPU,
-                  memory, and high performance storage; well suited for a wide
-                  range of use cases.
-                </RadioGroupHint>
-                {/* TODO: find the logic behind this ad hoc spacing */}
-                <RadioGroup name="instance-type" className="mt-8">
-                  {renderLargeRadioCards('general')}
-                </RadioGroup>
-              </fieldset>
-            </TabPanel>
-            <TabPanel>
-              <fieldset aria-describedby="cpu-instance-hint">
-                <legend className="sr-only">
-                  Choose a CPU-optimized instance
-                </legend>
-                <RadioGroupHint id="cpu-instance-hint">
-                  CPU optimized instances provide a good balance of...
-                </RadioGroupHint>
-                <RadioGroup name="instance-type" className="mt-8">
-                  {renderLargeRadioCards('cpuOptimized')}
-                </RadioGroup>
-              </fieldset>
-            </TabPanel>
-            <TabPanel>
-              <fieldset aria-describedby="memory-instance-hint">
-                <legend className="sr-only">
-                  Choose a memory-optimized instance
-                </legend>
-                <RadioGroupHint id="memory-instance-hint">
-                  Memory optimized instances provide a good balance of...
-                </RadioGroupHint>
-                <RadioGroup name="instance-type" className="mt-8">
-                  {renderLargeRadioCards('memoryOptimized')}
-                </RadioGroup>
-              </fieldset>
-            </TabPanel>
-            <TabPanel>
-              <fieldset aria-describedby="custom-instance-hint">
-                <legend className="sr-only">Choose a custom instance</legend>
-                <RadioGroupHint id="custom-instance-hint">
-                  Custom instances...
-                </RadioGroupHint>
-                <RadioGroup name="instance-type" className="mt-8">
-                  {renderLargeRadioCards('custom')}
-                </RadioGroup>
-              </fieldset>
-            </TabPanel>
-          </TabPanels>
+          <Tabs.List aria-label="Choose CPUs and RAM">
+            <Tabs.Label>General purpose</Tabs.Label>
+            <Tabs.Label>CPU-optimized</Tabs.Label>
+            <Tabs.Label>Memory-optimized</Tabs.Label>
+            <Tabs.Label badge="New">Custom</Tabs.Label>
+          </Tabs.List>
+          <Tabs.Views>
+            <fieldset aria-describedby="general-instance-hint">
+              <legend className="sr-only">
+                Choose a general purpose instance
+              </legend>
+              <RadioGroupHint id="general-instance-hint">
+                General purpose instances provide a good balance of CPU, memory,
+                and high performance storage; well suited for a wide range of
+                use cases.
+              </RadioGroupHint>
+              {/* TODO: find the logic behind this ad hoc spacing */}
+              <RadioGroup name="instance-type" className="mt-8">
+                {renderLargeRadioCards('general')}
+              </RadioGroup>
+            </fieldset>
+            <fieldset aria-describedby="cpu-instance-hint">
+              <legend className="sr-only">
+                Choose a CPU-optimized instance
+              </legend>
+              <RadioGroupHint id="cpu-instance-hint">
+                CPU optimized instances provide a good balance of...
+              </RadioGroupHint>
+              <RadioGroup name="instance-type" className="mt-8">
+                {renderLargeRadioCards('cpuOptimized')}
+              </RadioGroup>
+            </fieldset>
+            <fieldset aria-describedby="memory-instance-hint">
+              <legend className="sr-only">
+                Choose a memory-optimized instance
+              </legend>
+              <RadioGroupHint id="memory-instance-hint">
+                Memory optimized instances provide a good balance of...
+              </RadioGroupHint>
+              <RadioGroup name="instance-type" className="mt-8">
+                {renderLargeRadioCards('memoryOptimized')}
+              </RadioGroup>
+            </fieldset>
+            <fieldset aria-describedby="custom-instance-hint">
+              <legend className="sr-only">Choose a custom instance</legend>
+              <RadioGroupHint id="custom-instance-hint">
+                Custom instances...
+              </RadioGroupHint>
+              <RadioGroup name="instance-type" className="mt-8">
+                {renderLargeRadioCards('custom')}
+              </RadioGroup>
+            </fieldset>
+          </Tabs.Views>
         </Tabs>
         <Divider />
         <div className="flex mt-20">

--- a/libs/ui/lib/badge/Badge.tsx
+++ b/libs/ui/lib/badge/Badge.tsx
@@ -52,7 +52,7 @@ export const Badge = ({
   return (
     <span
       className={cn(
-        'inline-flex items-center uppercase font-mono text-sm font-thin rounded-sm px-1 whitespace-nowrap',
+        'inline-flex items-baseline uppercase font-mono text-xs font-thin rounded-sm py-0.5 px-1 whitespace-nowrap',
         badgeColors[variant][color],
         className
       )}

--- a/libs/ui/lib/tabs/Tabs.css
+++ b/libs/ui/lib/tabs/Tabs.css
@@ -2,7 +2,7 @@
 }
 
 [data-reach-tab-list] {
-  @apply space-x-2.5 mb-8;
+  @apply space-x-2.5 mb-8 bg-transparent;
 }
 
 [data-reach-tab-panels] {
@@ -16,6 +16,10 @@
 
 [data-reach-tab][data-selected] {
   @apply text-green-500 border-green-500;
+}
+
+[data-reach-tab][data-selected] > span {
+  @apply bg-green-950;
 }
 
 [data-reach-tab-panel] {

--- a/libs/ui/lib/tabs/Tabs.stories.tsx
+++ b/libs/ui/lib/tabs/Tabs.stories.tsx
@@ -1,11 +1,50 @@
 import type { StoryObj } from '@storybook/react'
 import type { ComponentProps } from 'react'
-import { TabListLine } from './Tabs'
+import type { TabLabelProps } from './Tabs'
+import { Tabs } from './Tabs'
+import React from 'react'
 
-type Story = StoryObj<ComponentProps<typeof TabListLine>>
+type Story = StoryObj<
+  ComponentProps<typeof Tabs> & {
+    tabs: Array<string | TabLabelProps>
+    views: React.ReactNode
+  }
+>
 
 export default {
-  component: TabListLine,
+  component: Tabs,
+  render: (args) => {
+    console.log({ args })
+    return (
+      <Tabs>
+        <Tabs.List>
+          {args.tabs.map((tab) =>
+            typeof tab === 'string' ? (
+              <Tabs.Label>{tab}</Tabs.Label>
+            ) : (
+              <Tabs.Label {...tab} />
+            )
+          )}
+        </Tabs.List>
+        <Tabs.Views>
+          {React.Children.map(args.views, (view) => view)}
+        </Tabs.Views>
+      </Tabs>
+    )
+  },
+  args: {},
 } as Story
 
-export const Default: Story = {}
+export const Default: Story = {
+  args: {
+    tabs: ['hello', 'world'],
+    views: ['tab view 1', 'tab view 2'],
+  },
+}
+
+export const WithItemCount: Story = {
+  args: {
+    tabs: ['no items', { badge: '4', children: 'items' }],
+    views: ['Nothing to see here', 'You have 4 unread messages'],
+  },
+}

--- a/libs/ui/lib/tabs/Tabs.tsx
+++ b/libs/ui/lib/tabs/Tabs.tsx
@@ -1,22 +1,72 @@
 import React from 'react'
-import cn from 'classnames'
+
+import type { TabListProps as RListProps } from '@reach/tabs'
+import {
+  Tabs as RTabs,
+  TabList as RList,
+  Tab,
+  TabPanels,
+  TabPanel,
+} from '@reach/tabs'
 
 // the tabs component is just @reach/tabs plus custom CSS
 import './Tabs.css'
+import type { ChildrenProp } from '../../util/children'
+import { pluckType } from '../../util/children'
+import { Badge } from '../badge/Badge'
 
-// Add the pretty line filling out the rest of the space next to the tabs.
-// Unfortunately the line needs to be outside TabList because "TabList should
-// only render Tabs". This is the most straightforward way to add a line in a
-// way that's reusable and doesn't mess up the calling code. props could be
-// normal ReactNode but for now let's require that there's exactly one child.
-// This is only meant to wrap TabList.
-export const TabListLine = (props: {
-  children: React.ReactElement
+interface TabsProps {
+  children: React.ReactNode
   className?: string
-}) => (
-  <div className={cn('flex', props.className)}>
-    {props.children}
-    {/* bottom margin must match that of [data-reach-tab-list] */}
-    <div className="border-b border-gray-400 flex-1 ml-2.5 mb-8" />
-  </div>
-)
+}
+export function Tabs({ children, ...props }: TabsProps) {
+  const childArray = React.Children.toArray(children)
+  const list = pluckType(childArray, Tabs.List)
+  const views = pluckType(childArray, Tabs.Views)
+  return (
+    <RTabs {...props}>
+      {list}
+      {views}
+    </RTabs>
+  )
+}
+
+Tabs.List = ({ children, ...props }: RListProps) => {
+  const after =
+    'after:block after:border-b after:w-full after:border-gray-400 after:ml-2.5'
+  return (
+    <RList className={`${after}`} {...props}>
+      {children}
+    </RList>
+  )
+}
+
+export interface TabLabelProps extends ChildrenProp {
+  badge?: string
+}
+Tabs.Label = ({ badge, children }: TabLabelProps) => {
+  return (
+    <Tab className="whitespace-nowrap min-w-max">
+      {children}
+      {badge && (
+        <Badge
+          className="ml-2 pb-0.3 text-current"
+          color="darkGray"
+          variant="dim"
+        >
+          {badge}
+        </Badge>
+      )}
+    </Tab>
+  )
+}
+
+Tabs.Views = ({ children }: ChildrenProp) => {
+  return (
+    <TabPanels>
+      {React.Children.map(children, (child) => (
+        <TabPanel>{child}</TabPanel>
+      ))}
+    </TabPanels>
+  )
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3087225/141925127-1c6230ae-d907-4043-aedf-74590850e64c.png)

The tabs component hasn't really changed but the API has. Instead of just being the reach tabs component that's used at the call site this wraps reach's API as well as making some minor stylistic updates. I've also went ahead and added a more detailed story.

I'm still thinking a bit about the exposed API. It doesn't feel quite right the way it stands. 

The designs show a full bleed experience like below:

![image](https://user-images.githubusercontent.com/3087225/141926313-bae2ea6b-fd8f-48ed-93f8-2b8c61c05be7.png)

It's still my intent to provide this experience, but the full bleed nature is (imo) a function of the layout not necessarily a function of the component. I'll include an example in the vpc page when I push that up.