### PR TITLE
Add custom width value to tailwind for use with action menu

### DIFF
--- a/libs/ui/lib/action-menu/ActionMenu.tsx
+++ b/libs/ui/lib/action-menu/ActionMenu.tsx
@@ -68,7 +68,7 @@ export function ActionMenu(props: ActionMenuProps) {
 
   return (
     <Dialog
-      className="ActionMenu mt-[20vh] !w-184 bg-transparent p-0"
+      className="ActionMenu mt-[20vh] !w-[46rem] bg-transparent p-0"
       aria-label={props.ariaLabel}
       isOpen={props.isOpen}
       onDismiss={onDismiss}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -36,9 +36,6 @@ module.exports = {
       borderRadius: {
         ...borderRadiusTokens,
       },
-      width: {
-        184: '46rem',
-      },
     },
     colors: {
       transparent: 'transparent',


### PR DESCRIPTION
https://github.com/oxidecomputer/console/pull/678#discussion_r820186763

I try and use `vw` units sparingly. The `vh` for the margin top is a good idea but there's so much variation in screen width size, tying the width to that can look funky very quickly.

~~It feels strange to add a tailwind config for a value we're using in one place – but using rems here might be a better practice than defining a pixel value – scaling properly with text size changes.~~