### PR TITLE
Ensure button ref gets passed down when a tooltip is used

### DIFF
--- a/libs/ui/lib/button/Button.tsx
+++ b/libs/ui/lib/button/Button.tsx
@@ -137,7 +137,10 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     ref
   ) => {
     return (
-      <Wrap when={disabled && disabledReason} with={<Tooltip content={disabledReason!} />}>
+      <Wrap
+        when={disabled && disabledReason}
+        with={<Tooltip content={disabledReason!} ref={ref} />}
+      >
         <button
           className={cn(buttonStyle({ size, variant, color }), className, {
             'visually-disabled': disabled,


### PR DESCRIPTION
Something I missed. As a consequence of the tooltip cloning and element passed to it we need to pass the ref down so it'll be appropriately added to the child element. The ref is passed down here: 

https://github.com/oxidecomputer/console/blob/01c2abd0ea7c0cb3c6699585d5b749d2f60d0832/libs/ui/lib/tooltip/Tooltip.tsx#L133