### PR TITLE
Fix subnet form cancel button not working

### DIFF
--- a/app/forms/subnet-create.tsx
+++ b/app/forms/subnet-create.tsx
@@ -17,7 +17,7 @@ export function CreateSubnetForm({
   title = 'Create subnet',
   initialValues = values,
   onSubmit,
-  onDismiss,
+  onSuccess,
   onError,
   ...props
 }: PrebuiltFormProps<typeof values>) {
@@ -25,9 +25,9 @@ export function CreateSubnetForm({
   const queryClient = useApiQueryClient()
 
   const createSubnet = useApiMutation('vpcSubnetsPost', {
-    onSuccess() {
+    onSuccess(data) {
       queryClient.invalidateQueries('vpcSubnetsGet', parentNames)
-      onDismiss?.()
+      onSuccess?.(data)
     },
     onError,
   })

--- a/app/hooks/use-form.tsx
+++ b/app/hooks/use-form.tsx
@@ -50,7 +50,7 @@ export const useForm = <K extends keyof FormTypes>(
   return [
     <Suspense fallback={null} key={`${id}-key`}>
       <SideModal id={`${id}-modal`} isOpen={isOpen} onDismiss={onDismiss}>
-        <DynForm onDismiss={onDismiss} onSuccess={onSuccess} {...formProps} />
+        <DynForm {...formProps} onDismiss={onDismiss} onSuccess={onSuccess} />
       </SideModal>
     </Suspense>,
     invokeForm,


### PR DESCRIPTION
Fixes #757 

Turns out this was only an issue with `subnet-create` which was specifically caused because `onDismiss` wasn't being passed down to `Form`. There was also the bug that `onSuccess` wasn't being called where it should, so I fixed that too. Lastly I noticed an issue in the hook where if you overrode `onSuccess` or `onDismiss` it'd stomp on the modal close logic, so I updated that too. 