### PR TITLE
Add support for elevation utilities

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,7 @@ const {
   textUtilities,
   colorUtilities,
   borderRadiusTokens,
+  elevationUtilities,
 } = require('@oxide/design-system/styles/dist/tailwind-tokens')
 
 /** @type {import('tailwindcss/tailwind-config').TailwindConfig} */
@@ -68,6 +69,7 @@ module.exports = {
           appearance: 'textfield',
         },
       })
+      addUtilities(elevationUtilities)
     }),
   ],
 }


### PR DESCRIPTION
Allows us to use `elevation-0`, `elevation-1`, `elevation-2`, and `elevation-3` as tailwind classes to style elements that are floating over the surface. `elevation-0` _is_ the surface, so that's provided more as an override for the others. 

Read more about the elevation design [here](https://www.figma.com/file/iMVpYGoNGpwMEL9gd0oeYF/Core?node-id=720%3A3507).