### PR TITLE
Less noisy MSW logging in browser console

### DIFF
--- a/app/main.tsx
+++ b/app/main.tsx
@@ -40,9 +40,26 @@ async function startMockAPI() {
   const { handlers } = await import('@oxide/api-mocks')
   const { setupWorker } = await import('msw')
   const { default: workerUrl } = await import('./mockServiceWorker.js?url')
+  // https://mswjs.io/docs/api/setup-worker/start#options
   await setupWorker(...handlers).start({
-    serviceWorker: {
-      url: workerUrl,
+    quiet: true, // don't log successfully handled requests
+    serviceWorker: { url: workerUrl },
+    // custom handler only to make logging less noisy. unhandled requests still
+    // pass through to the server
+    onUnhandledRequest(req) {
+      const path = req.url.pathname
+      const ignore = [
+        path.includes('libs/ui/assets'), // assets obviously loaded from file system
+        path.startsWith('/forms/'), // lazy loaded forms
+      ].some(Boolean)
+      if (!ignore) {
+        // message format copied from MSW source
+        console.warn(`[MSW] Warning: captured an API request without a matching request handler:
+
+  • ${req.method} ${req.url.pathname} 
+
+If you want to intercept this unhandled request, create a request handler for it.`)
+      }
     },
   })
 }


### PR DESCRIPTION
The noise was making the console useless. Not good.

- Stop logging on successfully handled requests, we don't need that
- Add an ignore list of paths we expect to be unhandled, like assets and lazy-loaded `/forms/*`, and don't do the "warning! unimplemented!" thing for those

### Before

![2022-04-28-msw-logging-before](https://user-images.githubusercontent.com/3612203/165804633-cdfd2baf-eb73-4d04-9515-c0187d49dcee.gif)

### After

![2022-04-28-msw-logging-after](https://user-images.githubusercontent.com/3612203/165804657-e57d8902-f051-4cc2-81d7-d41c11a26174.gif)