### PR TITLE
fix blank user ID on profile refresh

### DIFF
--- a/app/pages/settings/ProfilePage.tsx
+++ b/app/pages/settings/ProfilePage.tsx
@@ -23,6 +23,7 @@ export function ProfilePage() {
         required
         disabled
         fieldClassName="!cursor-default"
+        value={user?.id}
       />
       <span className="inline-block text-secondary">
         <span>Your user information is managed by your organization. </span>


### PR DESCRIPTION
Kind of a funny little bug. `initialValues` gets the initial blank value for the user ID and doesn't update when the request comes back. It works on client-side nav because the ID is already there in the cache. Not sure if this is the best way but it does work.

![2022-06-29-profile-id-bug](https://user-images.githubusercontent.com/3612203/177817539-d865d211-8f61-4d6f-8a37-37b449378fe3.gif)
