### PR TITLE
Use absolute path for serial console quick action so it works from list view.

### DIFF
--- a/app/pages/project/instances/actions.tsx
+++ b/app/pages/project/instances/actions.tsx
@@ -82,7 +82,9 @@ export const useMakeInstanceActions = (
       {
         label: 'View serial console',
         onActivate() {
-          navigate('serial-console')
+          navigate(
+            `/orgs/${projectParams.orgName}/projects/${projectParams.projectName}/instances/${instanceName}/serial-console`
+          )
         },
       },
       {


### PR DESCRIPTION
This would previously 404 as it would try to navigate to `/orgs/$org/projects/$proj/instances/serial-console` if you clicked the link in the main instance list view. Using an absolute path keeps it working in both the specific instance page and the list view.