### PR TITLE
Add instance breadcrumb

### DIFF
--- a/app/components/TopBar.tsx
+++ b/app/components/TopBar.tsx
@@ -13,7 +13,7 @@ import { isTruthy } from '@oxide/util'
 
 import { pb } from 'app/util/path-builder'
 
-import { OrgPicker, ProjectPicker, SiloSystemPicker } from './TopBarPicker'
+import { InstancePicker, OrgPicker, ProjectPicker, SiloSystemPicker } from './TopBarPicker'
 
 /**
  * TODO: This is a temporary flag to disable the silo picker until we have
@@ -40,7 +40,7 @@ export function TopBar() {
   const loggedIn = user && !error
 
   const isSystem = useLocation().pathname.startsWith(pb.system()) // lol
-  const { projectName } = useParams()
+  const { instanceName, projectName } = useParams()
 
   const [cornerPicker, ...otherPickers] = [
     hasSiloPerms && <SiloSystemPicker isSystem={isSystem} key={0} />,
@@ -53,6 +53,7 @@ export function TopBar() {
     // in hindsight.
     !isSystem && <OrgPicker key={1} />,
     projectName && <ProjectPicker key={2} />,
+    instanceName && <InstancePicker key={3} />,
   ].filter(isTruthy)
 
   // The height of this component is governed by the `PageContainer`

--- a/app/components/TopBarPicker.tsx
+++ b/app/components/TopBarPicker.tsx
@@ -20,71 +20,93 @@ type TopBarPickerProps = {
   display?: string
   /** The actively selected option. Used as display if display isn't present. */
   current: string | null | undefined
-  items: TopBarPickerItem[]
+  items?: TopBarPickerItem[]
   noItemsText?: string
   icon?: React.ReactElement
 }
 
-const TopBarPicker = (props: TopBarPickerProps) => (
-  <Menu>
-    <MenuButton
-      aria-label={props['aria-label']}
-      className="group flex w-full items-center justify-between"
-    >
-      <div className="flex items-center">
-        {props.icon ? <div className="mr-2 flex items-center">{props.icon}</div> : null}
-        {props.current ? (
-          <div className="text-left">
-            <div className="text-mono-sm text-secondary">{props.category}</div>
-            <div className="overflow-hidden text-ellipsis whitespace-nowrap text-sans-md">
-              {props.display ?? props.current}
-            </div>
-          </div>
-        ) : (
-          <div className="text-left">
-            <div className="text-mono-sm text-secondary">
-              Select
-              <br />
-              {props.category}
-            </div>
-          </div>
-        )}
-      </div>
-      {/* aria-hidden is a tip from the Reach docs */}
-      <div className="ml-4 flex h-[1.625rem] w-[1.125rem] flex-shrink-0 items-center justify-center rounded border border-secondary group-hover:bg-hover">
-        <SelectArrows6Icon className="text-secondary" aria-hidden />
-      </div>
-    </MenuButton>
-    {/* TODO: item size and focus highlight */}
-    {/* TODO: popover position should be further right */}
-    <MenuList className="ox-menu-list">
-      {props.items.length > 0 ? (
-        props.items.map(({ label, to }) => {
-          const isSelected = props.current === label
-          return (
-            <MenuLink
-              key={label}
-              as={Link}
-              to={to}
-              className={cn('ox-menu-item', { 'is-selected': isSelected })}
+const TopBarPicker = (props: TopBarPickerProps) => {
+  if (props.items) {
+    return (
+      <Menu>
+        <TopBarPickerButton ariaLabel={props['aria-label']}>
+          <TopBarPickerInner {...props} />
+        </TopBarPickerButton>
+        {/* TODO: item size and focus highlight */}
+        {/* TODO: popover position should be further right */}
+        <MenuList className="ox-menu-list">
+          {props.items.length > 0 ? (
+            props.items.map(({ label, to }) => {
+              const isSelected = props.current === label
+              return (
+                <MenuLink
+                  key={label}
+                  as={Link}
+                  to={to}
+                  className={cn('ox-menu-item', { 'is-selected': isSelected })}
+                >
+                  <span className="flex w-full items-center justify-between">
+                    {label} {isSelected && <Success12Icon className="-mr-3 block" />}
+                  </span>
+                </MenuLink>
+              )
+            })
+          ) : (
+            <MenuItem
+              className="!pr-3 !text-center !text-secondary hover:cursor-default"
+              onSelect={() => {}}
+              disabled
             >
-              <span className="flex items-center justify-between">
-                {label} {isSelected && <Success12Icon />}
-              </span>
-            </MenuLink>
-          )
-        })
-      ) : (
-        <MenuItem
-          className="!pr-3 !text-center !text-secondary hover:cursor-default"
-          onSelect={() => {}}
-          disabled
-        >
-          {props.noItemsText || 'No items found'}
-        </MenuItem>
-      )}
-    </MenuList>
-  </Menu>
+              {props.noItemsText || 'No items found'}
+            </MenuItem>
+          )}
+        </MenuList>
+      </Menu>
+    )
+  } else {
+    return <TopBarPickerInner {...props} />
+  }
+}
+
+const TopBarPickerInner = (props: TopBarPickerProps) => (
+  <div className="flex items-center">
+    {props.icon ? <div className="mr-2 flex items-center">{props.icon}</div> : null}
+    {props.current ? (
+      <div className="text-left">
+        <div className="text-mono-sm text-secondary">{props.category}</div>
+        <div className="overflow-hidden text-ellipsis whitespace-nowrap text-sans-md">
+          {props.display ?? props.current}
+        </div>
+      </div>
+    ) : (
+      <div className="text-left">
+        <div className="text-mono-sm text-secondary">
+          Select
+          <br />
+          {props.category}
+        </div>
+      </div>
+    )}
+  </div>
+)
+
+const TopBarPickerButton = ({
+  children,
+  ariaLabel,
+}: {
+  children: React.ReactNode
+  ariaLabel: string
+}) => (
+  <MenuButton
+    aria-label={ariaLabel}
+    className="group flex w-full items-center justify-between"
+  >
+    {children}
+    {/* aria-hidden is a tip from the Reach docs */}
+    <div className="ml-4 flex h-[1.625rem] w-[1.125rem] flex-shrink-0 items-center justify-center rounded border border-secondary group-hover:bg-hover">
+      <SelectArrows6Icon className="text-secondary" aria-hidden />
+    </div>
+  </MenuButton>
 )
 
 /**
@@ -165,5 +187,24 @@ export function ProjectPicker() {
       items={items}
       noItemsText="No projects found"
     />
+  )
+}
+
+export function InstancePicker() {
+  const { orgName, projectName, instanceName } = useRequiredParams(
+    'orgName',
+    'projectName',
+    'instanceName'
+  )
+  const instanceUrl = `/orgs/${orgName}/projects/${projectName}/instances`
+
+  return (
+    <Link to={instanceUrl} className="flex items-center justify-between">
+      <TopBarPicker
+        aria-label="Switch project"
+        category="Instance"
+        current={instanceName}
+      />
+    </Link>
   )
 }


### PR DESCRIPTION
A rough-out of adding the instances breadcrumb to the top bar. In this case we don't have a dropdown so I'm using a link instead. A little awkwardness comes when conditionally wrapping in the `<MenuButton>`.