### PR TITLE
Ensure network selector is correctly defaulted

### DIFF
--- a/app/components/form/fields/NetworkInterfaceField.tsx
+++ b/app/components/form/fields/NetworkInterfaceField.tsx
@@ -38,9 +38,9 @@ export function NetworkInterfaceField() {
             : setValue({ type: newType })
         }}
       >
-        <Radio value="None">None</Radio>
-        <Radio value="Default">Default</Radio>
-        <Radio value="Create">Custom</Radio>
+        <Radio value="none">None</Radio>
+        <Radio value="default">Default</Radio>
+        <Radio value="create">Custom</Radio>
       </RadioField>
       {value.type === 'create' && (
         <>


### PR DESCRIPTION
This fixes an issue found in last week's demo where the networking type selection in instance create wasn't properly deafulting to... well, default. Turns out this was actually an issue b/c the values of the radio were wrong. 

![image](https://user-images.githubusercontent.com/3087225/171907018-4ad141b5-9ee8-448c-ad02-5caffcc8a80c.png)
