### PR TITLE
Script to automatically bump omicron

### DIFF
--- a/tools/bump-omicron.sh
+++ b/tools/bump-omicron.sh
@@ -24,12 +24,14 @@ fi
 # note that this will fail unless the current console commit has a release on
 # dl.oxide.computer, i.e., it is a commit on main that has been pushed to GH.
 CONSOLE_VERSION=$(git rev-parse HEAD)
+# short hash used in branch name to avoid collisions
+CONSOLE_VERSION_SHORT=$(git rev-parse --short HEAD)
 SHA2=$(curl --fail-with-body "https://dl.oxide.computer/releases/console/$CONSOLE_VERSION.sha256.txt")
 
 cd ../omicron
 git checkout main
 git pull
-git checkout -b bump-console
+git checkout -b "bump-console-$CONSOLE_VERSION_SHORT"
 
 cat <<EOF > tools/console_version
 COMMIT="$CONSOLE_VERSION"


### PR DESCRIPTION
We've consistently had a problem where we fail to keep Omicron up to date with console. I think this is mostly due to it being annoying to make the PR, so here is a script to make the PR.

- Get tarball SHA256 off dl.oxide.computer for current commit hash
  - Script fails if this fails
- Switch over to omicron
- Write commit SHA and tarball hash to `tools/console_version`
- Open filled-out PR in browser