### PR TITLE
Mini table border fix

### DIFF
--- a/libs/ui/lib/mini-table/mini-table.css
+++ b/libs/ui/lib/mini-table/mini-table.css
@@ -7,7 +7,7 @@
 }
 
 .ox-mini-table td {
-  @apply px-0 pt-2;
+  @apply relative px-0 pt-2;
 }
 
 .ox-mini-table tr {


### PR DESCRIPTION
Noticed this on safari:
<img width="1008" alt="image" src="https://user-images.githubusercontent.com/4020798/159670867-7c21b738-646a-4e29-837e-8c54ad2af78a.png">

Seems to resolve itself if you make the <td> parent `position: relative`