### PR TITLE
Resolve smoke test flakes

### DIFF
--- a/app/test/e2e/fixtures.ts
+++ b/app/test/e2e/fixtures.ts
@@ -297,6 +297,11 @@ export const test = base.extend<Fixtures>({
         .locator('role=button[name="Row actions"]')
         .click()
       await page.click('role=menuitem[name="Delete"]')
+      /**
+       * FIXME: This is a workaround to prevent a test failure flake where the `expectNotVisible` fails
+       * by finding _two_ of the cell that was supposed to be deleted above. I've been unable to reproduce
+       * this locally, so I'm not sure what's going on.
+       */
       await page.reload()
       await expectNotVisible(page, [`role=cell[name="${rowText}"]`])
     })


### PR DESCRIPTION
This is a workaround (but not a fix) for the smoke test flakes that we've been seeing. Here's an example of the flake: https://github.com/oxidecomputer/console/actions/runs/3473757516/jobs/5806224446.

I haven't been able to reproduce this failure locally and because it's happening inside a fixture we don't have good debug data. It seems that when we try to delete an entry from the table not only is it not deleted but it's _duplicated_. This is likely some very odd cache issue. I suspect it's only a temporary issue regardless. The fix here is just to reload the page before checking it. 