### PR TITLE
Add codemod to make responsive icons actually responsive

### DIFF
--- a/codemods/add-responsive-viewbox.icons.js
+++ b/codemods/add-responsive-viewbox.icons.js
@@ -1,0 +1,40 @@
+/**
+ * This codemod removes hardcoded widths and heights from
+ * responsive icons and replaces them with a viewBox
+ *
+ * @param {import('jscodeshift').FileInfo} file
+ * @param {import('jscodeshift').API} api
+ */
+export default function transformer(file, api) {
+  const j = api.jscodeshift
+  const source = j(file.source)
+
+  if (
+    !file.path.endsWith('.tsx') ||
+    !file.path.toLowerCase().includes('responsive')
+  )
+    return
+
+  // Grab width value and remove width prop
+  const widthProp = source.find(j.JSXAttribute, { name: { name: 'width' } })
+  const width = widthProp.find(j.NumericLiteral).get('value').value
+  widthProp.remove()
+
+  // Grab height value and remove height prop
+  const heightProp = source.find(j.JSXAttribute, { name: { name: 'height' } })
+  const height = heightProp.find(j.NumericLiteral).get('value').value
+  heightProp.remove()
+
+  // Insert viewBox into attribute list
+  return source
+    .find(j.JSXOpeningElement, { name: { name: 'svg' } })
+    .map((s) => {
+      s.node.attributes.unshift(
+        j.jsxAttribute(
+          j.jsxIdentifier('viewBox'),
+          j.literal(`0 0 ${width} ${height}`)
+        )
+      )
+    })
+    .toSource()
+}


### PR DESCRIPTION
Instead of having a hard coded `width` and `height` attribute, all we really need is a `viewBox`. This codemod grabs the width and height values, removes the original width/height attributes, and then generates a `viewBox`. 