### PR TITLE
"Fix" VPC create

### DIFF
--- a/app/forms/vpc-create.tsx
+++ b/app/forms/vpc-create.tsx
@@ -51,7 +51,7 @@ export function CreateVpcSideModalForm({
         (({ name, description, dnsName, ipv6Prefix }) =>
           createVpc.mutate({
             ...parentNames,
-            body: { name, description, dnsName, ipv6Prefix },
+            body: { name, description, dnsName, ipv6Prefix: ipv6Prefix || null },
           }))
       }
       submitDisabled={createVpc.isLoading}
@@ -60,7 +60,7 @@ export function CreateVpcSideModalForm({
     >
       <NameField id="vpc-name" />
       <DescriptionField id="vpc-description" />
-      <NameField id="vpc-dns-name" name="dnsName" label="DNS name" required={false} />
+      <NameField id="vpc-dns-name" name="dnsName" label="DNS name" />
       <TextField id="vpc-ipv6-prefix" name="ipv6Prefix" label="IPV6 prefix" />
     </SideModalForm>
   )


### PR DESCRIPTION
Closes #1143 

This is the minimum viable fix — make DNS name required on the client so never make the POST without it. It makes it work but it still lacks quite a bit. We will probably want to update the API to allow DNS name to be left blank, and let it default to the `name` value. I also had to make the IPv6 prefix fall back to `null` if the field is blank because the API doesn't like empty string.