### PR TITLE
Don't give error on entering IP

### DIFF
--- a/app/forms/firewall-rules-create.tsx
+++ b/app/forms/firewall-rules-create.tsx
@@ -136,7 +136,7 @@ export const CommonFields = ({ error }: { error: ErrorResult | null }) => {
       />
       {/* TODO: This is set as optional which is kind of wrong. This section represents an inlined
       subform which means it likely should be a custom field */}
-      <NameField id="targetValue" name="targetValue" label="Target name" required={false} />
+      <TextField id="targetValue" name="targetValue" label="Target name" required={false} />
 
       <div className="flex justify-end">
         {/* TODO does this clear out the form or the existing targets? */}


### PR DESCRIPTION
I meant to push this commit up with #1196. Right now the `targetValue` is a `Name` field which, for hopefully obvious reasons, doesn't work for an IP. That's the erroneous error issue @plotnick mentioned in #1191. 