### PR TITLE
Add automated task to periodically update icons

### DIFF
--- a/.github/workflows/update-icons.yaml
+++ b/.github/workflows/update-icons.yaml
@@ -2,7 +2,7 @@ name: Update icons
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 0 ? *'
+    - cron: '0 0 * * 1-5'
 
 jobs:
   update-icons:


### PR DESCRIPTION
Adds a GitHub action to automatically import any icon updates from figma. This import runs on a schedule (weekdays at 12am) or can be manually invoked. 