### PR TITLE
Make properties table responsive

### DIFF
--- a/libs/ui/lib/properties-table/PropertiesTable.stories.tsx
+++ b/libs/ui/lib/properties-table/PropertiesTable.stories.tsx
@@ -21,3 +21,26 @@ export const Default: Story = {
     ],
   },
 }
+
+export const TwoColumnResponsive: Story = {
+  render: () => (
+    <PropertiesTable.Group>
+      <PropertiesTable>
+        <PropertiesTable.Row label="Description">
+          Default network for the project
+        </PropertiesTable.Row>
+        <PropertiesTable.Row label="Dns Name">
+          frontend-production-vpn
+        </PropertiesTable.Row>
+      </PropertiesTable>
+      <PropertiesTable>
+        <PropertiesTable.Row label="Creation date">
+          2 Nov 2020, 06:12:52 UTC
+        </PropertiesTable.Row>
+        <PropertiesTable.Row label="last modified">
+          14 Nov 2020, 12:21:52 UTC
+        </PropertiesTable.Row>
+      </PropertiesTable>
+    </PropertiesTable.Group>
+  ),
+}

--- a/libs/ui/lib/properties-table/PropertiesTable.tsx
+++ b/libs/ui/lib/properties-table/PropertiesTable.tsx
@@ -22,9 +22,6 @@ export function PropertiesTable({ className, children }: PropertiesTableProps) {
         className,
         'properties-table grid border border-gray-400 rounded-sm divide-y children:p-2 children:border-gray-500'
       )}
-      style={{
-        gridTemplateColumns: 'minmax(min-content, 1fr) 3fr',
-      }}
     >
       {children}
     </div>
@@ -43,3 +40,19 @@ PropertiesTable.Row = ({ label, children }: PropertiesTableRowProps) => (
     <span>{children}</span>
   </>
 )
+
+interface PropertiesTableGroupProps {
+  children: ReactNode
+}
+
+PropertiesTable.Group = ({ children }: PropertiesTableGroupProps) => {
+  invariant(
+    isOneOf(children, [PropertiesTable]),
+    'PropertiesTable can only have PropertiesTable.Row as a child'
+  )
+  return (
+    <div className="flex min-w-min md-:flex-col lg+:space-x-4 md-:first:children:border-b-gray-500 md-:first:children:rounded-b-none md-:last:children:border-t-0 md-:last:children:rounded-t-none">
+      {children}
+    </div>
+  )
+}

--- a/libs/ui/lib/properties-table/properties-table.css
+++ b/libs/ui/lib/properties-table/properties-table.css
@@ -1,3 +1,7 @@
+.properties-table {
+  grid-template-columns: minmax(min-content, 1fr) 3fr;
+}
+
 .properties-table > *:nth-child(2) {
   @apply !border-0;
 }


### PR DESCRIPTION
## Background

The properties table (meta in figma) has somewhat of a unique behavior. On the networking page you see it appear in this configuration

![image](https://user-images.githubusercontent.com/3087225/142708023-4eed810e-383d-451f-bdb4-474879b354df.png)
 
Issue is, those two tables together take up a lot of space. At a certain point you have to collapse it down. That's actually somewhat of a non-trivial behavior given that they're actually two containers. You ultimately have to have a wrapping container to help position things based on break point.

When the screen is smaller the above breaks down into this:

![image](https://user-images.githubusercontent.com/3087225/142708097-8703e4b2-5260-48af-a899-5648794b5ca9.png)

## Approach

I've created a new `PropertiesTable.Group` component that you can wrap a set of `PropertiesTable`s in to give it this dual column/responsive treatment. 

## Issues with this approach

It mostly works well accept the tables are still separate containers, even when they collapse. This means at very small sizes the rows become misaligned

![image](https://user-images.githubusercontent.com/3087225/142708286-309df14d-caca-471a-ab96-cf9941dea0e4.png)

Notice the misalignment of the first two rows of text to the second to rows of text. 

I think this is ultimately fine for now and it's likely we should figure out a better design treatment for the table at smaller screen sizes generally. 
