### PR TITLE
Change `override` test helper to `overrideOnce`

### DIFF
--- a/app/pages/__tests__/ProjectCreatePage.spec.tsx
+++ b/app/pages/__tests__/ProjectCreatePage.spec.tsx
@@ -1,7 +1,7 @@
 import {
   clickByRole,
   fireEvent,
-  override,
+  overrideOnce,
   renderAppAt,
   screen,
   waitFor,
@@ -30,7 +30,7 @@ describe('ProjectCreatePage', () => {
   })
 
   it.todo('shows message for known error code in global code map', async () => {
-    override('post', projectsUrl, 403, { error_code: 'Forbidden' })
+    overrideOnce('post', projectsUrl, 403, { error_code: 'Forbidden' })
     renderAppAt(formUrl)
     await enterName('mock-project-2')
 
@@ -53,7 +53,7 @@ describe('ProjectCreatePage', () => {
   })
 
   it.todo('shows generic message for unknown server error', async () => {
-    override('post', projectsUrl, 400, { error_code: 'UnknownCode' })
+    overrideOnce('post', projectsUrl, 400, { error_code: 'UnknownCode' })
     renderAppAt(formUrl)
     await enterName('mock-project-2')
 

--- a/app/test/server.ts
+++ b/app/test/server.ts
@@ -5,7 +5,7 @@ import { handlers, json } from '@oxide/api-mocks'
 export const server = setupServer(...handlers)
 
 // Override request handlers in order to test special cases
-export function override(
+export function overrideOnce(
   method: keyof typeof rest,
   path: string,
   status: number,
@@ -13,9 +13,10 @@ export function override(
 ) {
   server.use(
     rest[method](path, (_req, res, ctx) =>
+      // https://mswjs.io/docs/api/response/once
       typeof body === 'string'
-        ? res(ctx.status(status), ctx.text(body))
-        : res(json(body, status))
+        ? res.once(ctx.status(status), ctx.text(body))
+        : res.once(json(body, status))
     )
   )
 }

--- a/app/test/utils.tsx
+++ b/app/test/utils.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from 'react-query'
 
 import { routes } from '../routes'
-export { override } from './server'
+export { overrideOnce } from './server'
 
 export const queryClientOptions = {
   defaultOptions: { queries: { retry: false } },

--- a/libs/api/__tests__/hooks.spec.ts
+++ b/libs/api/__tests__/hooks.spec.ts
@@ -1,7 +1,7 @@
 import { waitFor } from '@testing-library/react'
 import { renderHook, act } from '@testing-library/react-hooks'
 
-import { override, Wrapper } from 'app/test/utils'
+import { overrideOnce, Wrapper } from 'app/test/utils'
 import { org } from '@oxide/api-mocks'
 import type { ErrorResponse } from '../'
 import { useApiQuery, useApiMutation } from '../'
@@ -56,7 +56,7 @@ describe('useApiQuery', () => {
     // TODO: this test applies to the old generated client. now it's more like
     // data is null. error appears to get the JSON parse error for some reason
     it('sets error.data to null if error body is not json', async () => {
-      override('get', '/api/organizations', 503, 'not json')
+      overrideOnce('get', '/api/organizations', 503, 'not json')
 
       const { result } = renderGetOrgs()
 
@@ -162,7 +162,7 @@ describe('useApiMutation', () => {
     })
 
     it('sets error.data to null if error body is not json', async () => {
-      override('post', '/api/organizations', 404, 'not json')
+      overrideOnce('post', '/api/organizations', 404, 'not json')
 
       const { result } = renderCreateOrg()
       act(() => result.current.mutate(createParams))


### PR DESCRIPTION
Silly thing but I had this on my to-do list for a while and it's very easy. Override is used kind of like fetch mock, where we want to specify that we get a particular response, for example for testing particular kinds of errors. A fancier way to do this would be to use special params and encode the desired response in the real MSW handler, but for one-offs it's not really worth it.

The change here is making it so that when you use override, that override only applies once, after which the endpoint will fall back to the usual handler. I tested this manually by changing one of the tests to hit an overridden endpoint a second time.