### PR TITLE
Reduce timeouts for CI steps

### DIFF
--- a/.github/workflows/lintBuildTest.yml
+++ b/.github/workflows/lintBuildTest.yml
@@ -24,7 +24,7 @@ jobs:
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: yarn install
   ci:
-    timeout-minutes: 60
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     needs: install
     steps:
@@ -50,7 +50,7 @@ jobs:
         run: yarn build-for-nexus
   playwright:
     name: Playwright (${{ matrix.type }}-${{ matrix.browser }})
-    timeout-minutes: 60
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     needs: install
     strategy:


### PR DESCRIPTION
There's some weird CI stalls on #1226 which are causing the smoke tests to extend to the full hour timeout. That shouldn't happen. Looking at the current configuration, I think the timeouts are way too long. I've reduced the CI timeout to 5 minutes and the e2e timeout to 10 minutes. If either takes longer than that we should really work on optimizing them or breaking them down. 