### PR TITLE
Spruce up test utils file organization

### DIFF
--- a/app/pages/__tests__/InstanceCreatePage.spec.tsx
+++ b/app/pages/__tests__/InstanceCreatePage.spec.tsx
@@ -6,7 +6,7 @@ import {
   screen,
   typeByRole,
   waitFor,
-} from 'app/test-utils'
+} from 'app/test/utils'
 import { org, project, instance } from '@oxide/api-mocks'
 
 const formUrl = `/orgs/${org.name}/projects/${project.name}/instances/new`

--- a/app/pages/__tests__/ProjectCreatePage.spec.tsx
+++ b/app/pages/__tests__/ProjectCreatePage.spec.tsx
@@ -5,7 +5,7 @@ import {
   renderAppAt,
   screen,
   waitFor,
-} from 'app/test-utils'
+} from 'app/test/utils'
 import { org, project } from '@oxide/api-mocks'
 
 const projectsUrl = `/api/organizations/${org.name}/projects`

--- a/app/pages/project/networking/VpcPage/VpcPage.spec.ts
+++ b/app/pages/project/networking/VpcPage/VpcPage.spec.ts
@@ -1,12 +1,12 @@
+import userEvent from '@testing-library/user-event'
 import {
   clickByRole,
   renderAppAt,
   screen,
   typeByRole,
   waitForElementToBeRemoved,
-  userEvent,
   getByRole,
-} from 'app/test-utils'
+} from 'app/test/utils'
 import { defaultFirewallRules } from '@oxide/api-mocks'
 
 describe('VpcPage', () => {

--- a/app/routes.spec.tsx
+++ b/app/routes.spec.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import { matchRoutes } from 'react-router'
-import { renderAppAt } from './test-utils'
+import { renderAppAt } from './test/utils'
 
 import { projects } from '@oxide/api-mocks'
 

--- a/app/test/server.ts
+++ b/app/test/server.ts
@@ -1,0 +1,21 @@
+import { rest } from 'msw'
+import { setupServer } from 'msw/node'
+import { handlers, json } from '@oxide/api-mocks'
+
+export const server = setupServer(...handlers)
+
+// Override request handlers in order to test special cases
+export function override(
+  method: keyof typeof rest,
+  path: string,
+  status: number,
+  body: string | Record<string, unknown>
+) {
+  server.use(
+    rest[method](path, (_req, res, ctx) =>
+      typeof body === 'string'
+        ? res(ctx.status(status), ctx.text(body))
+        : res(json(body, status))
+    )
+  )
+}

--- a/app/test/setup.ts
+++ b/app/test/setup.ts
@@ -1,0 +1,22 @@
+import 'whatwg-fetch' // our node fetch polyfill of choice
+import '@testing-library/jest-dom' // fancy asserts
+
+import { setLogger } from 'react-query'
+import { resetDb } from '@oxide/api-mocks'
+import { server } from './server'
+
+// react-query calls console.error whenever a request fails.
+// this is annoying and we don't need it. leave log and warn there
+// just in case they tell us something useful
+setLogger({
+  log: console.log,
+  warn: console.warn,
+  error: () => {},
+})
+
+beforeAll(() => server.listen())
+afterEach(() => {
+  resetDb()
+  server.resetHandlers()
+})
+afterAll(() => server.close())

--- a/app/test/utils.tsx
+++ b/app/test/utils.tsx
@@ -1,55 +1,10 @@
 import React from 'react'
 import { BrowserRouter } from 'react-router-dom'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render as tlRender, screen } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from 'react-query'
-import { rest } from 'msw'
-import { setupServer } from 'msw/node'
-import { json } from '@oxide/api-mocks'
-import 'whatwg-fetch'
-import '@testing-library/jest-dom'
 
-import { routes } from './routes'
-import { handlers, resetDb } from '@oxide/api-mocks'
-import { afterAll, afterEach, beforeAll } from 'vitest'
-
-import { setLogger } from 'react-query'
-
-// react-query calls console.error whenever a request fails.
-// this is annoying and we don't need it. leave log and warn there
-// just in case they tell us something useful
-setLogger({
-  log: console.log,
-  warn: console.warn,
-  error: () => {},
-})
-
-/*****************************************
- * MSW
- ****************************************/
-const server = setupServer(...handlers)
-
-beforeAll(() => server.listen())
-afterEach(() => {
-  resetDb()
-  server.resetHandlers()
-})
-afterAll(() => server.close())
-
-// Override request handlers in order to test special cases
-export function override(
-  method: keyof typeof rest,
-  path: string,
-  status: number,
-  body: string | Record<string, unknown>
-) {
-  server.use(
-    rest[method](path, (_req, res, ctx) =>
-      typeof body === 'string'
-        ? res(ctx.status(status), ctx.text(body))
-        : res(json(body, status))
-    )
-  )
-}
+import { routes } from '../routes'
+export { override } from './server'
 
 /*****************************************
  * RENDERING
@@ -64,8 +19,8 @@ const queryClient = () =>
     },
   })
 
-const customRender = (ui: React.ReactElement) =>
-  render(ui, {
+export const customRender = (ui: React.ReactElement) =>
+  tlRender(ui, {
     wrapper: ({ children }) => (
       <QueryClientProvider client={queryClient()}>
         {children}
@@ -75,7 +30,7 @@ const customRender = (ui: React.ReactElement) =>
 
 export function renderAppAt(url: string) {
   window.history.pushState({}, 'Test page', url)
-  return render(routes, {
+  return tlRender(routes, {
     wrapper: ({ children }) => (
       <BrowserRouter>
         <QueryClientProvider client={queryClient()}>
@@ -91,8 +46,6 @@ export function renderAppAt(url: string) {
  ****************************************/
 
 export * from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-export { customRender as render, userEvent }
 
 // convenience functions so we can click and type in a one-liner. these were
 // initially created to use the user-event library, but it was remarkably slow.

--- a/libs/api/__tests__/hooks.spec.tsx
+++ b/libs/api/__tests__/hooks.spec.tsx
@@ -3,7 +3,7 @@ import { QueryClient, QueryClientProvider } from 'react-query'
 import { waitFor } from '@testing-library/react'
 import { renderHook, act } from '@testing-library/react-hooks'
 
-import { override } from 'app/test-utils'
+import { override } from 'app/test/utils'
 import { org } from '@oxide/api-mocks'
 import { useApiQuery, useApiMutation } from '../'
 

--- a/libs/api/__tests__/safety.spec.ts
+++ b/libs/api/__tests__/safety.spec.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import { execSync } from 'child_process'
 
-describe('Generated API client version matches API version specified for deployment', () => {
+it('Generated API client version matches API version specified for deployment', () => {
   const generatedVersion = fs
     .readFileSync(
       path.resolve(__dirname, '../__generated__/OMICRON_VERSION'),
@@ -31,7 +31,7 @@ const grepFiles = (s: string) =>
 it('@oxide/api-mocks is only referenced in test files', () => {
   const files = grepFiles("from '@oxide/api-mocks'")
   for (const file of files) {
-    expect(file).toMatch(/__tests__|test-utils|\.spec\.|tsconfig|api-mocks/)
+    expect(file).toMatch(/__tests__\/|app\/test\/|\.spec\.|tsconfig|api-mocks/)
   }
 })
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -62,5 +62,6 @@ export default defineConfig(({ mode }) => ({
   test: {
     global: true,
     environment: 'jsdom',
+    setupFiles: ['app/test/setup.ts'],
   },
 }))


### PR DESCRIPTION
Nothing interesting — the fact that we were doing our setup in test-utils instead of in an explicit setup file was bugging me. In practice it wasn't a problem because any test file that relied on the setup was importing test-utils, but in theory that doesn't have to be the case.