### PR TITLE
Update responsive icons to use viewBox instead of width/height

### DIFF
--- a/libs/ui/lib/icons/CentOSResponsiveIcon.tsx
+++ b/libs/ui/lib/icons/CentOSResponsiveIcon.tsx
@@ -11,8 +11,7 @@ function CentOSResponsiveIcon({
 }: React.SVGProps<SVGSVGElement> & SVGRProps) {
   return (
     <svg
-      width={16}
-      height={16}
+      viewBox="0 0 16 16"
       xmlns="http://www.w3.org/2000/svg"
       role="img"
       aria-labelledby={titleId}

--- a/libs/ui/lib/icons/DebianResponsiveIcon.tsx
+++ b/libs/ui/lib/icons/DebianResponsiveIcon.tsx
@@ -11,8 +11,7 @@ function DebianResponsiveIcon({
 }: React.SVGProps<SVGSVGElement> & SVGRProps) {
   return (
     <svg
-      width={16}
-      height={16}
+      viewBox="0 0 16 16"
       xmlns="http://www.w3.org/2000/svg"
       role="img"
       aria-labelledby={titleId}

--- a/libs/ui/lib/icons/FedoraResponsiveIcon.tsx
+++ b/libs/ui/lib/icons/FedoraResponsiveIcon.tsx
@@ -11,8 +11,7 @@ function FedoraResponsiveIcon({
 }: React.SVGProps<SVGSVGElement> & SVGRProps) {
   return (
     <svg
-      width={16}
-      height={16}
+      viewBox="0 0 16 16"
       xmlns="http://www.w3.org/2000/svg"
       role="img"
       aria-labelledby={titleId}

--- a/libs/ui/lib/icons/FreeBSDResponsiveIcon.tsx
+++ b/libs/ui/lib/icons/FreeBSDResponsiveIcon.tsx
@@ -11,8 +11,7 @@ function FreeBSDResponsiveIcon({
 }: React.SVGProps<SVGSVGElement> & SVGRProps) {
   return (
     <svg
-      width={16}
-      height={16}
+      viewBox="0 0 16 16"
       xmlns="http://www.w3.org/2000/svg"
       role="img"
       aria-labelledby={titleId}

--- a/libs/ui/lib/icons/UbuntuResponsiveIcon.tsx
+++ b/libs/ui/lib/icons/UbuntuResponsiveIcon.tsx
@@ -11,8 +11,7 @@ function UbuntuResponsiveIcon({
 }: React.SVGProps<SVGSVGElement> & SVGRProps) {
   return (
     <svg
-      width={16}
-      height={16}
+      viewBox="0 0 16 16"
       xmlns="http://www.w3.org/2000/svg"
       role="img"
       aria-labelledby={titleId}

--- a/libs/ui/lib/icons/WindowsResponsiveIcon.tsx
+++ b/libs/ui/lib/icons/WindowsResponsiveIcon.tsx
@@ -11,8 +11,7 @@ function WindowsResponsiveIcon({
 }: React.SVGProps<SVGSVGElement> & SVGRProps) {
   return (
     <svg
-      width={16}
-      height={16}
+      viewBox="0 0 16 16"
       xmlns="http://www.w3.org/2000/svg"
       role="img"
       aria-labelledby={titleId}


### PR DESCRIPTION
Most of our icons designed on a pixel grid so they're intentionally constrained by width and height. The exception to this is our responsive icons. Here we really just want to have a viewbox attribute to properly constrain the proportions. Outside of that, width and height tailwind classes can be used as normal to regulate their size. 

This _should_ have been generated by the `update-icons` action, but it's being a right PITA. I'll get around to making that actually work so we won't have to worry about updating these manually. 