### PR TITLE
Add better layout sides for pagination and container actions

### DIFF
--- a/app/layouts/helpers.css
+++ b/app/layouts/helpers.css
@@ -11,7 +11,7 @@
 }
 
 .ox-content-pane {
-  @apply relative flex flex-grow flex-col pt-4 pb-20;
+  @apply relative flex flex-grow flex-col pt-4 pb-10;
 }
 
 .ox-content-pane > *,
@@ -21,9 +21,14 @@
   margin-right: var(--content-gutter);
 }
 .ox-content-pane-actions {
-  @apply sticky bottom-0 h-14 flex-shrink-0 overflow-hidden;
+  @apply sticky bottom-0 flex-shrink-0 overflow-hidden bg-default;
 }
 
-.ox-pagination-border {
-  @apply bottom-14 !mx-0 h-0 !w-full bg-default border-secondary;
+.ox-content-pane-actions:not(:empty) {
+  @apply border-t border-secondary;
+}
+
+.ox-content-pane-actions > * {
+  margin-left: var(--content-gutter);
+  margin-right: var(--content-gutter);
 }

--- a/libs/pagination/Pagination.tsx
+++ b/libs/pagination/Pagination.tsx
@@ -14,8 +14,7 @@ export function Pagination({ inline = false, ...props }: PaginationProps) {
 
   return (
     <Tunnel.In>
-      <hr className="ox-pagination-border" />
-      <UIPagination className="py-5" {...props} />
+      <UIPagination className="h-14 py-5" {...props} />
     </Tunnel.In>
   )
 }


### PR DESCRIPTION
This mostly improves how the container that houses pagination (and eventually page form actions) works from a style perspective. 

It removes the responsibility of the pane actions container for the height of whatever contents it contains and sets the background. Setting the background is for convenience and if the container doesn't collapse it just gets in the way (and can't have a background set for obvious reasons). 

Secondly it adds a top border to the content pane when it's not empty. This simplifies the visual responsibility for anything rendering inside of that container. 

Lastly it normalizes the margins on children of the content pane actions to be equal to that of the content pane itself. Again, this just helps the content not have to know about those styles. 