### PR TITLE
Use `Promise.all` in e2e `expectVisible` and `expectNotVisible`

### DIFF
--- a/app/util/e2e.ts
+++ b/app/util/e2e.ts
@@ -9,13 +9,17 @@ export async function forEach(loc: Locator, fn: (loc0: Locator) => void) {
 }
 
 export async function expectVisible(page: Page, selectors: string[]) {
-  for (const selector of selectors) {
-    await expect(page.locator(selector)).toBeVisible()
-  }
+  await Promise.all(
+    selectors.map((selector) => async () => {
+      await expect(page.locator(selector)).toBeVisible()
+    })
+  )
 }
 
 export async function expectNotVisible(page: Page, selectors: string[]) {
-  for (const selector of selectors) {
-    await expect(page.locator(selector)).not.toBeVisible()
-  }
+  await Promise.all(
+    selectors.map((selector) => async () => {
+      await expect(page.locator(selector)).not.toBeVisible()
+    })
+  )
 }


### PR DESCRIPTION
Saw a tweet that made me realize I should be doing this. Cuts the big click everything test from 7.9s to 6.9s on my machine. The timings were surprisingly consistent across multiple runs.