### PR TITLE
Fix visual tests to auto accept on main

### DIFF
--- a/.github/workflows/visual-test.yaml
+++ b/.github/workflows/visual-test.yaml
@@ -13,9 +13,18 @@ jobs:
       - uses: actions/checkout@v1
       - name: Install dependencies
         run: yarn
-      - name: Publish to Chromatic
+      - name: Run chromatic visual tests for branch
+        if: github.ref != 'refs/heads/main'
         uses: chromaui/action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           onlyChanged: true
+      - name: Update visual tests in main
+        if: github.ref == 'refs/heads/main'
+        uses: chromaui/action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          onlyChanged: true
+          autoAcceptChanges: true


### PR DESCRIPTION
This is supposed to be happening automatically, but I think it's having some issues being that we're rebasing. Anyway, this just ensures any unaccepted tests that get to main are auto accepted. 