### PR TITLE
Add utilities for our fonts

### DIFF
--- a/libs/ui/lib/__stories__/Typography.stories.mdx
+++ b/libs/ui/lib/__stories__/Typography.stories.mdx
@@ -1,0 +1,30 @@
+import { Meta } from '@storybook/addon-docs'
+import { Section } from '../../util/story-section'
+
+<Meta title="Foundations/Typography" />
+
+<Section title="Display" className="space-x-4">
+  <span className="!ml-0 !text-display-2xl">text-display-2xl</span>
+  <span className="!text-display-xl">text-display-xl</span>
+  <span className="!text-display-lg">text-display-lg</span>
+  <span className="!text-display-md">text-display-md</span>
+</Section>
+
+<Section title="Mono" className="space-x-4">
+  <span className="!ml-0 !text-mono-lg">text-mono-lg</span>
+  <span className="!text-mono-md">text-mono-md</span>
+  <span className="!text-mono-sm">text-mono-sm</span>
+  <span className="!text-mono-xs">text-mono-xs</span>
+</Section>
+
+<Section title="Sans" className="space-x-4">
+  <span className="!ml-0 !text-sans-lg">text-sans-lg</span>
+  <span className="!text-sans-md">text-sans-md</span>
+  <span className="!text-sans-sm">text-sans-sm</span>
+</Section>
+
+<Section title="Sans Medium" className="space-x-4">
+  <span className="!ml-0 !text-sans-semi-lg">text-sans-semi-lg</span>
+  <span className="!text-sans-semi-md">text-sans-semi-md</span>
+  <span className="!text-sans-semi-sm">text-sans-semi-sm</span>
+</Section>

--- a/libs/ui/lib/icons/Icons.stories.tsx
+++ b/libs/ui/lib/icons/Icons.stories.tsx
@@ -1,6 +1,6 @@
 import * as icons from './index'
 import React from 'react'
-import { Section } from '../..//util/story-section'
+import { Section } from '../../util/story-section'
 import type { StoryObj } from '@storybook/react'
 import type { ComponentProps } from 'react'
 
@@ -21,8 +21,6 @@ export default {
     },
   },
 } as Story
-
-console.log(icons)
 
 export const All: Story = {
   render: ({ color }) => {

--- a/libs/ui/styles/index.css
+++ b/libs/ui/styles/index.css
@@ -39,25 +39,4 @@
   .font-sans {
     letter-spacing: 0.02em;
   }
-
-  .text-display-lg {
-    @apply font-display font-light;
-    font-size: 1.25rem;
-    letter-spacing: 0.04em;
-    line-height: 1;
-  }
-
-  .text-display-xl {
-    @apply font-display font-light;
-    font-size: 1.625rem;
-    letter-spacing: 0.03em;
-    line-height: 1;
-  }
-
-  .text-display-2xl {
-    @apply font-display font-light;
-    font-size: 2.625rem;
-    letter-spacing: 0.03em;
-    line-height: 1;
-  }
 }

--- a/libs/ui/util/story-section.tsx
+++ b/libs/ui/util/story-section.tsx
@@ -17,7 +17,7 @@ export const Section = ({
   className?: string
 }) => (
   <section className={cn(className, 'mb-8 mr-8')}>
-    <h2 className="text-display-xl text-green-500 border-green-800 border-b pb-4 mb-4">
+    <h2 className="text-display-2xl text-green-500 border-green-800 border-b pb-4 mb-4">
       {capitalize(title)}
     </h2>
     {children}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -84,11 +84,104 @@ module.exports = {
     },
   },
   plugins: [
-    plugin(({ addVariant }) => {
+    plugin(({ addVariant, addUtilities }) => {
       // imitation of the twin.macro svg: variant. svg:text-green-500 puts green
       // on an SVG that's an immediate child of the element
       addVariant('svg', '& > svg')
       addVariant('children', '& > *')
+
+      const displayFamily = {
+        'font-family': '"Haas Grot Disp Web", sans-serif',
+      }
+      const monoFamily = {
+        'font-family': '"GT America Mono", monospace',
+      }
+      const sansFamily = {
+        'font-family': 'Inter, sans-serif',
+      }
+      addUtilities({
+        '.text-display-md': {
+          ...displayFamily,
+          'font-size': '1rem',
+          'line-height': '1.5rem',
+          'letter-spacing': '0.05rem',
+          'font-weight': 300,
+        },
+        '.text-display-lg': {
+          ...displayFamily,
+          'font-size': '1.25rem',
+          'line-height': '1.3rem',
+          'letter-spacing': '0.04rem',
+          'font-weight': 300,
+        },
+        '.text-display-xl': {
+          ...displayFamily,
+          'font-size': '1.25rem',
+          'line-height': '1.3rem',
+          'letter-spacing': '0.04rem',
+          'font-weight': 300,
+        },
+        '.text-display-2xl': {
+          ...displayFamily,
+          'font-size': '1.625rem',
+          'line-height': '1.1rem',
+          'letter-spacing': '0.03rem',
+          'font-weight': 300,
+        },
+        '.text-mono-xs': {
+          ...monoFamily,
+          'font-size': '0.625rem',
+          'letter-spacing': '0.04rem',
+        },
+        '.text-mono-sm': {
+          ...monoFamily,
+          'font-size': '0.6875rem',
+          'letter-spacing': '0.04rem',
+        },
+        '.text-mono-md': {
+          ...monoFamily,
+          'font-size': '0.75rem',
+          'letter-spacing': '0.04rem',
+        },
+        '.text-mono-lg': {
+          ...monoFamily,
+          'font-size': '0.75rem',
+          'letter-spacing': '0.04rem',
+        },
+        '.text-sans-sm': {
+          ...sansFamily,
+          'font-size': '0.75rem',
+          'letter-spacing': '0.04rem',
+        },
+        '.text-sans-md': {
+          ...sansFamily,
+          'font-size': '0.8125rem',
+          'letter-spacing': '0.03rem',
+        },
+        '.text-sans-lg': {
+          ...sansFamily,
+          'font-size': '1rem',
+          'letter-spacing': '0.02rem',
+        },
+        '.text-sans-semi-sm': {
+          ...sansFamily,
+          'font-size': '0.75rem',
+          'letter-spacing': '0.02rem',
+          'font-weight': 500,
+        },
+        '.text-sans-semi-md': {
+          ...sansFamily,
+          'font-size': '0.875rem',
+          'letter-spacing': '0.02rem',
+          'font-weight': 500,
+        },
+        '.text-sans-semi-lg': {
+          ...sansFamily,
+          'font-size': '1rem',
+          'letter-spacing': '0.02rem',
+          'font-weight': 500,
+        },
+      })
     }),
   ],
 }


### PR DESCRIPTION
This adds tailwind utilities directly for our fonts so that we can utilize the correct subset without having to stitch together tailwind's system to match our needs. 

![image](https://user-images.githubusercontent.com/3087225/143314941-8644c51b-5005-4317-888f-1d884b31a9fe.png)

As I was putting these together it struck me how small most of these fonts look. We may need to consider adjusting the size on some of these for accessibility/legibility purposes. Note that the screenshot above is rendered on windows which generally is shit at rendering fonts. 

## Follow up work

After this is merged we'll incrementally move to using these utilities over tailwinds built in `text-` and `font-` utilities. Once we've migrated we'll disable those core plugins. 
