### PR TITLE
useParams returns `{ readonly [k in K]: string } & Params`

### DIFF
--- a/app/forms/disk-attach.tsx
+++ b/app/forms/disk-attach.tsx
@@ -20,7 +20,7 @@ export function AttachDiskForm({
   ...props
 }: PrebuiltFormProps<typeof values, Disk>) {
   const queryClient = useApiQueryClient()
-  const pathParams = useParams('orgName', 'projectName', 'instanceName?')
+  const pathParams = useParams('orgName', 'projectName')
 
   const attachDisk = useApiMutation('instanceDisksAttach', {
     onSuccess(data) {

--- a/app/hooks/use-params.ts
+++ b/app/hooks/use-params.ts
@@ -1,32 +1,27 @@
+import type { Params } from 'react-router-dom'
 import { useParams as _useParams } from 'react-router-dom'
 import { invariant } from '@oxide/util'
 
-type OptionalKey<K> = K extends `${infer U}?` ? U : never
-type RequiredKey<K> = K extends OptionalKey<K> ? never : K
-
-type ParamsWithOptionalKeys<K extends string> = {
-  [key in RequiredKey<K>]: string
-} & {
-  [key in OptionalKey<K>]?: string
-}
-
 /**
  * Wrapper for React Router's `useParams` that throws (in dev) if any of the
- * specified params is missing.
+ * specified params is missing. The specified params are guaranteed by TS to be
+ * present on the resulting params object. Any other param is allowed to be
+ * pulled off the object, but TS will require you to check if it's undefined.
  *
- * @returns an object where the params are guaranteed (in dev) to be present
+ * @returns an object where the specified params are guaranteed (in dev) to be
+ * present
  */
-export function useParams<K extends string>(
-  ...paramNames: K[]
-): ParamsWithOptionalKeys<K> {
+// default of never is required to prevent the highly undesirable property that if
+// you don't pass any arguments, the result object thinks every property is defined
+export function useParams<K extends string = never>(...paramNames: K[]) {
   const params = _useParams()
   if (process.env.NODE_ENV !== 'production') {
     for (const k of paramNames) {
       invariant(
-        k.endsWith('?') || k in params,
+        k in params,
         `Param '${k}' not found in route. You might be rendering a component under the wrong route.`
       )
     }
   }
-  return params as ParamsWithOptionalKeys<K>
+  return params as { readonly [k in K]: string } & Params
 }


### PR DESCRIPTION
Copied the text below from [this comment](https://github.com/oxidecomputer/console/pull/760/files#r846541815). I feel less strongly about this than #777 but it does feel right. I just don't think there's much point passing param names to `useParams` if it's not going to check for them.

---

It occurred to me that for any param you pass in as optional, you're not doing any runtime checking on it, so you're essentially in the same boat as any other param _not_ passed in here, i.e., you're in the same boat as if you used the original `useParams`, where every key needs a check to make sure it's defined. So instead of passing in optional args here, you could only pass in the _required_ ones 

```ts
useParams('orgName', 'projectName')
```

and give the result object a type that looks basically like this:

```ts
{
  orgName: string;
  projectName: string;
  [k: string]?: string;
}
```

<img width="535" alt="image" src="https://user-images.githubusercontent.com/3612203/162550373-bc514b83-06a5-44c8-a1d4-2ca7935773f1.png">

And you get the same result, i.e., you can still pull `instanceName` off it provided you check that it's defined. That version is implemented here:

https://github.com/oxidecomputer/console/compare/update-instance-page...alt-use-params

I kind of like this because it's close to the original. We even use their `Params` type, and if you call it without any args (`useParams()`) the result is identical to the original.