### PR TITLE
Unbreak the e2e tests

### DIFF
--- a/app/components/form/fields/DiskSizeField.tsx
+++ b/app/components/form/fields/DiskSizeField.tsx
@@ -1,6 +1,4 @@
 import { useFormikContext } from 'formik'
-import React from 'react'
-import invariant from 'tiny-invariant'
 
 import { GiB } from '@oxide/util'
 
@@ -21,7 +19,6 @@ export function DiskSizeField({
   ...props
 }: DiskSizeProps) {
   const { values } = useFormikContext<Record<string, number>>()
-  invariant(blockSizeField in values, `expected form values to contain ${blockSizeField}`)
   const blockSize = values[blockSizeField]
   return (
     <TextField

--- a/app/forms/__tests__/instance-create.e2e.ts
+++ b/app/forms/__tests__/instance-create.e2e.ts
@@ -12,7 +12,7 @@ test.describe('Instance Create Form', () => {
     await page.fill('input[name=bootDiskName]', 'my-boot-disk')
     await page.fill('input[name=bootDiskSize]', '20')
 
-    await page.locator('input[value=ubuntu] ~ .ox-radio-card').click()
+    await page.locator('input[value=ubuntu-1] ~ .ox-radio-card').click()
 
     await page.locator('button:has-text("Create instance")').click()
 


### PR DESCRIPTION
Following up on #923 to fix the e2e tests that introduced. This is really just unbreaking the tests, I'll still need to follow up with the `blockSize` selection in instance create. 