### PR TITLE
Open renovate PRs for @oxide package updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -24,5 +24,11 @@
       packageNames: ['typescript'],
       enabled: true,
     },
+    // Open PRs for any oxide packages
+    {
+      managers: ['npm'],
+      packagePatterns: ['@oxide/*'],
+      enabled: true,
+    },
   ],
 }


### PR DESCRIPTION
If an `@oxide/*` package like `@oxide/design-system` has a newer published version, automatically create a renovate PR for it. 