### PR TITLE
Speed up the slow tests

### DIFF
--- a/app/pages/project/networking/VpcPage/VpcPage.spec.ts
+++ b/app/pages/project/networking/VpcPage/VpcPage.spec.ts
@@ -120,7 +120,7 @@ describe('VpcPage', () => {
 
       // table refetches and now includes the new rule as well as the originals
       await screen.findByText('my-new-rule')
-      getBySelectorAndText('td', 'instancehost-filter-instanceUDP123-456')
+      getBySelectorAndText('td', 'instance host-filter-instance UDP 123-456')
 
       for (const { name } of defaultFirewallRules) {
         screen.getByText(name)
@@ -200,7 +200,7 @@ describe('VpcPage', () => {
       expect(document.querySelectorAll('tbody tr').length).toEqual(4)
 
       // the filters cell says "Instance edit-filter-instance" and "ICMP"
-      getBySelectorAndText('td', 'instanceedit-filter-instanceICMP')
+      getBySelectorAndText('td', 'instance edit-filter-instance ICMP')
 
       // other 3 rules are still there
       const rest = defaultFirewallRules.filter((r) => r.name !== 'allow-icmp')

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "autoprefixer": "^10.2.5",
     "babel-loader": "^8.2.2",
     "chromatic": "^6.4.2",
+    "dom-accessibility-api": "^0.5.11",
     "esbuild-register": "^3.3.2",
     "eslint": "7.32.0",
     "eslint-config-prettier": "^8.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6336,15 +6336,15 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dom-accessibility-api@^0.5.11, dom-accessibility-api@^0.5.9:
+  version "0.5.11"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.11.tgz#79d5846c4f90eba3e617d9031e921de9324f84ed"
+  integrity sha512-7X6GvzjYf4yTdRKuCVScV+aA9Fvh5r8WzWrXBH9w82ZWB/eYDMGCnazoC/YAqAzUJWHzLOnZqr46K3iEyUhUvw==
+
 dom-accessibility-api@^0.5.6:
   version "0.5.6"
   resolved "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.6.tgz"
   integrity sha512-DplGLZd8L1lN64jlT27N9TVSESFR5STaEJvX+thCby7fuCHonfPpAlodYc3vuUYbDuDec5w8AMP7oCM5TWFsqw==
-
-dom-accessibility-api@^0.5.9:
-  version "0.5.11"
-  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.11.tgz#79d5846c4f90eba3e617d9031e921de9324f84ed"
-  integrity sha512-7X6GvzjYf4yTdRKuCVScV+aA9Fvh5r8WzWrXBH9w82ZWB/eYDMGCnazoC/YAqAzUJWHzLOnZqr46K3iEyUhUvw==
 
 dom-converter@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
Replace `byRole` queries with a custom selector + text matcher query. It's less flexible because now we're looking for `td`s and buttons, but the tests are about 4x faster. It's entirely possible we decide we don't care that much about the slowness and instead just crank up the timeouts on these, but I wanted to see how fast it was possible to make them.

They are about 3x slower in CI than on my machine, which means we still need the extended timeouts, which in turn means the primary value of speeding these tests up would be for local development. I am torn here because I love the Testing Library philosophy of querying the DOM by ARIA role (explicitly assigned, or more often, [implicit](https://www.w3.org/TR/html-aria/#docconformance)) and [accessible name](https://www.tpgi.com/what-is-an-accessible-name/).

## Timing

### Before (local)

```
√ app/pages/project/networking/VpcPage/VpcPage.spec.ts (3) 12114ms
 √ VpcPage (3) 12114ms
   √ subnet (1) 1052ms
     √ create works 1052ms
   √ firewall rule (2) 11061ms
     √ create works 5650ms
     √ edit works 5412ms
```

### After (local)

```
√ app/pages/project/networking/VpcPage/VpcPage.spec.ts (3) 3693ms
 √ VpcPage (3) 3693ms
   √ subnet (1) 690ms
     √ create works 690ms
   √ firewall rule (2) 3003ms
     √ create works 1790ms
     √ edit works 1212ms
```

## Accessible names

One very useful thing I learned was how Testing Library computes accessible names. It uses [dom-accessibility-api/](https://github.com/eps1lon/dom-accessibility-api/). Turns out this is _very_ slow and is probably a big reason `*byRole` queries are slow. If we use the instantaneous `el.textContent` for the text, `getAllBySelectorAndText('td', 'new-rule-name')` takes about ~15ms, which means `findBySelectorAndText` works fine with a 50ms interval. But with `computerAccessibleName` from that library, it takes **over 250ms** per run, which is not compatible with the 50ms interval. (Note that on each run it's going through like 50 `td`s and calling `computeAccessibleName` on them.)

`computeAccessibleName` also takes a `getComputedStyle` config option that lets you mock out that function to make it go faster.