### PR TITLE
Only show loading bar if loading takes more than 20ms

### DIFF
--- a/app/layouts/RootLayout.tsx
+++ b/app/layouts/RootLayout.tsx
@@ -36,6 +36,8 @@ export default function RootLayout() {
   )
 }
 
+const LOADING_BAR_DELAY_MS = 20
+
 /**
  * Loading bar for top-level navigations. When a nav first starts, the bar zooms
  * from 0 to A quickly and then more slowly grows from A to B. The idea is that
@@ -43,6 +45,11 @@ export default function RootLayout() {
  * and B. The animation from 0 to A to B is represented by the `loading` label.
  * Then once we're done fetching, we switch to the `done` animation from B to
  * 100.
+ *
+ * **Important:** we only do any of this if the navigation takes longer than
+ * `LOADING_BAR_DELAY_MS`. This prevents us from showing the loading bar on navs
+ * that are instantaneous, like opening a create form. Sometimes normal page
+ * navs are also instantaneous due to caching.
  *
  * ```
  *   ├──────────┼──────────┼──────────┤
@@ -55,27 +62,57 @@ export default function RootLayout() {
 function LoadingBar() {
   const navigation = useNavigation()
 
-  // done with a ref because there's no need to bring React state into this
-  const ref = useRef<HTMLDivElement>(null)
+  // use a ref because there's no need to bring React state into this
+  const barRef = useRef<HTMLDivElement>(null)
+
+  // only used for checking the loading state from inside the timeout callback
+  const loadingRef = useRef(false)
+  loadingRef.current = navigation.state === 'loading'
 
   useEffect(() => {
     const loading = navigation.state === 'loading'
-    const el = ref.current
-    if (el) {
+    if (barRef.current) {
       if (loading) {
-        // Remove class and force reflow. Without this, the animation does not
-        // restart from the beginning if we nav again while already loading.
-        // https://gist.github.com/paulirish/5d52fb081b3570c81e3a
-        el.classList.remove('loading', 'done')
-        el.scrollTop
+        // instead of adding the `loading` class right when loading starts, set
+        // a LOADING_BAR_DELAY_MS timeout that starts the animation, but ONLY if
+        // we are still loading when the callback runs. If the loaders in a
+        // particular nav finish immediately, the value of `loadingRef.current`
+        // will be back to `false` by the time the callback runs, skipping the
+        // animation sequence entirely.
+        const timeout = setTimeout(() => {
+          if (loadingRef.current) {
+            // Remove class and force reflow. Without this, the animation does
+            // not restart from the beginning if we nav again while already
+            // loading. https://gist.github.com/paulirish/5d52fb081b3570c81e3a
+            //
+            // It's important that this happen inside the timeout and inside the
+            // condition for the case where we're doing an instant nav while a
+            // nav animation is already running. If we did this outside the
+            // timeout callback or even inside the callback but outside the
+            // condition, we'd immediately kill an in-progress loading animation
+            // that was about to finish on its own anyway.
+            barRef.current?.classList.remove('loading', 'done')
+            barRef.current?.scrollTop
 
-        el.classList.add('loading')
-      } else if (el.classList.contains('loading')) {
+            // Kick off the animation
+            barRef.current?.classList.add('loading')
+          }
+        }, LOADING_BAR_DELAY_MS)
+
+        // Clean up the timeout if we get another render in the meantime. This
+        // doesn't seem to affect behavior but it's the Correct thing to do.
+        return () => clearTimeout(timeout)
+      } else if (barRef.current.classList.contains('loading')) {
         // Needs the if condition because if loading is false and we *don't*
         // have the `loading` animation running, we're on initial pageload and
-        // we don't want to run the done animation.
+        // we don't want to run the done animation. This is also necessary for
+        // the case where we want to skip the animation entirely because the
+        // loaders finished very quickly: when we get here, the callback that
+        // sets the loading class will not have run yet, so we will not apply
+        // the done class, which is correct because we don't want to run the
+        // `done` animation if the `loading` animation hasn't happened.
 
-        el.classList.replace('loading', 'done')
+        barRef.current.classList.replace('loading', 'done')
 
         // We don't need to remove `done` when it's over done because the final
         // state has opacity 0, and whenever a new animation starts, we remove
@@ -91,7 +128,7 @@ function LoadingBar() {
 
   return (
     <div className="fixed top-0 left-0 right-0 z-50">
-      <div ref={ref} className="global-loading-bar h-px bg-accent" />
+      <div ref={barRef} className="global-loading-bar h-px bg-accent" />
     </div>
   )
 }


### PR DESCRIPTION
Surprisingly easy: instead of adding the `loading` class right when loading starts, set a 20ms timeout that starts the animation, but ONLY if we are still loading when the callback runs. So if loaders run instantly, the value of `loadingRef.current` will be back to `false` by the time the callback runs, canceling the animation.

https://user-images.githubusercontent.com/3612203/199830527-c84c5ca6-297f-4c8a-ba58-fb597c753eb6.mp4

