### PR TITLE
Updating a group's role should not change it into a user

### DIFF
--- a/app/forms/access-util.ts
+++ b/app/forms/access-util.ts
@@ -1,4 +1,4 @@
-import type { Policy, RoleKey } from '@oxide/api'
+import type { IdentityType, Policy, RoleKey } from '@oxide/api'
 import { allRoles } from '@oxide/api'
 import { capitalize } from '@oxide/util'
 
@@ -20,6 +20,7 @@ export type AddRoleModalProps = {
 }
 
 export type EditRoleModalProps = AddRoleModalProps & {
-  userId: string
+  identityId: string
+  identityType: IdentityType
   defaultValues: { roleName: RoleKey }
 }

--- a/app/forms/org-access.tsx
+++ b/app/forms/org-access.tsx
@@ -1,5 +1,5 @@
 import {
-  setUserRole,
+  updateRole,
   useApiMutation,
   useApiQueryClient,
   useUsersNotInPolicy,
@@ -38,7 +38,10 @@ export function OrgAccessAddUserSideModal({ onDismiss, policy }: AddRoleModalPro
 
         updatePolicy.mutate({
           path: orgParams,
-          body: setUserRole(userId, roleName, policy),
+          body: updateRole(
+            { identityId: userId, identityType: 'silo_user', roleName },
+            policy
+          ),
         })
       }}
       loading={updatePolicy.isLoading}
@@ -69,7 +72,8 @@ export function OrgAccessAddUserSideModal({ onDismiss, policy }: AddRoleModalPro
 
 export function OrgAccessEditUserSideModal({
   onDismiss,
-  userId,
+  identityId,
+  identityType,
   policy,
   defaultValues,
 }: EditRoleModalProps) {
@@ -92,7 +96,7 @@ export function OrgAccessEditUserSideModal({
       onSubmit={({ roleName }) => {
         updatePolicy.mutate({
           path: orgParams,
-          body: setUserRole(userId, roleName, policy),
+          body: updateRole({ identityId, identityType, roleName }, policy),
         })
       }}
       loading={updatePolicy.isLoading}

--- a/app/forms/project-access.tsx
+++ b/app/forms/project-access.tsx
@@ -1,5 +1,5 @@
 import {
-  setUserRole,
+  updateRole,
   useApiMutation,
   useApiQueryClient,
   useUsersNotInPolicy,
@@ -38,7 +38,10 @@ export function ProjectAccessAddUserSideModal({ onDismiss, policy }: AddRoleModa
 
         updatePolicy.mutate({
           path: projectParams,
-          body: setUserRole(userId, roleName, policy),
+          body: updateRole(
+            { identityId: userId, identityType: 'silo_user', roleName },
+            policy
+          ),
         })
       }}
       loading={updatePolicy.isLoading}
@@ -70,7 +73,8 @@ export function ProjectAccessAddUserSideModal({ onDismiss, policy }: AddRoleModa
 
 export function ProjectAccessEditUserSideModal({
   onDismiss,
-  userId,
+  identityId,
+  identityType,
   policy,
   defaultValues,
 }: EditRoleModalProps) {
@@ -93,7 +97,7 @@ export function ProjectAccessEditUserSideModal({
       onSubmit={({ roleName }) => {
         updatePolicy.mutate({
           path: projectParams,
-          body: setUserRole(userId, roleName, policy),
+          body: updateRole({ identityId, identityType, roleName }, policy),
         })
       }}
       loading={updatePolicy.isLoading}

--- a/app/forms/silo-access.tsx
+++ b/app/forms/silo-access.tsx
@@ -1,5 +1,5 @@
 import {
-  setUserRole,
+  updateRole,
   useApiMutation,
   useApiQueryClient,
   useUsersNotInPolicy,
@@ -34,7 +34,10 @@ export function SiloAccessAddUserSideModal({ onDismiss, policy }: AddRoleModalPr
         if (roleName === '') return
 
         updatePolicy.mutate({
-          body: setUserRole(userId, roleName, policy),
+          body: updateRole(
+            { identityId: userId, identityType: 'silo_user', roleName },
+            policy
+          ),
         })
       }}
       loading={updatePolicy.isLoading}
@@ -65,7 +68,8 @@ export function SiloAccessAddUserSideModal({ onDismiss, policy }: AddRoleModalPr
 
 export function SiloAccessEditUserSideModal({
   onDismiss,
-  userId,
+  identityId,
+  identityType,
   policy,
   defaultValues,
 }: EditRoleModalProps) {
@@ -85,7 +89,7 @@ export function SiloAccessEditUserSideModal({
       formOptions={{ defaultValues }}
       onSubmit={({ roleName }) => {
         updatePolicy.mutate({
-          body: setUserRole(userId, roleName, policy),
+          body: updateRole({ identityId, identityType, roleName }, policy),
         })
       }}
       loading={updatePolicy.isLoading}

--- a/app/pages/OrgAccessPage.tsx
+++ b/app/pages/OrgAccessPage.tsx
@@ -2,11 +2,11 @@ import { useMemo, useState } from 'react'
 import type { LoaderFunctionArgs } from 'react-router-dom'
 
 import type { IdentityType, RoleKey } from '@oxide/api'
+import { deleteRole } from '@oxide/api'
 import {
   apiQueryClient,
   byGroupThenName,
   getEffectiveRole,
-  setUserRole,
   useApiMutation,
   useApiQuery,
   useApiQueryClient,
@@ -138,7 +138,7 @@ export function OrgAccessPage() {
             updatePolicy.mutate({
               path: orgParams,
               // we know policy is there, otherwise there's no row to display
-              body: setUserRole(row.id, null, orgPolicy!),
+              body: deleteRole(row.id, orgPolicy!),
             })
           },
           disabled: !row.orgRole && "You don't have permission to delete this user",
@@ -171,7 +171,8 @@ export function OrgAccessPage() {
         <OrgAccessEditUserSideModal
           onDismiss={() => setEditingUserRow(null)}
           policy={orgPolicy}
-          userId={editingUserRow.id}
+          identityId={editingUserRow.id}
+          identityType={editingUserRow.identityType}
           defaultValues={{ roleName: editingUserRow.orgRole }}
         />
       )}

--- a/app/pages/SiloAccessPage.tsx
+++ b/app/pages/SiloAccessPage.tsx
@@ -1,11 +1,11 @@
 import { useMemo, useState } from 'react'
 
 import type { IdentityType, RoleKey } from '@oxide/api'
+import { deleteRole } from '@oxide/api'
 import {
   apiQueryClient,
   byGroupThenName,
   getEffectiveRole,
-  setUserRole,
   useApiMutation,
   useApiQuery,
   useApiQueryClient,
@@ -122,7 +122,7 @@ export function SiloAccessPage() {
             // TODO: confirm delete
             updatePolicy.mutate({
               // we know policy is there, otherwise there's no row to display
-              body: setUserRole(row.id, null, siloPolicy!),
+              body: deleteRole(row.id, siloPolicy!),
             })
           },
           disabled: !row.siloRole && "You don't have permission to delete this user",
@@ -155,7 +155,8 @@ export function SiloAccessPage() {
         <SiloAccessEditUserSideModal
           onDismiss={() => setEditingUserRow(null)}
           policy={siloPolicy}
-          userId={editingUserRow.id}
+          identityId={editingUserRow.id}
+          identityType={editingUserRow.identityType}
           defaultValues={{ roleName: editingUserRow.siloRole }}
         />
       )}

--- a/app/pages/project/access/ProjectAccessPage.tsx
+++ b/app/pages/project/access/ProjectAccessPage.tsx
@@ -3,11 +3,11 @@ import { useMemo, useState } from 'react'
 import type { LoaderFunctionArgs } from 'react-router-dom'
 
 import type { IdentityType, RoleKey } from '@oxide/api'
+import { deleteRole } from '@oxide/api'
 import {
   apiQueryClient,
   byGroupThenName,
   getEffectiveRole,
-  setUserRole,
   useApiMutation,
   useApiQuery,
   useApiQueryClient,
@@ -155,7 +155,7 @@ export function ProjectAccessPage() {
             updatePolicy.mutate({
               path: projectParams,
               // we know policy is there, otherwise there's no row to display
-              body: setUserRole(row.id, null, projectPolicy!),
+              body: deleteRole(row.id, projectPolicy!),
             })
           },
           disabled: !row.projectRole && "You don't have permission to delete this user",
@@ -188,7 +188,8 @@ export function ProjectAccessPage() {
         <ProjectAccessEditUserSideModal
           onDismiss={() => setEditingUserRow(null)}
           policy={projectPolicy}
-          userId={editingUserRow.id}
+          identityId={editingUserRow.id}
+          identityType={editingUserRow.identityType}
           defaultValues={{ roleName: editingUserRow.projectRole }}
         />
       )}

--- a/libs/api/roles.spec.ts
+++ b/libs/api/roles.spec.ts
@@ -1,9 +1,10 @@
 import type { Policy } from './roles'
+import { deleteRole } from './roles'
 import {
   byGroupThenName,
   getEffectiveRole,
   roleOrder,
-  setUserRole,
+  updateRole,
   userRoleFromPolicies,
 } from './roles'
 
@@ -32,25 +33,35 @@ test('role order assigns a different order number to every role', () => {
 
 const emptyPolicy = { roleAssignments: [] }
 
-const abcAdmin: Policy = {
-  roleAssignments: [{ identityId: 'abc', identityType: 'silo_user', roleName: 'admin' }],
-}
+const abcAdmin = {
+  identityId: 'abc',
+  identityType: 'silo_user',
+  roleName: 'admin',
+} as const
 
-const abcViewer: Policy = {
-  roleAssignments: [{ identityId: 'abc', identityType: 'silo_user', roleName: 'viewer' }],
-}
+const abcAdminPolicy: Policy = { roleAssignments: [abcAdmin] }
 
-describe('setUserRole', () => {
+const abcViewer = {
+  identityId: 'abc',
+  identityType: 'silo_user',
+  roleName: 'viewer',
+} as const
+
+const abcViewerPolicy: Policy = { roleAssignments: [abcViewer] }
+
+describe('updateRole', () => {
   it('adds a user', () => {
-    expect(setUserRole('abc', 'admin', emptyPolicy)).toEqual(abcAdmin)
+    expect(updateRole(abcAdmin, emptyPolicy)).toEqual(abcAdminPolicy)
   })
 
   it('overrides an existing user', () => {
-    expect(setUserRole('abc', 'viewer', abcAdmin)).toEqual(abcViewer)
+    expect(updateRole(abcViewer, abcAdminPolicy)).toEqual(abcViewerPolicy)
   })
+})
 
-  it('deletes a user when passed a roleId of null', () => {
-    expect(setUserRole('abc', null, abcViewer)).toEqual(emptyPolicy)
+describe('deleteRole', () => {
+  it('deletes a user by ID', () => {
+    expect(deleteRole('abc', abcViewerPolicy)).toEqual(emptyPolicy)
   })
 })
 

--- a/libs/api/roles.ts
+++ b/libs/api/roles.ts
@@ -55,23 +55,23 @@ export type Policy = { roleAssignments: RoleAssignment[] }
 
 /**
  * Returns a new updated policy. Does not modify the passed-in policy.
- *
- * @param roleName Pass `null` to delete the user from the policy.
  */
-export function setUserRole(
-  userId: string,
-  roleName: RoleKey | null,
-  policy: Policy
-): Policy {
-  // filter out any existing role assignments — we're pretending for now that you can only
-  const roleAssignments = policy.roleAssignments.filter((ra) => ra.identityId !== userId)
-  if (roleName !== null) {
-    roleAssignments.push({
-      identityId: userId,
-      identityType: 'silo_user',
-      roleName,
-    })
-  }
+export function updateRole(newAssignment: RoleAssignment, policy: Policy): Policy {
+  const roleAssignments = policy.roleAssignments.filter(
+    (ra) => ra.identityId !== newAssignment.identityId
+  )
+  roleAssignments.push(newAssignment)
+  return { roleAssignments }
+}
+
+/**
+ * Delete any role assignments for user or group ID. Returns a new updated
+ * policy. Does not modify the passed-in policy.
+ */
+export function deleteRole(identityId: string, policy: Policy): Policy {
+  const roleAssignments = policy.roleAssignments.filter(
+    (ra) => ra.identityId !== identityId
+  )
   return { roleAssignments }
 }
 


### PR DESCRIPTION
We were hard-coding an identity type of `silo_user` in the update function. This is prep for #1222. Wanted to keep it separate.