### PR TITLE
Render null instead of the word "loading"

### DIFF
--- a/app/components/InstancePageHeader.tsx
+++ b/app/components/InstancePageHeader.tsx
@@ -68,10 +68,10 @@ export const InstancePageHeader = () => {
     if (error.raw.status === 404) {
       return <div>Instance not found</div>
     } else {
-      return <div>loading</div>
+      return null
     }
   }
-  if (!instance) return <div>loading</div>
+  if (!instance) return null
 
   const handleStop = () => {
     if (instanceCan.stop(instance)) {

--- a/app/components/InstancesTable.tsx
+++ b/app/components/InstancesTable.tsx
@@ -178,7 +178,7 @@ export const InstancesTable = ({ className }: { className?: string }) => {
     hooks.visibleColumns.push((columns) => [selectCol, ...columns, menuCol])
   })
 
-  if (!instances) return <div>loading</div>
+  if (!instances) return null
 
   // hasPrev check is there because the API doesn't leave off nextPage when
   // we're on the last page, so there's an empty page at the end we want to show

--- a/app/pages/OrgPage.tsx
+++ b/app/pages/OrgPage.tsx
@@ -11,7 +11,7 @@ export default function OrgPage() {
     organizationName: orgName,
   })
 
-  if (!org) return <div>loading</div>
+  if (!org) return null
 
   return (
     <>

--- a/app/pages/ProjectsPage.tsx
+++ b/app/pages/ProjectsPage.tsx
@@ -39,7 +39,7 @@ const ProjectsPage = () => {
     organizationName: orgName,
   })
 
-  if (!data) return <div>loading</div>
+  if (!data) return null
 
   return (
     <>

--- a/app/pages/instances/Storage.tsx
+++ b/app/pages/instances/Storage.tsx
@@ -53,7 +53,7 @@ function Storage() {
   const bootDiskTable = useTable({ columns, data: bootDisks })
   const otherDisksTable = useTable({ columns, data: otherDisks })
 
-  if (!data) return <div>loading</div>
+  if (!data) return null
 
   return (
     <div className="mt-16">

--- a/app/pages/project/Storage.tsx
+++ b/app/pages/project/Storage.tsx
@@ -30,7 +30,7 @@ export default function ProjectStorage() {
 
   const table = useTable({ columns, data: disks })
 
-  if (!data) return <div>loading</div>
+  if (!data) return null
 
   return (
     <>

--- a/app/pages/project/index.tsx
+++ b/app/pages/project/index.tsx
@@ -13,7 +13,7 @@ const ProjectPage = () => {
     projectName,
   })
 
-  if (!project) return <div>loading</div>
+  if (!project) return null
 
   return (
     <>

--- a/app/routes.tsx
+++ b/app/routes.tsx
@@ -13,7 +13,7 @@ function lazyLoad(importFunc: () => Promise<{ default: React.ComponentType }>) {
   const Inner = React.lazy(importFunc)
   return () => (
     // TODO: nicer fallback
-    <Suspense fallback="loading">
+    <Suspense fallback={null}>
       <Inner />
     </Suspense>
   )


### PR DESCRIPTION
It's still jarring in some cases but overall a tiny improvement. Generally I don't want to put too much effort into this because I'm hoping not to have many noticeable loading states at all once they port the Remix transition manager to React Router, as Ryan Florence has said they will do soon.