### PR TITLE
Use tuple union for discriminated Result type

### DIFF
--- a/libs/api-mocks/msw/util.ts
+++ b/libs/api-mocks/msw/util.ts
@@ -1,0 +1,11 @@
+import type { ResponseTransformer } from 'msw'
+import { context, compose } from 'msw'
+
+/**
+ * Custom transformer: convenience function for less typing. Equivalent to
+ * `res(ctx.status(status), ctx.json(body))` in a handler.
+ *
+ * https://mswjs.io/docs/basics/response-transformer#custom-transformer
+ */
+export const json = <B>(body: B, status = 200): ResponseTransformer<B> =>
+  compose(context.status(status), context.json(body))

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "ts-unused-exports": "^7.0.3",
     "tsconfig-paths-webpack-plugin": "^3.5.1",
     "type-fest": "^2.10.0",
-    "typescript": "4.5.5",
+    "typescript": "^4.6.1-rc",
     "url-loader": "^4.1.1",
     "vite": "^2.8.0",
     "vitest": "^0.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13626,10 +13626,10 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.5.5:
-  version "4.5.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
-  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
+typescript@^4.6.1-rc:
+  version "4.6.1-rc"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.1-rc.tgz#75baa823a6fca592f358b486acc2039f103ca2af"
+  integrity sha512-tLPT3GelVfTN9wXPOuPKfY83PkMvgdF3V3gHK/ElNrpQPdLKQ/HMU5cS6+7epYSIF2gne190jzydAW0FLLwU7A==
 
 uglify-js@^3.1.4:
   version "3.14.1"


### PR DESCRIPTION
Requires TS 4.6 RC. I wanted to see if it would work, then I went all the way, so we might as well keep it. The tuple type makes for cleaner destructuring and cleaner inline construction of success and error objects.

```diff
- { ok: instance, err: null }
+ [ instance, null ] 

- { ok: null, err }
+ [ null, err ] 
```

Then I added `Ok` and `Err` functions to do that for us, which kind of eliminates the difference, since it could just as easily return `{ ok: instance, err: null }` as `[instance, null]`. However, switching to the tuples also eliminates a bunch of annoying `instance.ok.id` stuff we had to do, so I lean toward saying it's worth it.

To get VS Code to use 4.6 for Intellisense, I had to check this:

<img width="390" alt="Screen Shot 2022-02-15 at 8 49 23 PM" src="https://user-images.githubusercontent.com/3612203/154180980-0302089c-d285-4a76-bd03-44026e86823b.png">

Even though in theory this is already on:

https://github.com/oxidecomputer/console/blob/9d1524668ab9ff0227d787a42d00db391d9a8bd5/.vscode/settings.json#L8