### PR TITLE
Disable sidebar nav links in system layout that go to blank pages

### DIFF
--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -71,6 +71,7 @@ export const NavLinkItem = (props: {
   to: string
   children: React.ReactNode
   end?: boolean
+  disabled?: boolean
 }) => (
   <li>
     <NavLink
@@ -78,6 +79,7 @@ export const NavLinkItem = (props: {
       className={({ isActive }) =>
         cn(linkStyles, {
           'text-accent !bg-accent-secondary svg:!text-accent-tertiary': isActive,
+          'pointer-events-none': props.disabled,
         })
       }
       end={props.end}

--- a/app/components/TopBarPicker.tsx
+++ b/app/components/TopBarPicker.tsx
@@ -141,7 +141,7 @@ export function SiloSystemPicker({ value }: { value: 'silo' | 'system' }) {
       {...commonProps}
       category="System"
       current="System"
-      display="Happy Customer, Inc."
+      display="Oxide Computer Co."
     />
   ) : (
     // TODO: actual silo name

--- a/app/layouts/SystemLayout.tsx
+++ b/app/layouts/SystemLayout.tsx
@@ -62,25 +62,25 @@ export default function SystemLayout() {
           <NavLinkItem to={pb.silos()}>
             <Cloud16Icon /> Silos
           </NavLinkItem>
-          <NavLinkItem to={pb.systemIssues()}>
+          <NavLinkItem to={pb.systemIssues()} disabled>
             <Instances16Icon /> Issues
           </NavLinkItem>
           <NavLinkItem to={pb.systemUtilization()}>
             <Snapshots16Icon /> Utilization
           </NavLinkItem>
-          <NavLinkItem to={pb.systemInventory()}>
+          <NavLinkItem to={pb.systemInventory()} disabled>
             <Storage16Icon /> Inventory
           </NavLinkItem>
-          <NavLinkItem to={pb.systemHealth()}>
+          <NavLinkItem to={pb.systemHealth()} disabled>
             <Health16Icon /> Health
           </NavLinkItem>
-          <NavLinkItem to={pb.systemUpdate()}>
+          <NavLinkItem to={pb.systemUpdate()} disabled>
             <SoftwareUpdate16Icon /> System Update
           </NavLinkItem>
-          <NavLinkItem to={pb.systemNetworking()}>
+          <NavLinkItem to={pb.systemNetworking()} disabled>
             <Networking16Icon /> Networking
           </NavLinkItem>
-          <NavLinkItem to={pb.systemSettings()}>
+          <NavLinkItem to={pb.systemSettings()} disabled>
             <Settings16Icon /> Settings
           </NavLinkItem>
         </Sidebar.Nav>


### PR DESCRIPTION
Disable links so @smklein isn't tempted to click them when he's demoing. No visual indication that they're disabled except that on hover, there's no gray background and the mouse doesn't go 👆. Also changed `Happy Customer, Inc.` to `Oxide Computer Co.`. Whatever.

![2023-01-30-disable-nav-links](https://user-images.githubusercontent.com/3612203/215575582-543830e5-cf97-409e-b1fe-0116693e5861.gif)
