### PR TITLE
Cleanup user references

### DIFF
--- a/app/pages/__tests__/org-access.e2e.ts
+++ b/app/pages/__tests__/org-access.e2e.ts
@@ -1,6 +1,6 @@
 import { test } from '@playwright/test'
 
-import { users } from '@oxide/api-mocks'
+import { user1, user2, user3 } from '@oxide/api-mocks'
 
 import { expectNotVisible, expectRowVisible, expectVisible } from 'app/test/e2e'
 
@@ -13,18 +13,18 @@ test('Click through org access page', async ({ page }) => {
   await page.click('role=link[name*="Access & IAM"]')
   await expectVisible(page, ['role=heading[name*="Access & IAM"]'])
   await expectRowVisible(table, {
-    ID: users[0].id,
+    ID: user1.id,
     Name: 'Hannah Arendt',
     'Silo role': 'admin',
     'Org role': '',
   })
   await expectRowVisible(table, {
-    ID: users[1].id,
+    ID: user2.id,
     Name: 'Hans Jonas',
     'Silo role': '',
     'Org role': 'viewer',
   })
-  await expectNotVisible(page, [`role=cell[name="${users[2].id}"]`])
+  await expectNotVisible(page, [`role=cell[name="${user3.id}"]`])
 
   // Add user 2 as collab
   await page.click('role=button[name="Add user to organization"]')
@@ -53,7 +53,7 @@ test('Click through org access page', async ({ page }) => {
 
   // User 3 shows up in the table
   await expectRowVisible(table, {
-    ID: users[2].id,
+    ID: user3.id,
     Name: 'Jacob Klein',
     'Silo role': '',
     'Org role': 'collaborator',
@@ -61,7 +61,7 @@ test('Click through org access page', async ({ page }) => {
 
   // now change user 3's role from collab to viewer
   await page
-    .locator('role=row', { hasText: users[2].id })
+    .locator('role=row', { hasText: user3.id })
     .locator('role=button[name="Row actions"]')
     .click()
   await page.click('role=menuitem[name="Change role"]')
@@ -73,16 +73,16 @@ test('Click through org access page', async ({ page }) => {
   await page.click('role=option[name="Viewer"]')
   await page.click('role=button[name="Update role"]')
 
-  await expectRowVisible(table, { ID: users[2].id, 'Org role': 'viewer' })
+  await expectRowVisible(table, { ID: user3.id, 'Org role': 'viewer' })
 
   // now delete user 2
   await page
-    .locator('role=row', { hasText: users[1].id })
+    .locator('role=row', { hasText: user2.id })
     .locator('role=button[name="Row actions"]')
     .click()
-  await expectVisible(page, [`role=cell[name=${users[1].id}]`])
+  await expectVisible(page, [`role=cell[name=${user2.id}]`])
   await page.click('role=menuitem[name="Delete"]')
-  await expectNotVisible(page, [`role=cell[name=${users[1].id}]`])
+  await expectNotVisible(page, [`role=cell[name=${user2.id}]`])
 
   // now add an org role to user 1, who currently only has silo role
   await page.click('role=button[name="Add user to organization"]')
@@ -92,7 +92,7 @@ test('Click through org access page', async ({ page }) => {
   await page.click('role=option[name="Viewer"]')
   await page.click('role=button[name="Add user"]')
   await expectRowVisible(table, {
-    ID: users[0].id,
+    ID: user1.id,
     Name: 'Hannah Arendt',
     'Silo role': 'admin',
     'Org role': 'viewer',

--- a/app/pages/__tests__/project-access.e2e.ts
+++ b/app/pages/__tests__/project-access.e2e.ts
@@ -1,6 +1,6 @@
 import { test } from '@playwright/test'
 
-import { users } from '@oxide/api-mocks'
+import { user1, user2, user3, user4 } from '@oxide/api-mocks'
 
 import { expectNotVisible, expectRowVisible, expectVisible } from 'app/test/e2e'
 
@@ -12,27 +12,27 @@ test('Click through project access page', async ({ page }) => {
   await expectVisible(page, ['role=heading[name*="Access & IAM"]'])
   const table = page.locator('table')
   await expectRowVisible(table, {
-    ID: users[0].id,
+    ID: user1.id,
     Name: 'Hannah Arendt',
     'Silo role': 'admin',
     'Org role': '',
     'Project role': '',
   })
   await expectRowVisible(table, {
-    ID: users[1].id,
+    ID: user2.id,
     Name: 'Hans Jonas',
     'Silo role': '',
     'Org role': 'viewer',
     'Project role': '',
   })
   await expectRowVisible(table, {
-    ID: users[2].id,
+    ID: user3.id,
     Name: 'Jacob Klein',
     'Silo role': '',
     'Org role': '',
     'Project role': 'collaborator',
   })
-  await expectNotVisible(page, [`role=cell[name="${users[3].id}"]`])
+  await expectNotVisible(page, [`role=cell[name="${user4.id}"]`])
 
   // Add user 4 as collab
   await page.click('role=button[name="Add user to project"]')
@@ -61,14 +61,14 @@ test('Click through project access page', async ({ page }) => {
 
   // User 4 shows up in the table
   await expectRowVisible(table, {
-    ID: users[3].id,
+    ID: user4.id,
     Name: 'Simone de Beauvoir',
     'Project role': 'collaborator',
   })
 
   // now change user 4 role from collab to viewer
   await page
-    .locator('role=row', { hasText: users[3].id })
+    .locator('role=row', { hasText: user4.id })
     .locator('role=button[name="Row actions"]')
     .click()
   await page.click('role=menuitem[name="Change role"]')
@@ -80,17 +80,17 @@ test('Click through project access page', async ({ page }) => {
   await page.click('role=option[name="Viewer"]')
   await page.click('role=button[name="Update role"]')
 
-  await expectRowVisible(table, { ID: users[3].id, 'Project role': 'viewer' })
+  await expectRowVisible(table, { ID: user4.id, 'Project role': 'viewer' })
 
   // now delete user 3. has to be 3 or 4 because they're the only ones that come
   // from the project policy
   await page
-    .locator('role=row', { hasText: users[2].id })
+    .locator('role=row', { hasText: user3.id })
     .locator('role=button[name="Row actions"]')
     .click()
-  await expectVisible(page, [`role=cell[name=${users[2].id}]`])
+  await expectVisible(page, [`role=cell[name=${user3.id}]`])
   await page.click('role=menuitem[name="Delete"]')
-  await expectNotVisible(page, [`role=cell[name=${users[2].id}]`])
+  await expectNotVisible(page, [`role=cell[name=${user3.id}]`])
 
   // now add a project role to user 1, who currently only has silo role
   await page.click('role=button[name="Add user to project"]')
@@ -100,7 +100,7 @@ test('Click through project access page', async ({ page }) => {
   await page.click('role=option[name="Viewer"]')
   await page.click('role=button[name="Add user"]')
   await expectRowVisible(table, {
-    ID: users[0].id,
+    ID: user1.id,
     Name: 'Hannah Arendt',
     'Silo role': 'admin',
     'Org role': '',


### PR DESCRIPTION
The mapping of `user-1` to `users[0]` etc was a bit confusing. I should've just done this to begin with. 