### PR TITLE
Upgrade vitest, fix process.env.API_URL problem

### DIFF
--- a/libs/api/index.ts
+++ b/libs/api/index.ts
@@ -7,7 +7,7 @@ import {
 import { Api } from './__generated__/Api'
 
 const api = new Api({
-  baseUrl: process.env.API_URL ?? '/api',
+  baseUrl: process.env.API_URL,
 })
 
 type A = typeof api.methods

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "typescript": "4.6.1-rc",
     "url-loader": "^4.1.1",
     "vite": "^2.8.0",
-    "vitest": "^0.3.6",
+    "vitest": "^0.5.5",
     "webpack": "^5.40.0",
     "whatwg-fetch": "^3.6.2"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,7 +27,7 @@ export default defineConfig(({ mode }) => ({
     // minify: false, // uncomment for debugging
   },
   define: {
-    'process.env.API_URL': JSON.stringify(process.env.API_URL),
+    'process.env.API_URL': JSON.stringify(process.env.API_URL ?? '/api'),
     'process.env.MSW': JSON.stringify(mode !== 'production' && process.env.MSW),
   },
   plugins: [react()],

--- a/yarn.lock
+++ b/yarn.lock
@@ -13872,10 +13872,10 @@ tinypool@^0.1.2:
   resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-0.1.2.tgz#5b1d5f5bb403afac8c67000047951ce76342fda7"
   integrity sha512-fvtYGXoui2RpeMILfkvGIgOVkzJEGediv8UJt7TxdAOY8pnvUkFg/fkvqTfXG9Acc9S17Cnn1S4osDc2164guA==
 
-tinyspy@^0.2.10:
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-0.2.10.tgz#7f684504bda345620f7a6a8462c618ef3d055517"
-  integrity sha512-Qij6rGWCDjWIejxCXXVi6bNgvrYBp3PbqC4cBP/0fD6WHDOHCw09Zd13CsxrDqSR5PFq01WeqDws8t5lz5sH0A==
+tinyspy@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-0.3.0.tgz#51bcc198173385c50416df791cd10c192078cb36"
+  integrity sha512-c5uFHqtUp74R2DJE3/Efg0mH5xicmgziaQXMm/LvuuZn3RdpADH32aEGDRyCzObXT1DNfwDMqRQ/Drh1MlO12g==
 
 title-case@^2.1.0:
   version "2.1.1"
@@ -14547,6 +14547,18 @@ vfile@^4.0.0:
     unist-util-stringify-position "^2.0.0"
     vfile-message "^2.0.0"
 
+vite@^2.7.10:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-2.8.4.tgz#4e52a534289b7b4e94e646df2fc5556ceaa7336b"
+  integrity sha512-GwtOkkaT2LDI82uWZKcrpRQxP5tymLnC7hVHHqNkhFNknYr0hJUlDLfhVRgngJvAy3RwypkDCWtTKn1BjO96Dw==
+  dependencies:
+    esbuild "^0.14.14"
+    postcss "^8.4.6"
+    resolve "^1.22.0"
+    rollup "^2.59.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
 vite@^2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/vite/-/vite-2.8.0.tgz#0646ab9eee805fb24b667889644ac04bc516d0d3"
@@ -14559,30 +14571,18 @@ vite@^2.8.0:
   optionalDependencies:
     fsevents "~2.3.2"
 
-vite@^2.8.2:
-  version "2.8.3"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-2.8.3.tgz#bb9b7f1f1446d2e538e81026f48d2fe9f1926963"
-  integrity sha512-967klrEiG7HEsN7fQYYVETs5495Iu6GpI7YyxoO5yVTJCRxjV8HhWgNWKgrbazjoOB9DQuztL53/nUoNqHNsWg==
-  dependencies:
-    esbuild "^0.14.14"
-    postcss "^8.4.6"
-    resolve "^1.22.0"
-    rollup "^2.59.0"
-  optionalDependencies:
-    fsevents "~2.3.2"
-
-vitest@^0.3.6:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.3.6.tgz#ae5e173b7c45b6e595cbba00f956739759bf9729"
-  integrity sha512-EzlAmGHDh/sQhzKeqDtEae6nlFM5pJKJefj5P2eUUmg6DcXL2Xj365M7eN29P2tMofzs+qZD/LW+d2wopfNl0g==
+vitest@^0.5.5:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.5.5.tgz#148c4a7c79cd6ecd3f0f9abc0065dd1883808417"
+  integrity sha512-oBKIXpFOGN7jDdK0MO4uWcB+UOPRyEJveB8XDx74XsFNbjGF7vHmHqwAomNE8MGtDW8hBKvSSbr58hibFiQc5Q==
   dependencies:
     "@types/chai" "^4.3.0"
     "@types/chai-subset" "^1.3.3"
     chai "^4.3.6"
     local-pkg "^0.4.1"
     tinypool "^0.1.2"
-    tinyspy "^0.2.10"
-    vite "^2.8.2"
+    tinyspy "^0.3.0"
+    vite "^2.7.10"
 
 vm-browserify@^1.0.1:
   version "1.1.2"


### PR DESCRIPTION
In [v0.5.4](https://github.com/vitest-dev/vitest/releases/tag/v0.5.4) they fixed a bug where matching by test name would only look at the `it` string instead of the full `describe + describe + it` etc name. 