### PR TITLE
give all instances an ephemeral IP at create time

### DIFF
--- a/app/forms/instance-create.tsx
+++ b/app/forms/instance-create.tsx
@@ -165,6 +165,7 @@ export default function CreateInstanceForm({
                 },
                 ...values.disks,
               ],
+              externalIps: [{ type: 'ephemeral' }],
             },
           })
         })

--- a/libs/api-mocks/msw/handlers.ts
+++ b/libs/api-mocks/msw/handlers.ts
@@ -385,7 +385,7 @@ export const handlers = [
       const newInstance: Json<Api.Instance> = {
         id: genId('instance'),
         project_id: project.id,
-        ...req.body,
+        ...pick(req.body, 'name', 'description', 'hostname', 'memory', 'ncpus'),
         ...getTimestamps(),
         run_state: 'running',
         time_run_state_updated: new Date().toISOString(),


### PR DESCRIPTION
#1097 without the checkbox — always include `external_ips: [{ type: "ephemeral" }]` in the instance create POST.