### PR TITLE
Change RR path param names to match API selectors

### DIFF
--- a/app/components/TopBarPicker.tsx
+++ b/app/components/TopBarPicker.tsx
@@ -195,7 +195,7 @@ export function SiloPicker() {
 }
 
 export function OrgPicker() {
-  const { orgName: organization } = useParams()
+  const { organization } = useParams()
   const { data } = useApiQuery('organizationListV1', { query: { limit: 20 } })
   const items = (data?.items || []).map(({ name }) => ({
     label: name,

--- a/app/forms/network-interface-edit.tsx
+++ b/app/forms/network-interface-edit.tsx
@@ -1,5 +1,3 @@
-import invariant from 'tiny-invariant'
-
 import type { NetworkInterface } from '@oxide/api'
 import { useApiMutation, useApiQueryClient } from '@oxide/api'
 import { pick } from '@oxide/util'
@@ -21,10 +19,6 @@ export default function EditNetworkInterfaceForm({
 
   const editNetworkInterface = useApiMutation('instanceNetworkInterfaceUpdateV1', {
     onSuccess() {
-      invariant(
-        instanceSelector.instance,
-        'instanceName is required when posting a network interface'
-      )
       queryClient.invalidateQueries('instanceNetworkInterfaceListV1', {
         query: instanceSelector,
       })

--- a/app/hooks/use-params.ts
+++ b/app/hooks/use-params.ts
@@ -2,8 +2,6 @@ import type { Params } from 'react-router-dom'
 import { useParams } from 'react-router-dom'
 import invariant from 'tiny-invariant'
 
-import { toApiSelector } from '@oxide/util'
-
 const err = (param: string) =>
   `Param '${param}' not found in route. You might be rendering a component under the wrong route.`
 
@@ -23,41 +21,22 @@ export const requireParams =
     return requiredParams as { readonly [k in K]: string }
   }
 
-const requireOrgParams = requireParams('orgName')
-const requireProjectParams = requireParams('orgName', 'projectName')
-const requireInstanceParams = requireParams('orgName', 'projectName', 'instanceName')
-const requireVpcParams = requireParams('orgName', 'projectName', 'vpcName')
-const requireSiloParams = requireParams('siloName')
+export const getOrgSelector = requireParams('organization')
+export const getProjectSelector = requireParams('organization', 'project')
+export const getInstanceSelector = requireParams('organization', 'project', 'instance')
+export const getVpcSelector = requireParams('organization', 'project', 'vpc')
+export const getSiloSelector = requireParams('silo')
 const requireSledParams = requireParams('sledId')
 export const requireUpdateParams = requireParams('version')
-
-const useOrgParams = () => requireOrgParams(useParams())
-const useProjectParams = () => requireProjectParams(useParams())
-const useInstanceParams = () => requireInstanceParams(useParams())
-const useVpcParams = () => requireVpcParams(useParams())
-const useSiloParams = () => requireSiloParams(useParams())
-export const useSledParams = () => requireSledParams(useParams())
-export const useUpdateParams = () => requireUpdateParams(useParams())
-
-// non-hook versions for use in loaders
-
-export const getSiloSelector = (p: Readonly<Params<string>>) =>
-  toApiSelector(requireSiloParams(p))
-export const getOrgSelector = (p: Readonly<Params<string>>) =>
-  toApiSelector(requireOrgParams(p))
-export const getProjectSelector = (p: Readonly<Params<string>>) =>
-  toApiSelector(requireProjectParams(p))
-export const getInstanceSelector = (p: Readonly<Params<string>>) =>
-  toApiSelector(requireInstanceParams(p))
-export const getVpcSelector = (p: Readonly<Params<string>>) =>
-  toApiSelector(requireVpcParams(p))
 
 // Wrappers for RR's `useParams` that guarantee (in dev) that the specified
 // params are present. Only the specified keys end up in the result object, but
 // we do not error if there are other params present in the query string.
 
-export const useSiloSelector = () => toApiSelector(useSiloParams())
-export const useOrgSelector = () => toApiSelector(useOrgParams())
-export const useProjectSelector = () => toApiSelector(useProjectParams())
-export const useVpcSelector = () => toApiSelector(useVpcParams())
-export const useInstanceSelector = () => toApiSelector(useInstanceParams())
+export const useOrgSelector = () => getOrgSelector(useParams())
+export const useProjectSelector = () => getProjectSelector(useParams())
+export const useInstanceSelector = () => getInstanceSelector(useParams())
+export const useVpcSelector = () => getVpcSelector(useParams())
+export const useSiloSelector = () => getSiloSelector(useParams())
+export const useSledParams = () => requireSledParams(useParams())
+export const useUpdateParams = () => requireUpdateParams(useParams())

--- a/app/layouts/ProjectLayout.tsx
+++ b/app/layouts/ProjectLayout.tsx
@@ -29,8 +29,8 @@ const ProjectLayout = () => {
   const navigate = useNavigate()
   // org and project will always be there, instance may not
   const projectSelector = useProjectSelector()
-  const { project: projectName } = projectSelector
-  const { instanceName } = useParams()
+  const { project } = projectSelector
+  const { instance } = useParams()
   const currentPath = useLocation().pathname
   useQuickActions(
     useMemo(
@@ -46,12 +46,12 @@ const ProjectLayout = () => {
           // filter out the entry for the path we're currently on
           .filter((i) => !matchPath(`/orgs/:org/projects/:project/${i.path}`, currentPath))
           .map((i) => ({
-            navGroup: `Project '${projectName}'`,
+            navGroup: `Project '${project}'`,
             value: i.value,
             // TODO: Update this to use the new path builder
             onSelect: () => navigate(i.path),
           })),
-      [currentPath, navigate, projectName]
+      [currentPath, navigate, project]
     )
   )
 
@@ -61,7 +61,7 @@ const ProjectLayout = () => {
         {useSiloSystemPicker('silo')}
         <OrgPicker />
         <ProjectPicker />
-        {instanceName && <InstancePicker />}
+        {instance && <InstancePicker />}
       </TopBar>
       <Sidebar>
         <Sidebar.Nav>
@@ -72,7 +72,7 @@ const ProjectLayout = () => {
           <DocsLinkItem />
         </Sidebar.Nav>
         <Divider />
-        <Sidebar.Nav heading={projectName}>
+        <Sidebar.Nav heading={project}>
           <NavLinkItem to={pb.instances(projectSelector)}>
             <Instances16Icon /> Instances
           </NavLinkItem>

--- a/app/layouts/SystemLayout.tsx
+++ b/app/layouts/SystemLayout.tsx
@@ -46,12 +46,12 @@ export default function SystemLayout() {
   // robust way of doing this would be to make a separate layout for the
   // silo-specific routes in the route config, but it's overkill considering
   // this is a one-liner. Switch to that approach at the first sign of trouble.
-  const { siloName } = useParams()
+  const { silo } = useParams()
   return (
     <PageContainer>
       <TopBar>
         <SiloSystemPicker value="system" />
-        {siloName && <SiloPicker />}
+        {silo && <SiloPicker />}
       </TopBar>
       <Sidebar>
         <Sidebar.Nav>

--- a/app/routes.tsx
+++ b/app/routes.tsx
@@ -62,10 +62,10 @@ import {
 } from './pages/system/UpdatePage'
 import { pb } from './util/path-builder'
 
-const orgCrumb: CrumbFunc = (m) => m.params.orgName!
-const projectCrumb: CrumbFunc = (m) => m.params.projectName!
-const instanceCrumb: CrumbFunc = (m) => m.params.instanceName!
-const vpcCrumb: CrumbFunc = (m) => m.params.vpcName!
+const orgCrumb: CrumbFunc = (m) => m.params.organization!
+const projectCrumb: CrumbFunc = (m) => m.params.project!
+const instanceCrumb: CrumbFunc = (m) => m.params.instance!
+const vpcCrumb: CrumbFunc = (m) => m.params.vpc!
 
 export const routes = createRoutesFromElements(
   <Route element={<RootLayout />}>
@@ -99,7 +99,7 @@ export const routes = createRoutesFromElements(
           <Route path="silos" />
           <Route path="silos-new" element={<CreateSiloSideModalForm />} />
         </Route>
-        <Route path="silos/:siloName" element={<SiloPage />} loader={SiloPage.loader}>
+        <Route path="silos/:silo" element={<SiloPage />} loader={SiloPage.loader}>
           <Route index />
           <Route path="idps-new" element={<CreateIdpSideModalForm />} />
         </Route>
@@ -146,9 +146,9 @@ export const routes = createRoutesFromElements(
       <Route index element={<Navigate to={pb.orgs()} replace />} />
 
       {/* These are done here instead of nested so we don't flash a layout on 404s */}
-      <Route path="orgs/:orgName" element={<Navigate to="projects" replace />} />
+      <Route path="orgs/:organization" element={<Navigate to="projects" replace />} />
       <Route
-        path="orgs/:orgName/projects/:projectName"
+        path="orgs/:organization/projects/:project"
         element={<Navigate to="instances" replace />}
       />
 
@@ -166,7 +166,7 @@ export const routes = createRoutesFromElements(
             handle={{ crumb: 'New org' }}
           />
           <Route
-            path="orgs/:orgName/edit"
+            path="orgs/:organization/edit"
             element={<EditOrgSideModalForm />}
             loader={EditOrgSideModalForm.loader}
             handle={{ crumb: 'Edit org' }}
@@ -180,7 +180,7 @@ export const routes = createRoutesFromElements(
         />
       </Route>
 
-      <Route path="orgs/:orgName" handle={{ crumb: orgCrumb }}>
+      <Route path="orgs/:organization" handle={{ crumb: orgCrumb }}>
         <Route element={<OrgLayout />}>
           <Route
             path="access"
@@ -197,7 +197,7 @@ export const routes = createRoutesFromElements(
               handle={{ crumb: 'New project' }}
             />
             <Route
-              path="projects/:projectName/edit"
+              path="projects/:project/edit"
               element={<EditProjectSideModalForm />}
               loader={EditProjectSideModalForm.loader}
               handle={{ crumb: 'Edit project' }}
@@ -207,7 +207,7 @@ export const routes = createRoutesFromElements(
 
         {/* PROJECT */}
         <Route
-          path="projects/:projectName"
+          path="projects/:project"
           element={<ProjectLayout />}
           handle={{ crumb: projectCrumb }}
         >
@@ -217,13 +217,10 @@ export const routes = createRoutesFromElements(
             loader={CreateInstanceForm.loader}
             handle={{ crumb: 'New instance' }}
           />
-          <Route
-            path="instances/:instanceName"
-            element={<Navigate to="storage" replace />}
-          />
+          <Route path="instances/:instance" element={<Navigate to="storage" replace />} />
           <Route path="instances" handle={{ crumb: 'Instances' }}>
             <Route index element={<InstancesPage />} loader={InstancesPage.loader} />
-            <Route path=":instanceName" handle={{ crumb: instanceCrumb }}>
+            <Route path=":instance" handle={{ crumb: instanceCrumb }}>
               <Route element={<InstancePage />} loader={InstancePage.loader}>
                 <Route
                   path="storage"
@@ -260,7 +257,7 @@ export const routes = createRoutesFromElements(
               handle={{ crumb: 'New VPC' }}
             />
             <Route
-              path="vpcs/:vpcName/edit"
+              path="vpcs/:vpc/edit"
               element={<EditVpcSideModalForm />}
               loader={EditVpcSideModalForm.loader}
               handle={{ crumb: 'Edit VPC' }}
@@ -269,7 +266,7 @@ export const routes = createRoutesFromElements(
 
           <Route path="vpcs" handle={{ crumb: 'VPCs' }}>
             <Route
-              path=":vpcName"
+              path=":vpc"
               element={<VpcPage />}
               loader={VpcPage.loader}
               handle={{ crumb: vpcCrumb }}

--- a/libs/util/selector.spec.ts
+++ b/libs/util/selector.spec.ts
@@ -1,6 +1,6 @@
 import { assertType } from 'vitest'
 
-import { toApiSelector, toPathQuery } from './selector'
+import { toPathQuery } from './selector'
 
 describe('toPathQuery', () => {
   it('works in the base case', () => {
@@ -32,20 +32,5 @@ describe('toPathQuery', () => {
     // type error if key is not in the object
     // @ts-expect-error
     toPathQuery('instance', { instanc: 'i', project: 'p', organization: 'o' })
-  })
-})
-
-describe('toApiSelector', () => {
-  it('converts xName to x, handling orgName specially', () => {
-    const result = toApiSelector({ orgName: 'abc', projectName: 'def' })
-    expect(result).toEqual({ organization: 'abc', project: 'def' })
-
-    // make sure it gets the type right
-    assertType<{ organization: string; project: string }>(result)
-  })
-
-  it('type errors on keys that do not end in Name', () => {
-    // @ts-expect-error keys must end in 'Name'
-    toApiSelector({ projectNam: 'abc' })
   })
 })

--- a/libs/util/selector.ts
+++ b/libs/util/selector.ts
@@ -1,5 +1,3 @@
-import type { Replace } from 'type-fest'
-
 import { exclude } from '@oxide/util'
 
 /**
@@ -17,33 +15,3 @@ export const toPathQuery = <K extends string, PK extends K>(
   path: { [pathKey]: selector[pathKey] } as { [K0 in PK]: string },
   query: exclude(selector, pathKey) as { [K0 in Exclude<K, PK>]: string },
 })
-
-type StripName<K extends string> = K extends `${infer K0}Name` ? K0 : K
-
-/**
- * Turn
- *
- * ```ts
- * { orgName: 'abc', projectName: 'def' }
- * ```
- * into
- * ```ts
- * { organization: 'abc', project: 'def' }
- * ```
- *
- * while maintaining type-level awareness of keys. Note special handling of
- * `orgName` to avoid having to convert hundreds of lines of existing code to
- * use `organizationName`. Organizations are going to disappear anyway, which
- * will make this unnecessary.
- */
-export function toApiSelector<K extends `${string}Name`>(selector: Record<K, string>) {
-  return Object.fromEntries(
-    Object.entries(selector).map(([k, v]) => [
-      k === 'orgName' ? 'organization' : stripName(k as K),
-      v,
-    ])
-  ) as { [K1 in StripName<Replace<K, 'orgName', 'organizationName'>>]: string }
-}
-
-const stripName = <K extends string>(nameKey: `${K}Name`) =>
-  nameKey.replace(/Name$/, '') as StripName<K>


### PR DESCRIPTION
Easier than expected. This let me delete some code that was just there to help with the transition.