### PR TITLE
Fall back to browser default cmd+k on second press

### DIFF
--- a/app/hooks/use-quick-actions.tsx
+++ b/app/hooks/use-quick-actions.tsx
@@ -57,12 +57,14 @@ export function QuickActions() {
   // only memoized to avoid render churn in useKey
   const openDialog = useCallback(
     (e) => {
-      if (anyItems) {
+      if (anyItems && !isOpen) {
         e.preventDefault()
         setIsOpen(true)
+      } else {
+        setIsOpen(false)
       }
     },
-    [anyItems]
+    [isOpen, anyItems]
   )
 
   useKey('mod+k', openDialog)


### PR DESCRIPTION
If the quick actions menu is already open, cmd/ctrl+k closes it and passes the event off to the browser (i.e., does not `e.preventDefault()`). It doesn't care whether you've typed into the box or anything, which keeps things simple because the place where the shortcut is bound does not have access to the contents of the input. If we wanted to only listen for the second cmd+k if you haven't typed, we'd have to do something a lot more complicated.

Closes #702 