### PR TITLE
Add ts-unused-exports but don't use it in CI or anything

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "build:storybook": "build-storybook -c libs/ui/.storybook -o dist/storybook/ui",
     "//": "Required due to jscodeshift shipping with windows line endings starting in v0.12. See https://github.com/facebook/jscodeshift/issues/424.",
     "jscodeshift": "node node_modules/.bin/jscodeshift",
-    "postinstall": "patch-package"
+    "postinstall": "patch-package",
+    "unused-exports": "ts-unused-exports tsconfig.json --ignoreFiles=\\.stories --excludePathsFromReport=\"libs/api/index.ts;libs/ui/index.ts\""
   },
   "private": true,
   "dependencies": {
@@ -115,6 +116,7 @@
     "swagger-typescript-api": "9.3.1",
     "tailwindcss": "^3.0.9",
     "ts-node": "^9.1.1",
+    "ts-unused-exports": "^7.0.3",
     "tsconfig-paths-webpack-plugin": "^3.5.1",
     "typescript": "4.5.5",
     "url-loader": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14197,6 +14197,14 @@ ts-pnp@^1.1.6:
   resolved "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
 
+ts-unused-exports@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/ts-unused-exports/-/ts-unused-exports-7.0.3.tgz#37a06d103d9d5b8619807dbd50d89f698e8cebf1"
+  integrity sha512-D0VdTiTfrmZM7tViQEMuzG0+giU5z5crn4vjK+f1dnxTKcNx23Vc2lpMgd1vP3lYrwnvJofZmCnvEuJ7XUeV2Q==
+  dependencies:
+    chalk "^4.0.0"
+    tsconfig-paths "^3.9.0"
+
 tsconfig-paths-webpack-plugin@^3.5.1:
   version "3.5.1"
   resolved "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-3.5.1.tgz"


### PR DESCRIPTION
Kinda handy, don't see much downside to putting the script in there even if we don't rely on it yet.