### PR TITLE
Stop linting for non-null assertions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,6 +26,7 @@
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-empty-interface": "off",
     "@typescript-eslint/ban-ts-comment": "off",
+    "@typescript-eslint/no-non-null-assertion": "off",
     "@typescript-eslint/no-unused-vars": [
       "error",
       { "argsIgnorePattern": "^_" }

--- a/app/components/Breadcrumbs.tsx
+++ b/app/components/Breadcrumbs.tsx
@@ -10,7 +10,6 @@ export function matchesToCrumbs(matches: RouteMatch[]): Crumb[] {
   return filtered.map((m, i) => ({
     label:
       // at this point we've already filtered out all falsy crumbs
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       typeof m.route.crumb === 'function' ? m.route.crumb(m) : m.route.crumb!,
     // last one is the page we're on, so no link
     href: i < filtered.length - 1 ? m.pathname : undefined,

--- a/app/components/__tests__/Breadcrumbs.spec.tsx
+++ b/app/components/__tests__/Breadcrumbs.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
-
 import { matchRoutes } from 'react-router-dom'
 import { getRouteConfig } from '../../routes'
 import { matchesToCrumbs } from '../Breadcrumbs'

--- a/app/routes.spec.tsx
+++ b/app/routes.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
-
 import { matchRoutes } from 'react-router-dom'
 import { renderAppAt } from './test/utils'
 

--- a/app/routes.tsx
+++ b/app/routes.tsx
@@ -53,11 +53,9 @@ import { FormPage } from './components/FormPage'
  * `types/react-router.d.ts`
  */
 
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 const orgCrumb = (m: RouteMatch) => m.params.orgName!
 const projectCrumb = (m: RouteMatch) => m.params.projectName!
 const instanceCrumb = (m: RouteMatch) => m.params.instanceName!
-/* eslint-enable @typescript-eslint/no-non-null-assertion */
 
 /** React Router route config in JSX form */
 export const routes = (

--- a/libs/ui/lib/action-menu/ActionMenu.tsx
+++ b/libs/ui/lib/action-menu/ActionMenu.tsx
@@ -42,7 +42,7 @@ export function ActionMenu(props: ActionMenuProps) {
   const groupedItems = Object.entries(
     groupBy(
       items.filter((i) => i.navGroup),
-      (i) => i.navGroup! // eslint-disable-line @typescript-eslint/no-non-null-assertion
+      (i) => i.navGroup!
     )
   )
 

--- a/libs/ui/lib/pagination/Pagination.tsx
+++ b/libs/ui/lib/pagination/Pagination.tsx
@@ -77,7 +77,6 @@ export const Pagination = ({
               )}
               disabled={!hasNext}
               // nextPage will be defined if hasNext is true
-              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               onClick={onNext.bind(null, nextPage!)}
             >
               next


### PR DESCRIPTION
It's getting silly to keep adding the linter-disabler comment every time we have a good reason to use it!