### PR TITLE
Fixing spacing below the label without a tooltip

### DIFF
--- a/libs/ui/lib/field-label/FieldLabel.tsx
+++ b/libs/ui/lib/field-label/FieldLabel.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import type { ElementType, PropsWithChildren } from 'react'
-import { Wrap } from '@oxide/util'
 import { Info8Icon, Tooltip } from '@oxide/ui'
 
 /**
@@ -42,7 +41,7 @@ export const FieldLabel = <T extends ElementType = 'label'>({
 }: PropsWithChildren<FieldLabelProps<T>>) => {
   const Component = as || 'label'
   return (
-    <Wrap with={<div className="mb-2 flex space-x-2" />} when={tip}>
+    <div className="mb-2 flex h-4 space-x-2">
       <Component
         id={id}
         className="flex items-center text-sans-sm"
@@ -62,6 +61,6 @@ export const FieldLabel = <T extends ElementType = 'label'>({
           <Info8Icon />
         </Tooltip>
       )}
-    </Wrap>
+    </div>
   )
 }

--- a/libs/ui/lib/tooltip/Tooltip.tsx
+++ b/libs/ui/lib/tooltip/Tooltip.tsx
@@ -88,7 +88,7 @@ export const Tooltip: FC<TooltipProps> = ({
         onMouseLeave={closeTooltip}
         onFocus={openTooltip}
         onBlur={closeTooltip}
-        className={cn('svg:pointer-events-none', {
+        className={cn('mt-[2px] h-4 svg:pointer-events-none svg:align-top', {
           'dashed-underline': definition,
         })}
       >


### PR DESCRIPTION
<img width="505" alt="CleanShot 2022-03-31 at 10 25 25@2x" src="https://user-images.githubusercontent.com/4020798/161027837-431310a5-40f7-401f-8817-4853f5fc531a.png">


Spacing without the tooltip wasn't right – a couple of issues; alignment between the icon and the rest of the text, and the height of the label itself is changed when the SVG is present.

I set a height on the tooltip icon, but that alone still shifts the height of the label from 16px to 18px. So here it's also on the `FieldLabel` itself. In terms of alignment between the icon and the text, using `align-top` to override the default which is set to middle and offsetting by a couple of px seems to do the job. Perhaps if the tooltip icon and the label were in a shared `div` then `align-middle` would work – but I imagine that might not be possible with how the tooltip works?