### PR TITLE
Remove `/api/` prefix from handlers

### DIFF
--- a/libs/api-mocks/msw/handlers.ts
+++ b/libs/api-mocks/msw/handlers.ts
@@ -969,7 +969,7 @@ export const handlers = [
   getById('/by-id/images/:id', db.images),
   getById('/by-id/snapshots/:id', db.snapshots),
 ].map((h) => {
-  // Prefix if MSW is set which is not true when it's a standalone server
+  // Append prefixes if it's running as MSW and not a standalone server
   if (process.env.MSW) {
     h.info.path = '/api' + h.info.path
   }


### PR DESCRIPTION
This updates the MSW handlers to map closer to what's specified in omicron by removing the `/api/` prefix from the routes. 