### PR TITLE
Disk picker on disk metrics page

### DIFF
--- a/app/components/form/fields/useDateTimeRangePicker.tsx
+++ b/app/components/form/fields/useDateTimeRangePicker.tsx
@@ -91,7 +91,7 @@ export function useDateTimeRangePicker(initialPreset: RangeKey) {
         }
 
         return (
-          <Form className="flex mt-8 mb-4 gap-4 h-24">
+          <Form className="flex gap-4 h-24">
             <ListboxField
               className="mr-4" // in addition to gap-4
               id="preset"


### PR DESCRIPTION
Closes #1150. Still thinking about tests for this screen. It's not that easy to assert about the contents of the graphs like it is with the contents of a table.

![2022-09-12-disk-picker](https://user-images.githubusercontent.com/3612203/189762924-e91bdf94-619c-4f5b-a6be-7f089b6c8e9a.gif)
