### PR TITLE
Add license comment to output bundles

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,12 +7,12 @@ import tsConfig from './tsconfig.json'
 
 // exclamation point required to not get minified out
 const banner = `/*!
-* This Source Code Form is subject to the terms of the Mozilla Public
-* License, v. 2.0. If a copy of the MPL was not distributed with this
-* file, You can obtain one at https://mozilla.org/MPL/2.0/.
-*
-* Copyright 2023 Oxide Computer Company
-*/`
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright 2023 Oxide Computer Company
+ */`
 
 const mapObj = <V0, V>(
   obj: Record<string, V0>,
@@ -31,14 +31,13 @@ export default defineConfig(({ mode }) => ({
     emptyOutDir: true,
     sourcemap: true,
     // minify: false, // uncomment for debugging
-    rollupOptions: {
-      input: {
-        app: 'index.html',
-      },
-      output: {
-        banner,
-      },
-    },
+    // we still need this for the storybook deploy
+    rollupOptions: process.env.VERCEL
+      ? {}
+      : {
+          input: { app: 'index.html' },
+          output: { banner },
+        },
   },
   define: {
     'process.env.API_URL': JSON.stringify(process.env.API_URL ?? '/api'),


### PR DESCRIPTION
Closes #807 

So far it does this. I want to figure out

- [ ] Can we actually use MPL?
  - I doubt it works for a big file containing a bunch of MIT licensed third party libs together with our source. However, we can make rollup put our code in a separate bundle
- [ ] Is it ok if it's at the top, or does it need to specifically be over the section we actually wrote? This file includes a bunch of libraries.

<img width="552" alt="image" src="https://user-images.githubusercontent.com/3612203/217391610-c57cc216-9386-43e0-8821-fd4a179ad24d.png">
