### PR TITLE
VS Code config file nesting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,11 @@
   "editor.formatOnSave": true,
   "eslint.format.enable": true,
   "tailwindCSS.experimental.classRegex": ["classed.[a-z]+`([^`]*)`"],
-  "css.customData": ["./.vscode/css.json"]
+  "css.customData": ["./.vscode/css.json"],
+  "explorer.fileNesting.enabled": true,
+  "explorer.fileNesting.expand": false,
+  "explorer.fileNesting.patterns": {
+    ".gitignore": ".gitattributes, .gitmodules, .gitmessage, .mailmap, .git-blame*",
+    "package.json": ".babelrc, .editorconfig, .eslint*, .figma*, .github*, .huskyrc*, plopfile*, .prettier*, .vercel*, .vscode*, Dockerfile, .dockerignore, playwright.config.*, prettier*, tsconfig.*, vitest.config.*, yarn*, postcss.config.*, tailwind.config.*, vite.config.ts"
+  }
 }


### PR DESCRIPTION
Nest our config files under `package.json`. These default to collapsed, they're just expanded here to show the grouping. Unfortunately it doesn't seem to work on folders, otherwise `.husky` and `.github` and `.vscode` would all also belong inside the group IMO.

<img width="209" alt="image" src="https://user-images.githubusercontent.com/3612203/167455495-03e57f3c-267e-4f4f-9407-785c6e4fc54c.png">

### We could group differently

I shoved everything under `package.json`, and it's a net improvement, but it doesn't have to be that way. Some things are test related, some things are QA deploy related. I just couldn't come up with natural sub-groupings.