### PR TITLE
MSW lookup functions take params directly

### DIFF
--- a/libs/api-mocks/msw/db.ts
+++ b/libs/api-mocks/msw/db.ts
@@ -1,4 +1,3 @@
-import type { DefaultRequestBody, PathParams, RestRequest } from 'msw'
 import type { Merge } from 'type-fest'
 import type { Json } from '../json-type'
 import { json } from './util'
@@ -27,83 +26,77 @@ export type DiskParams = Merge<ProjectParams, { instanceName?: string; diskName:
 export type VpcSubnetParams = Merge<VpcParams, { subnetName: string }>
 export type VpcRouterParams = Merge<VpcParams, { routerName: string }>
 
-// lets us make sure you're only calling a lookup function from a handler with
-// the required path params
-type Req<P extends PathParams> = RestRequest<DefaultRequestBody, P>
-
-export function lookupOrg(req: Req<OrgParams>): Result<Json<Api.Organization>> {
-  const org = db.orgs.find((o) => o.name === req.params.orgName)
+export function lookupOrg(params: OrgParams): Result<Json<Api.Organization>> {
+  const org = db.orgs.find((o) => o.name === params.orgName)
   if (!org) return Err(notFoundErr)
   return Ok(org)
 }
 
-export function lookupProject(req: Req<ProjectParams>): Result<Json<Api.Project>> {
-  const [org, err] = lookupOrg(req)
+export function lookupProject(params: ProjectParams): Result<Json<Api.Project>> {
+  const [org, err] = lookupOrg(params)
   if (err) return Err(err)
 
   const project = db.projects.find(
-    (p) => p.organization_id === org.id && p.name === req.params.projectName
+    (p) => p.organization_id === org.id && p.name === params.projectName
   )
   if (!project) return Err(notFoundErr)
 
   return Ok(project)
 }
 
-export function lookupVpc(req: Req<VpcParams>): Result<Json<Api.Vpc>> {
-  const [project, err] = lookupProject(req)
+export function lookupVpc(params: VpcParams): Result<Json<Api.Vpc>> {
+  const [project, err] = lookupProject(params)
   if (err) return Err(err)
 
-  const vpc = db.vpcs.find(
-    (p) => p.project_id === project.id && p.name === req.params.vpcName
-  )
+  const vpc = db.vpcs.find((p) => p.project_id === project.id && p.name === params.vpcName)
 
   if (!vpc) return Err(notFoundErr)
 
   return Ok(vpc)
 }
 
-export function lookupInstance(req: Req<InstanceParams>): Result<Json<Api.Instance>> {
-  const [project, err] = lookupProject(req)
+export function lookupInstance(params: InstanceParams): Result<Json<Api.Instance>> {
+  const [project, err] = lookupProject(params)
   if (err) return Err(err)
 
   const instance = db.instances.find(
-    (p) => p.project_id === project.id && p.name === req.params.instanceName
+    (p) => p.project_id === project.id && p.name === params.instanceName
   )
   if (!instance) return Err(notFoundErr)
 
   return Ok(instance)
 }
 
-export function lookupDisk(req: Req<DiskParams>): Result<Json<Api.Disk>> {
-  const [project, err] = lookupProject(req)
+export function lookupDisk(params: DiskParams): Result<Json<Api.Disk>> {
+  const [project, err] = lookupProject(params)
   if (err) return Err(err)
 
   const disk = db.disks.find(
-    (d) => d.project_id === project.id && d.name === req.params.diskName
+    (d) => d.project_id === project.id && d.name === params.diskName
   )
   if (!disk) return Err(notFoundErr)
 
   return Ok(disk)
 }
 
-export function lookupVpcSubnet(req: Req<VpcSubnetParams>): Result<Json<Api.VpcSubnet>> {
-  const [vpc, err] = lookupVpc(req)
+export function lookupVpcSubnet(params: VpcSubnetParams): Result<Json<Api.VpcSubnet>> {
+  const [vpc, err] = lookupVpc(params)
   if (err) return Err(err)
 
   const subnet = db.vpcSubnets.find(
-    (p) => p.vpc_id === vpc.id && p.name === req.params.subnetName
+    (p) => p.vpc_id === vpc.id && p.name === params.subnetName
   )
   if (!subnet) return Err(notFoundErr)
 
   return Ok(subnet)
 }
 
-export function lookupVpcRouter(req: Req<VpcRouterParams>): Result<Json<Api.VpcRouter>> {
-  const [vpc, err] = lookupVpc(req)
+export function lookupVpcRouter(params: VpcRouterParams): Result<Json<Api.VpcRouter>> {
+  const [vpc, err] = lookupVpc(params)
   if (err) return Err(err)
 
   const router = db.vpcRouters.find(
-    (r) => r.vpc_id === vpc.id && r.name === req.params.routerName
+    (r) => r.vpc_id === vpc.id && r.name === params.routerName
   )
   if (!router) return Err(notFoundErr)
 
@@ -111,17 +104,17 @@ export function lookupVpcRouter(req: Req<VpcRouterParams>): Result<Json<Api.VpcR
 }
 
 const initDb = {
-  orgs: [mock.org],
-  projects: [mock.project],
-  instances: [mock.instance],
   disks: [...mock.disks],
   images: [...mock.images],
+  instances: [mock.instance],
+  orgs: [mock.org],
+  projects: [mock.project],
   snapshots: [...mock.snapshots],
+  vpcFirewallRules: [...mock.defaultFirewallRules],
+  vpcRouterRoutes: [mock.vpcRouterRoute],
+  vpcRouters: [mock.vpcRouter],
   vpcs: [mock.vpc],
   vpcSubnets: [mock.vpcSubnet],
-  vpcRouters: [mock.vpcRouter],
-  vpcRouterRoutes: [mock.vpcRouterRoute],
-  vpcFirewallRules: [...mock.defaultFirewallRules],
 }
 
 const clone = (o: unknown) => JSON.parse(JSON.stringify(o))

--- a/libs/api-mocks/msw/handlers.ts
+++ b/libs/api-mocks/msw/handlers.ts
@@ -95,7 +95,7 @@ export const handlers = [
         return res(unavailableErr)
       }
 
-      const [org, err] = lookupOrg(req)
+      const [org, err] = lookupOrg(req.params)
       if (err) return res(err)
 
       return res(json(org))
@@ -105,7 +105,7 @@ export const handlers = [
   rest.get<never, OrgParams, Json<Api.ProjectResultsPage> | GetErr>(
     '/api/organizations/:orgName/projects',
     (req, res) => {
-      const [org, err] = lookupOrg(req)
+      const [org, err] = lookupOrg(req.params)
       if (err) return res(err)
 
       const projects = db.projects.filter((p) => p.organization_id === org.id)
@@ -116,7 +116,7 @@ export const handlers = [
   rest.post<Json<Api.ProjectCreate>, OrgParams, Json<Api.Project> | PostErr>(
     '/api/organizations/:orgName/projects',
     (req, res) => {
-      const [org, err] = lookupOrg(req)
+      const [org, err] = lookupOrg(req.params)
       if (err) return res(err)
 
       const alreadyExists = db.projects.some(
@@ -143,7 +143,7 @@ export const handlers = [
   rest.get<never, ProjectParams, Json<Api.Project> | GetErr>(
     '/api/organizations/:orgName/projects/:projectName',
     (req, res) => {
-      const [project, err] = lookupProject(req)
+      const [project, err] = lookupProject(req.params)
       if (err) return res(err)
       return res(json(project))
     }
@@ -152,7 +152,7 @@ export const handlers = [
   rest.get<never, ProjectParams, Json<Api.InstanceResultsPage> | GetErr>(
     '/api/organizations/:orgName/projects/:projectName/instances',
     (req, res) => {
-      const [project, err] = lookupProject(req)
+      const [project, err] = lookupProject(req.params)
       if (err) return res(err)
       const instances = db.instances.filter((i) => i.project_id === project.id)
       return res(json({ items: instances }))
@@ -162,7 +162,7 @@ export const handlers = [
   rest.get<never, InstanceParams, Json<Api.Instance> | GetErr>(
     '/api/organizations/:orgName/projects/:projectName/instances/:instanceName',
     (req, res) => {
-      const [instance, err] = lookupInstance(req)
+      const [instance, err] = lookupInstance(req.params)
       if (err) return res(err)
       return res(json(instance))
     }
@@ -171,7 +171,7 @@ export const handlers = [
   rest.delete<never, InstanceParams, GetErr>(
     '/api/organizations/:orgName/projects/:projectName/instances/:instanceName',
     (req, res, ctx) => {
-      const [instance, err] = lookupInstance(req)
+      const [instance, err] = lookupInstance(req.params)
       if (err) return res(err)
       db.instances = db.instances.filter((i) => i.id !== instance.id)
       return res(ctx.status(204))
@@ -181,7 +181,7 @@ export const handlers = [
   rest.post<Json<Api.InstanceCreate>, ProjectParams, Json<Api.Instance> | PostErr>(
     '/api/organizations/:orgName/projects/:projectName/instances',
     (req, res) => {
-      const [project, err] = lookupProject(req)
+      const [project, err] = lookupProject(req.params)
       if (err) return res(err)
 
       const alreadyExists = db.instances.some(
@@ -209,7 +209,7 @@ export const handlers = [
   rest.post<never, InstanceParams, Json<Api.Instance> | PostErr>(
     '/api/organizations/:orgName/projects/:projectName/instances/:instanceName/start',
     (req, res) => {
-      const [instance, err] = lookupInstance(req)
+      const [instance, err] = lookupInstance(req.params)
       if (err) return res(err)
       instance.run_state = 'running'
       return res(json(instance, 202))
@@ -219,7 +219,7 @@ export const handlers = [
   rest.post<never, InstanceParams, Json<Api.Instance> | PostErr>(
     '/api/organizations/:orgName/projects/:projectName/instances/:instanceName/stop',
     (req, res) => {
-      const [instance, err] = lookupInstance(req)
+      const [instance, err] = lookupInstance(req.params)
       if (err) return res(err)
       instance.run_state = 'stopped'
       return res(json(instance, 202))
@@ -229,7 +229,7 @@ export const handlers = [
   rest.get<never, InstanceParams, Json<Api.DiskResultsPage> | GetErr>(
     '/api/organizations/:orgName/projects/:projectName/instances/:instanceName/disks',
     (req, res) => {
-      const [instance, err] = lookupInstance(req)
+      const [instance, err] = lookupInstance(req.params)
       if (err) return res(err)
       const disks = db.disks.filter(
         (d) => 'instance' in d.state && d.state.instance === instance.id
@@ -241,7 +241,7 @@ export const handlers = [
   rest.post<never, DiskParams, Json<Api.Disk> | PostErr>(
     '/api/organizations/:orgName/projects/:projectName/instances/:instanceName/disks',
     (req, res) => {
-      const [disk, err] = lookupDisk(req)
+      const [disk, err] = lookupDisk(req.params)
       if (err) return res(err)
       return res(json(disk))
     }
@@ -250,7 +250,7 @@ export const handlers = [
   rest.get<never, ProjectParams, Json<Api.DiskResultsPage> | GetErr>(
     '/api/organizations/:orgName/projects/:projectName/disks',
     (req, res) => {
-      const [project, err] = lookupProject(req)
+      const [project, err] = lookupProject(req.params)
       if (err) return res(err)
       const disks = db.disks.filter((d) => d.project_id === project.id)
       return res(json({ items: disks }))
@@ -260,7 +260,7 @@ export const handlers = [
   rest.post<Json<Api.DiskCreate>, ProjectParams, Json<Api.Disk> | PostErr>(
     '/api/organizations/:orgName/projects/:projectName/disks',
     (req, res) => {
-      const [project, err] = lookupProject(req)
+      const [project, err] = lookupProject(req.params)
       if (err) return res(err)
       const alreadyExists = db.disks.some(
         (s) => s.project_id === project.id && s.name === req.body.name
@@ -293,7 +293,7 @@ export const handlers = [
   rest.get<never, ProjectParams, Json<Api.ImageResultsPage> | GetErr>(
     '/api/organizations/:orgName/projects/:projectName/images',
     (req, res) => {
-      const [project, err] = lookupProject(req)
+      const [project, err] = lookupProject(req.params)
       if (err) return res(err)
       const images = db.images.filter((i) => i.project_id === project.id)
       return res(json({ items: images }))
@@ -303,7 +303,7 @@ export const handlers = [
   rest.get<never, ProjectParams, Json<Api.SnapshotResultsPage> | GetErr>(
     '/api/organizations/:orgName/projects/:projectName/snapshots',
     (req, res) => {
-      const [project, err] = lookupProject(req)
+      const [project, err] = lookupProject(req.params)
       if (err) return res(err)
       const snapshots = db.snapshots.filter((i) => i.project_id === project.id)
       return res(json({ items: snapshots }))
@@ -313,7 +313,7 @@ export const handlers = [
   rest.get<never, ProjectParams, Json<Api.VpcResultsPage> | GetErr>(
     '/api/organizations/:orgName/projects/:projectName/vpcs',
     (req, res) => {
-      const [project, err] = lookupProject(req)
+      const [project, err] = lookupProject(req.params)
       if (err) return res(err)
       const vpcs = db.vpcs.filter((v) => v.project_id === project.id)
       return res(json({ items: vpcs }))
@@ -323,7 +323,7 @@ export const handlers = [
   rest.get<never, VpcParams, Json<Api.Vpc> | GetErr>(
     '/api/organizations/:orgName/projects/:projectName/vpcs/:vpcName',
     (req, res) => {
-      const [vpc, err] = lookupVpc(req)
+      const [vpc, err] = lookupVpc(req.params)
       if (err) return res(err)
       return res(json(vpc))
     }
@@ -332,7 +332,7 @@ export const handlers = [
   rest.post<Json<Api.VpcCreate>, ProjectParams, Json<Api.Vpc> | PostErr>(
     '/api/organizations/:orgName/projects/:projectName/vpcs',
     (req, res) => {
-      const [project, err] = lookupProject(req)
+      const [project, err] = lookupProject(req.params)
       if (err) return res(err)
       const alreadyExists = db.vpcs.some(
         (s) => s.project_id === project.id && s.name === req.body.name
@@ -360,7 +360,7 @@ export const handlers = [
   rest.get<never, VpcParams, Json<Api.VpcSubnetResultsPage> | GetErr>(
     '/api/organizations/:orgName/projects/:projectName/vpcs/:vpcName/subnets',
     (req, res) => {
-      const [vpc, err] = lookupVpc(req)
+      const [vpc, err] = lookupVpc(req.params)
       if (err) return res(err)
       const items = db.vpcSubnets.filter((s) => s.vpc_id === vpc.id)
       return res(json({ items }))
@@ -370,7 +370,7 @@ export const handlers = [
   rest.post<Json<Api.VpcSubnetCreate>, VpcParams, Json<Api.VpcSubnet> | PostErr>(
     '/api/organizations/:orgName/projects/:projectName/vpcs/:vpcName/subnets',
     (req, res) => {
-      const [vpc, err] = lookupVpc(req)
+      const [vpc, err] = lookupVpc(req.params)
       if (err) return res(err)
 
       const alreadyExists = db.vpcSubnets.some(
@@ -400,7 +400,7 @@ export const handlers = [
   rest.put<Json<Api.VpcSubnetUpdate>, VpcSubnetParams, Json<Api.VpcSubnet> | PostErr>(
     '/api/organizations/:orgName/projects/:projectName/vpcs/:vpcName/subnets/:subnetName',
     (req, res, ctx) => {
-      const [subnet, err] = lookupVpcSubnet(req)
+      const [subnet, err] = lookupVpcSubnet(req.params)
       if (err) return res(err)
 
       if (req.body.name) {
@@ -422,7 +422,7 @@ export const handlers = [
   rest.get<never, VpcParams, Json<Api.VpcFirewallRules> | GetErr>(
     '/api/organizations/:orgName/projects/:projectName/vpcs/:vpcName/firewall/rules',
     (req, res) => {
-      const [vpc, err] = lookupVpc(req)
+      const [vpc, err] = lookupVpc(req.params)
       if (err) return res(err)
       const rules = db.vpcFirewallRules.filter((r) => r.vpc_id === vpc.id)
       return res(json({ rules: sortBy(rules, (r) => r.name) }))
@@ -436,7 +436,7 @@ export const handlers = [
   >(
     '/api/organizations/:orgName/projects/:projectName/vpcs/:vpcName/firewall/rules',
     (req, res) => {
-      const [vpc, err] = lookupVpc(req)
+      const [vpc, err] = lookupVpc(req.params)
       if (err) return res(err)
       const rules = req.body.rules.map((rule) => ({
         vpc_id: vpc.id,
@@ -456,7 +456,7 @@ export const handlers = [
   rest.get<never, VpcParams, Json<Api.VpcRouterResultsPage> | GetErr>(
     '/api/organizations/:orgName/projects/:projectName/vpcs/:vpcName/routers',
     (req, res) => {
-      const [vpc, err] = lookupVpc(req)
+      const [vpc, err] = lookupVpc(req.params)
       if (err) return res(err)
       const items = db.vpcRouters.filter((s) => s.vpc_id === vpc.id)
       return res(json({ items }))
@@ -466,7 +466,7 @@ export const handlers = [
   rest.post<Json<Api.VpcRouterCreate>, VpcParams, Json<Api.VpcRouter> | PostErr>(
     '/api/organizations/:orgName/projects/:projectName/vpcs/:vpcName/routers',
     (req, res) => {
-      const [vpc, err] = lookupVpc(req)
+      const [vpc, err] = lookupVpc(req.params)
       if (err) return res(err)
 
       const alreadyExists = db.vpcRouters.some(
@@ -493,7 +493,7 @@ export const handlers = [
   rest.put<Json<Api.VpcRouterUpdate>, VpcRouterParams, Json<Api.VpcRouter> | PostErr>(
     '/api/organizations/:orgName/projects/:projectName/vpcs/:vpcName/routers/:routerName',
     (req, res, ctx) => {
-      const [router, err] = lookupVpcRouter(req)
+      const [router, err] = lookupVpcRouter(req.params)
       if (err) return res(err)
 
       if (req.body.name) {
@@ -509,7 +509,7 @@ export const handlers = [
   rest.get<never, VpcRouterParams, Json<Api.RouterRouteResultsPage> | GetErr>(
     '/api/organizations/:orgName/projects/:projectName/vpcs/:vpcName/routers/:routerName/routes',
     (req, res) => {
-      const [router, err] = lookupVpcRouter(req)
+      const [router, err] = lookupVpcRouter(req.params)
       if (err) return res(err)
       const items = db.vpcRouterRoutes.filter((s) => s.vpc_router_id === router.id)
       return res(json({ items }))


### PR DESCRIPTION
Need this for #841. Making it a separate PR to reduce noise in that diff. The lookup functions take the `req` and use `req.params` internally, but a case arises in #841 where we need to construct a lookup call from params manually, which means we don't have a `req`. Turns out there is no need for these functions to take the `req` anyway. Taking the params directly is both simpler and more flexible. I think originally there was a reason I wanted the `req` in there, but there isn't anymore!