### PR TITLE
Listbox / input helptext tweaks

### DIFF
--- a/app/components/form/fields/ListboxField.tsx
+++ b/app/components/form/fields/ListboxField.tsx
@@ -27,10 +27,12 @@ export function ListboxField({
   const [, { value }, { setValue }] = useField({ name })
   return (
     <div className="max-w-lg">
-      <FieldLabel id={`${id}-label`} tip={description} optional={!required}>
-        {label}
-      </FieldLabel>
-      {helpText && <TextFieldHint id={`${id}-help-text`}>{helpText}</TextFieldHint>}
+      <div className="mb-2">
+        <FieldLabel id={`${id}-label`} tip={description} optional={!required}>
+          {label}
+        </FieldLabel>
+        {helpText && <TextFieldHint id={`${id}-help-text`}>{helpText}</TextFieldHint>}
+      </div>
       <Listbox
         defaultValue={value}
         items={items}

--- a/app/components/form/fields/RadioField.tsx
+++ b/app/components/form/fields/RadioField.tsx
@@ -41,13 +41,15 @@ export function RadioField({
 }: RadioFieldProps) {
   return (
     <div>
-      {label && (
-        <FieldLabel id={`${id}-label`} tip={description}>
-          {label} {units && <span className="ml-1 text-secondary">({units})</span>}
-        </FieldLabel>
-      )}
-      {/* TODO: Figure out where this hint field def should live */}
-      {helpText && <TextFieldHint id={`${id}-help-text`}>{helpText}</TextFieldHint>}
+      <div className="mb-2">
+        {label && (
+          <FieldLabel id={`${id}-label`} tip={description}>
+            {label} {units && <span className="ml-1 text-secondary">({units})</span>}
+          </FieldLabel>
+        )}
+        {/* TODO: Figure out where this hint field def should live */}
+        {helpText && <TextFieldHint id={`${id}-help-text`}>{helpText}</TextFieldHint>}
+      </div>
       <RadioGroup
         name={name}
         aria-labelledby={cn(`${id}-label`, {

--- a/app/components/form/fields/TextField.tsx
+++ b/app/components/form/fields/TextField.tsx
@@ -48,9 +48,11 @@ export function TextField({
   const error = useFieldError(name)
   return (
     <div className="max-w-lg">
-      <FieldLabel id={`${id}-label`} tip={description} optional={!required}>
-        {label} {units && <span className="ml-1 text-secondary">({units})</span>}
-      </FieldLabel>
+      <div className="mb-2">
+        <FieldLabel id={`${id}-label`} tip={description} optional={!required}>
+          {label} {units && <span className="ml-1 text-secondary">({units})</span>}
+        </FieldLabel>
+      </div>
       {helpText && <TextFieldHint id={`${id}-help-text`}>{helpText}</TextFieldHint>}
       <UITextField
         id={id}

--- a/libs/ui/lib/field-label/FieldLabel.tsx
+++ b/libs/ui/lib/field-label/FieldLabel.tsx
@@ -20,7 +20,7 @@ export const FieldLabel = ({
 }: PropsWithChildren<FieldLabelProps>) => {
   const Component = as || 'label'
   return (
-    <div className="mb-2 flex h-4 items-center space-x-2">
+    <div className="flex h-4 items-center space-x-2">
       <Component id={id} className="flex items-center text-sans-sm" htmlFor={htmlFor}>
         {children}
         {optional && (

--- a/libs/ui/lib/listbox/Listbox.tsx
+++ b/libs/ui/lib/listbox/Listbox.tsx
@@ -59,7 +59,7 @@ export const Listbox: FC<ListboxProps> = ({
       </button>
       <ul
         className={cn(
-          '!children:border-b-secondary absolute left-0 right-0 z-10 mt-3 overflow-y-auto rounded border-secondary bg-raise children:border-b children:border-secondary last:children:border-b-0 focus:outline-none max-h-[17.5rem]',
+          '!children:border-b-secondary absolute left-0 right-0 z-10 mt-3 overflow-y-auto rounded border-secondary bg-raise children:border-b children:border-secondary last:children:border-b-0 focus:outline-none max-h-[17.5rem] shadow-2xl',
           select.isOpen && 'border'
         )}
         {...select.getMenuProps()}

--- a/libs/ui/lib/text-field/TextField.tsx
+++ b/libs/ui/lib/text-field/TextField.tsx
@@ -90,7 +90,7 @@ type HintProps = {
  * Pass id here and include that ID in aria-describedby on the TextField
  */
 export const TextFieldHint = ({ id, children, className }: HintProps) => (
-  <div id={id} className={cn('mb-2 text-sans-sm text-secondary', className)}>
+  <div id={id} className={cn('mt-1 text-sans-sm text-secondary', className)}>
     {children}
   </div>
 )


### PR DESCRIPTION
Regarding #992

When `helpText` is included this is less of an issue also (fixed the helpText spacing)

<img width="506" alt="CleanShot 2022-06-29 at 16 02 47@2x" src="https://user-images.githubusercontent.com/4020798/176470345-f3457a19-2f91-4fe6-8b1e-b479a8b6b638.png">
