### PR TITLE
Add log about which path failed when vite proxy fails

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -53,7 +53,7 @@ export default defineConfig(({ mode }) => ({
         target: 'http://localhost:12220',
         configure(proxy) {
           proxy.on('error', (_, req) => {
-            console.error('    to', req.url)
+            console.error('    to', '/api' + req.url)
           })
         },
         rewrite: (path) => path.replace(/^\/api/, ''),


### PR DESCRIPTION
We have warnings that spit out in the browser console when a request fails to be proxied through by MSW, but I wanted to enhance the proxy message spit out by vite to also give some indication of the route not served. I kept it minimal to reduce overall noise. 

![image](https://user-images.githubusercontent.com/3087225/174671392-0763a3cf-2ccc-4a51-bf8f-c01aefe17c57.png)

---

I figured this out by noticing the `proxy` settings are configured in our vite config. When I jumped to [vite's docs on proxy config](https://vitejs.dev/config/#server-proxy), it showed a usage of `configure`. The docs also mention it's powered by `http-proxy` which has [an example of how to listen for errors](https://github.com/http-party/node-http-proxy#listening-for-proxy-events). 
