### PR TITLE
Ensure Delete menu actions are red

### DIFF
--- a/app/pages/project/instances/actions.tsx
+++ b/app/pages/project/instances/actions.tsx
@@ -89,7 +89,7 @@ export const useMakeInstanceActions = (
           })
         },
         disabled: !instanceCan.delete(instance),
-        className: 'destructive',
+        className: instanceCan.delete(instance) ? 'destructive' : '',
       },
     ]
     // TODO: fix this lol

--- a/libs/table/columns/action-col.tsx
+++ b/libs/table/columns/action-col.tsx
@@ -1,5 +1,6 @@
 import { Menu, MenuButton, MenuItem, MenuList } from '@reach/menu-button'
 import type { ColumnDef } from '@tanstack/react-table'
+import cn from 'classnames'
 
 import { More12Icon } from '@oxide/ui'
 import { kebabCase } from '@oxide/util'
@@ -50,7 +51,12 @@ export const getActionsCol = <TData extends { id?: string }>(
               {actions.map((action) => {
                 return (
                   <MenuItem
-                    className={action.className}
+                    className={cn(
+                      action.className,
+                      action.label.toLowerCase() === 'delete' &&
+                        !action.disabled &&
+                        'destructive'
+                    )}
                     key={kebabCase(`action-${action.label}`)}
                     onSelect={action.onActivate}
                     disabled={action.disabled}


### PR DESCRIPTION
We had inconsistent implementations of `Delete` menu items being red. I updated the baseline to color all `delete` menu actions red _unless_ they're disabled. 

<img width="288" alt="image" src="https://user-images.githubusercontent.com/3087225/198087409-59406976-e924-4f28-b7d3-4514fc7fe07a.png">

<img width="354" alt="image" src="https://user-images.githubusercontent.com/3087225/198087554-78704676-90f2-4984-957a-703cf316035b.png">
