### PR TITLE
Disable system metrics so we can build off omicron main again

### DIFF
--- a/OMICRON_VERSION
+++ b/OMICRON_VERSION
@@ -1,1 +1,1 @@
-698ccddd1af6bbae07e854fe290984a08d369e54
+bce0f5ddf7f9f3be498fa9afb1fee8d3336c1f30

--- a/app/components/SystemMetric.tsx
+++ b/app/components/SystemMetric.tsx
@@ -1,5 +1,6 @@
-import type { SystemMetricName } from '@oxide/api'
-import { useApiQuery } from '@oxide/api'
+// import type { SystemMetricName } from '@oxide/api'
+// import { useApiQuery } from '@oxide/api'
+import type { MeasurementResultsPage } from '@oxide/api'
 import { Spinner } from '@oxide/ui'
 
 import { TimeSeriesAreaChart } from './TimeSeriesChart'
@@ -8,7 +9,8 @@ type SystemMetricProps = {
   title: string
   startTime: Date
   endTime: Date
-  metricName: SystemMetricName
+  metricName: string
+  // metricName: SystemMetricName
   /** Resource to filter data by. Can be fleet, silo, org, project. */
   filterId: string
   valueTransform?: (n: number) => number
@@ -16,24 +18,24 @@ type SystemMetricProps = {
 
 export function SystemMetric({
   title,
-  filterId,
   startTime,
   endTime,
-  metricName,
   valueTransform = (x) => x,
 }: SystemMetricProps) {
   // TODO: we're only pulling the first page. Should we bump the cap to 10k?
   // Fetch multiple pages if 10k is not enough? That's a bit much.
-  const { data: metrics, isLoading } = useApiQuery(
-    'systemMetric',
-    { id: filterId, metricName, startTime, endTime },
-    {
-      // TODO: this is actually kind of useless unless the time interval slides forward as time passes
-      refetchInterval: 5000,
-      // avoid graphs flashing blank while loading when you change the time
-      keepPreviousData: true,
-    }
-  )
+  // const { data: metrics, isLoading } = useApiQuery(
+  //   'systemMetric',
+  //   { id: filterId, metricName, startTime, endTime },
+  //   {
+  //     // TODO: this is actually kind of useless unless the time interval slides forward as time passes
+  //     refetchInterval: 5000,
+  //     // avoid graphs flashing blank while loading when you change the time
+  //     keepPreviousData: true,
+  //   }
+  // )
+  const metrics: MeasurementResultsPage = { items: [] }
+  const isLoading = false
 
   const data = (metrics?.items || []).map(({ datum, timestamp }) => ({
     timestamp: timestamp.getTime(),

--- a/app/routes.tsx
+++ b/app/routes.tsx
@@ -18,7 +18,6 @@ import NotFound from './pages/NotFound'
 import { OrgAccessPage } from './pages/OrgAccessPage'
 import OrgsPage from './pages/OrgsPage'
 import ProjectsPage from './pages/ProjectsPage'
-import { SiloUtilizationPage } from './pages/SiloUtilizationPage'
 import {
   DisksPage,
   ImagesPage,
@@ -35,7 +34,6 @@ import { AppearancePage } from './pages/settings/AppearancePage'
 import { HotkeysPage } from './pages/settings/HotkeysPage'
 import { ProfilePage } from './pages/settings/ProfilePage'
 import { SSHKeysPage } from './pages/settings/SSHKeysPage'
-import { CapacityUtilizationPage } from './pages/system/CapacityUtilizationPage'
 import SilosPage from './pages/system/SilosPage'
 import { pb } from './util/path-builder'
 
@@ -83,11 +81,7 @@ export const routes = createRoutesFromElements(
           loader={SilosPage.loader}
         />
         <Route path="issues" element={null} />
-        <Route
-          path="utilization"
-          element={<CapacityUtilizationPage />}
-          loader={CapacityUtilizationPage.loader}
-        />
+        <Route path="utilization" element={null} />
         <Route path="inventory" element={null} />
         <Route path="health" element={null} />
         <Route path="update" element={null} />
@@ -105,11 +99,7 @@ export const routes = createRoutesFromElements(
       />
 
       <Route element={<SiloLayout />}>
-        <Route
-          path="utilization"
-          element={<SiloUtilizationPage />}
-          loader={SiloUtilizationPage.loader}
-        />
+        <Route path="utilization" element={null} />
         <Route
           path="orgs"
           element={<OrgsPage />}

--- a/libs/api/__generated__/Api.ts
+++ b/libs/api/__generated__/Api.ts
@@ -1739,11 +1739,6 @@ export type DiskMetricName =
   | 'write'
   | 'write_bytes'
 
-export type SystemMetricName =
-  | 'virtual_disk_space_provisioned'
-  | 'cpus_provisioned'
-  | 'ram_provisioned'
-
 export interface DiskViewByIdParams {
   id: string
 }
@@ -2380,15 +2375,6 @@ export interface IpPoolServiceRangeAddParams {
 
 export interface IpPoolServiceRangeRemoveParams {
   rackId: string
-}
-
-export interface SystemMetricParams {
-  metricName: SystemMetricName
-  endTime?: Date
-  id?: string
-  limit?: number
-  pageToken?: string | null
-  startTime?: Date
 }
 
 export interface SystemPolicyViewParams {}
@@ -4071,20 +4057,6 @@ export class Api extends HttpClient {
         path: `/system/ip-pools-service/${rackId}/ranges/remove`,
         method: 'POST',
         body,
-        ...params,
-      }),
-
-    /**
-     * Access metrics data
-     */
-    systemMetric: (
-      { metricName, ...query }: SystemMetricParams,
-      params: RequestParams = {}
-    ) =>
-      this.request<MeasurementResultsPage>({
-        path: `/system/metrics/${metricName}`,
-        method: 'GET',
-        query,
         ...params,
       }),
 

--- a/libs/api/__generated__/OMICRON_VERSION
+++ b/libs/api/__generated__/OMICRON_VERSION
@@ -1,2 +1,2 @@
 # generated file. do not update manually. see docs/update-pinned-api.md
-698ccddd1af6bbae07e854fe290984a08d369e54
+bce0f5ddf7f9f3be498fa9afb1fee8d3336c1f30

--- a/libs/api/__generated__/validate.ts
+++ b/libs/api/__generated__/validate.ts
@@ -1460,12 +1460,6 @@ export const DiskMetricName = z.enum([
   'write_bytes',
 ])
 
-export const SystemMetricName = z.enum([
-  'virtual_disk_space_provisioned',
-  'cpus_provisioned',
-  'ram_provisioned',
-])
-
 export const DiskViewByIdParams = z.object({
   id: z.string().uuid(),
 })
@@ -2236,16 +2230,6 @@ export const IpPoolServiceRangeRemoveParams = z.object({
   rackId: z.string().uuid(),
 })
 export type IpPoolServiceRangeRemoveParams = z.infer<typeof IpPoolServiceRangeRemoveParams>
-
-export const SystemMetricParams = z.object({
-  metricName: SystemMetricName,
-  endTime: DateType.optional(),
-  id: z.string().uuid().optional(),
-  limit: z.number().min(1).max(4294967295).nullable().optional(),
-  pageToken: z.string().nullable().optional(),
-  startTime: DateType.optional(),
-})
-export type SystemMetricParams = z.infer<typeof SystemMetricParams>
 
 export const SystemPolicyViewParams = z.object({})
 export type SystemPolicyViewParams = z.infer<typeof SystemPolicyViewParams>


### PR DESCRIPTION
We built off https://github.com/oxidecomputer/omicron/pull/1782 for the demo, but in general we want to make sure we're pointing at Omicron main. I did as little as possible to make everything still typecheck, basically just commenting out the API call to an endpoint that no longer exists in the client and making the system and silo metrics page empty again.

I thought about putting a message in there saying they're coming back soon, but why bother.