### PR TITLE
Simplify `handleErrors`

### DIFF
--- a/libs/api/index.ts
+++ b/libs/api/index.ts
@@ -3,7 +3,6 @@ import { QueryClient } from '@tanstack/react-query'
 
 import type * as ApiTypes from './__generated__/Api'
 import { Api } from './__generated__/Api'
-import { handleErrors } from './errors'
 import {
   getUseApiMutation,
   getUseApiQuery,
@@ -17,8 +16,8 @@ const api = new Api({
 
 export type ApiMethods = typeof api.methods
 
-export const useApiQuery = getUseApiQuery(api.methods, handleErrors)
-export const useApiMutation = getUseApiMutation(api.methods, handleErrors)
+export const useApiQuery = getUseApiQuery(api.methods)
+export const useApiMutation = getUseApiMutation(api.methods)
 
 // Needs to be defined here instead of in app so we can use it to define
 // `apiQueryClient`, which provides API-typed versions of QueryClient methods
@@ -33,10 +32,10 @@ export const queryClient = new QueryClient({
 
 // to be used in loaders, which are outside the component tree and therefore
 // don't have access to context
-export const apiQueryClient = wrapQueryClient(api.methods, queryClient, handleErrors)
+export const apiQueryClient = wrapQueryClient(api.methods, queryClient)
 
 // to be used to retrieve the typed query client in components
-export const useApiQueryClient = getUseApiQueryClient(api.methods, handleErrors)
+export const useApiQueryClient = getUseApiQueryClient(api.methods)
 
 export * from './roles'
 export * from './util'

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "typescript": "4.7.4",
     "url-loader": "^4.1.1",
     "vite": "^3.0.4",
-    "vitest": "^0.18.1",
+    "vitest": "^0.22.1",
     "webpack": "^5.73.0",
     "whatwg-fetch": "^3.6.2"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -71,6 +71,6 @@ export default defineConfig(({ mode }) => ({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['app/test/setup.ts'],
-    includeSource: ['libs/util/*.ts'],
+    includeSource: ['app/**/*.ts', 'libs/**/*.ts'],
   },
 }))

--- a/yarn.lock
+++ b/yarn.lock
@@ -3978,10 +3978,10 @@
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.0.tgz#23509ebc1fa32f1b4d50d6a66c4032d5b8eaabdc"
   integrity sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==
 
-"@types/chai@^4.3.1":
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.1.tgz#e2c6e73e0bdeb2521d00756d099218e9f5d90a04"
-  integrity sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==
+"@types/chai@^4.3.3":
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.3.tgz#3c90752792660c4b562ad73b3fbd68bf3bc7ae07"
+  integrity sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==
 
 "@types/cookie@^0.4.1":
   version "0.4.1"
@@ -14683,10 +14683,10 @@ tinypool@^0.2.4:
   resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-0.2.4.tgz#4d2598c4689d1a2ce267ddf3360a9c6b3925a20c"
   integrity sha512-Vs3rhkUH6Qq1t5bqtb816oT+HeJTXfwt2cbPH17sWHIYKTotQIFPk3tf2fgqRrVyMDVOc1EnPgzIxfIulXVzwQ==
 
-tinyspy@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-1.0.0.tgz#0cb34587287b0432b33fe36a9bd945fe22b1eb89"
-  integrity sha512-FI5B2QdODQYDRjfuLF+OrJ8bjWRMCXokQPcwKm0W3IzcbUmBNv536cQc7eXGoAuXphZwgx1DFbqImwzz08Fnhw==
+tinyspy@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-1.0.2.tgz#6da0b3918bfd56170fb3cd3a2b5ef832ee1dff0d"
+  integrity sha512-bSGlgwLBYf7PnUsQ6WOc6SJ3pGOcd+d8AA6EUnLDDM0kWEstC1JIlSZA3UNliDXhd9ABoS7hiRBDCu+XP/sf1Q==
 
 title-case@^2.1.0:
   version "2.1.1"
@@ -15409,19 +15409,19 @@ vite@^3.0.4:
   optionalDependencies:
     fsevents "~2.3.2"
 
-vitest@^0.18.1:
-  version "0.18.1"
-  resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.18.1.tgz#33c5003fc8c4b296801897ae1a3f142f57015574"
-  integrity sha512-4F/1K/Vn4AvJwe7i2YblR02PT5vMKcw9KN4unDq2KD0YcSxX0B/6D6Qu9PJaXwVuxXMFTQ5ovd4+CQaW3bwofA==
+vitest@^0.22.1:
+  version "0.22.1"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.22.1.tgz#3122e6024bf782ee9aca53034017af7adb009c32"
+  integrity sha512-+x28YTnSLth4KbXg7MCzoDAzPJlJex7YgiZbUh6YLp0/4PqVZ7q7/zyfdL0OaPtKTpNiQFPpMC8Y2MSzk8F7dw==
   dependencies:
-    "@types/chai" "^4.3.1"
+    "@types/chai" "^4.3.3"
     "@types/chai-subset" "^1.3.3"
     "@types/node" "*"
     chai "^4.3.6"
     debug "^4.3.4"
     local-pkg "^0.4.2"
     tinypool "^0.2.4"
-    tinyspy "^1.0.0"
+    tinyspy "^1.0.2"
     vite "^2.9.12 || ^3.0.0-0"
 
 vm-browserify@^1.0.1:


### PR DESCRIPTION
No functionality changes here. I had a stroke of insight last night and realized we could avoid the ugly thing where we have to pass in `handleErrors` to all the request hooks if we just make it take `method: string` instead of `method: keyof ApiMethods`.

I also changed it so instead of `handleErrors` it's now `handleResult` and takes care of returning in the success case. That way we can call it very cleanly everywhere we need it.