### PR TITLE
Fix blank screen flash on client-side redirect

### DIFF
--- a/app/components/ProjectSelector.tsx
+++ b/app/components/ProjectSelector.tsx
@@ -24,7 +24,7 @@ const BrandIcon = () => (
 export const ProjectSelector = () => {
   const { orgName, projectName } = useAllParams('orgName')
 
-  const { data } = useApiQuery('projectList', { orgName, limit: 20 })
+  const { data } = useApiQuery('projectList', { orgName, limit: 10 })
 
   // filter out current project if there is one. if there isn't one, it'll be
   // undefined and it won't match any

--- a/app/routes.tsx
+++ b/app/routes.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { DataBrowserRouter, Navigate, Route } from 'react-router-dom'
+import { DataBrowserRouter, Navigate, Route, redirect } from 'react-router-dom'
 
 import type { CrumbFunc } from './components/Breadcrumbs'
 import { RouterDataErrorBoundary } from './components/ErrorBoundary'
@@ -72,10 +72,14 @@ export const Router = () => (
     <Route index element={<Navigate to="/orgs" replace />} />
 
     {/* These are done here instead of nested so we don't flash a layout on 404s */}
-    <Route path="/orgs/:orgName" element={<Navigate to="projects" replace />} />
+    <Route
+      path="/orgs/:orgName"
+      // redirect() doesn't do relative nav so we have to construct the path
+      loader={({ request }) => redirect(`${new URL(request.url).pathname}/projects`)}
+    />
     <Route
       path="/orgs/:orgName/projects/:projectName"
-      element={<Navigate to="instances" replace />}
+      loader={({ request }) => redirect(`${new URL(request.url).pathname}/instances`)}
     />
 
     <Route path="orgs" errorElement={<RouterDataErrorBoundary />}>


### PR DESCRIPTION
Closes #1123 

[`redirect`](https://beta.reactrouter.com/en/dev/fetch/redirect) is new in RR 6.4 (it comes from Remix) and it is now the recommended way to do these kinds of redirects, as opposed to rendering `<Navigate to="my-path" />`. There are some things I don't understand about `redirect`'s behavior that I want to note; otherwise this wouldn't be worth a whole PR.

### The phenomena

- Unlike `element={<Navigate to="my-path" />}`, returning a redirect from a loader does not cause it to hang out on the route while the next loader runs. That's why it fixes #1123, which is the point of this PR.
- The navigation appears to be client-side by default, which is what we want
  - This is a little surprising, and I initially resisted using this because I assumed it would be a full pageload, but it is not. When I click the link I get a client-side navigation. The only request that first is the loader for the page we're landing on.
  - This is pretty weird though because if you _try_ to do a full-page nav to, e.g., `https://google.com`, it will briefly flash a client-side error because that doesn't match any routes you have defined, and then it will actually navigate to google.com. I think this is a bug in RR. It's hard to imagine why you would ever want that to happen.
- The navigation is a replace
  - This is _very_ surprising, and is the other reason I wasn't already using `redirect`. I did not see a way to make it do a replace instead of a push, which is what we need. It appears to do a `replace` by default.

### Why might this be

First of all, `redirect` just returns a 302 `Response` with the passed-in location in the `Location` header. ([source](https://github.com/remix-run/react-router/blob/e610a249e756f30bfdd0eadc6856d8641e02ff07/packages/router/utils.ts#L1031-L1050))

The next thing to know is how RR handles a redirect returned from a loader. In `callLoaderOrAction`, a 302 response is converted into this "result" ([source](https://github.com/remix-run/react-router/blob/e610a249e756f30bfdd0eadc6856d8641e02ff07/packages/router/router.ts#L2286-L2310)):

```ts
return {
  type: ResultType.redirect,
  status,
  location,
  revalidate: result.headers.get("X-Remix-Revalidate") !== null,
};
```

Finally, in `handleLoaders`, the comment _says_ redirects are handled as a replace ([source](https://github.com/remix-run/react-router/blob/e610a249e756f30bfdd0eadc6856d8641e02ff07/packages/router/router.ts#L1042-L1048)) but this is only true if the `replace: true` is passed to `handleLoaders`, and as far as I can tell (I went through in the debugger) it is not. Then, of course, in practice it _is_ a replace, but I can't figure out why.

```ts
// If any loaders returned a redirect Response, start a new REPLACE navigation
let redirect = findRedirect(results);
if (redirect) {
  let redirectNavigation = getLoaderRedirect(state, redirect);
  await startRedirectNavigation(redirect, redirectNavigation, replace);
  return { shortCircuited: true };
}
```

So this works for us, but I don't understand why. I will try to find out from the devs. I have a feeling this is only accidentally right, and I want it to be right on purpose.