### PR TITLE
`Deno.Command`

### DIFF
--- a/tools/bump-omicron.ts
+++ b/tools/bump-omicron.ts
@@ -18,9 +18,11 @@ const VERSION_FILE_MISSING = `Omicron console version file at '${VERSION_FILE}' 
 
 /** Run shell command, get output as string */
 function run(cmd: string, args: string[]): string {
-  const { code, stdout } = new Deno.Command(cmd, { args, stdout: 'piped' }).outputSync()
+  const { success, stdout } = new Deno.Command(cmd, { args, stdout: 'piped' }).outputSync()
 
-  if (code !== 0) throw Error(`Shell command '${args.join(' ')}' failed`)
+  if (!success) {
+    throw Error(`Shell command '${cmd} ${args.join(' ')}' failed`)
+  }
 
   return new TextDecoder().decode(stdout).trim()
 }


### PR DESCRIPTION
Pointless, but the [Deno 1.31 announcement](https://deno.com/blog/v1.31#api-stabilizations) mentioned they plan on deprecating [`Deno.run`](https://deno.land/api@v1.31.0?s=Deno.run) in favor of the newly stabilized [`Deno.Command`](https://deno.land/api@v1.31.0?s=Deno.Command). I was curious what the new API was like, so I changed our one Deno script to use it.

I won't merge this until 1.31.1, which fixes Deno automatically picking up our `package.json` and spending 3 minutes installing all the dependencies in it for no reason. See https://github.com/denoland/deno/issues/17916#issuecomment-1444647248.