### PR TITLE
Classed components forward refs

### DIFF
--- a/libs/util/classed.tsx
+++ b/libs/util/classed.tsx
@@ -3,7 +3,7 @@
  * avoid build failures with the `vite:react-babel` plugin.
  */
 import cn from 'classnames'
-import React from 'react'
+import React, { forwardRef } from 'react'
 
 // all the cuteness of tw.span`text-green-500 uppercase` with zero magic
 
@@ -11,8 +11,14 @@ const make =
   <T extends keyof JSX.IntrinsicElements>(tag: T) =>
   // only one argument here means string interpolations are not allowed
   (strings: TemplateStringsArray) => {
-    const Comp = ({ className, children, ...rest }: JSX.IntrinsicElements[T]) =>
-      React.createElement(tag, { className: cn(strings[0], className), ...rest }, children)
+    const Comp = forwardRef(
+      ({ className, children, ...rest }: JSX.IntrinsicElements[T], ref) =>
+        React.createElement(
+          tag,
+          { className: cn(strings[0], className), ...rest, ref },
+          children
+        )
+    )
     Comp.displayName = `classed.${tag}`
     return Comp
   }


### PR DESCRIPTION
Saw this thrilling error

```
Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?

Check the render method of `SlotClone`.
Comp@http://localhost:4000/libs/util/classed.tsx:6:18
```

<details>
    <summary>Rest of the trace</summary>
    
```
$5e63c961fc1ce211$var$SlotClone<@http://localhost:4000/node_modules/.vite/deps/chunk-BFO3AUYE.js?v=f5c4d1a7:279:38
$5e63c961fc1ce211$export$8c6ed5c666ac1360<@http://localhost:4000/node_modules/.vite/deps/chunk-BFO3AUYE.js?v=f5c4d1a7:256:38
$8927f6f2acc4f386$export$250ffa63cdc0d034</Node<@http://localhost:4000/node_modules/.vite/deps/chunk-BFO3AUYE.js?v=f5c4d1a7:350:44
$5d3850c4d0b4e6c7$export$16f7638e4a34b909<@http://localhost:4000/node_modules/.vite/deps/@radix-ui_react-dialog.js?v=6f79c38c:252:44
div
$8927f6f2acc4f386$export$250ffa63cdc0d034</Node<@http://localhost:4000/node_modules/.vite/deps/chunk-BFO3AUYE.js?v=f5c4d1a7:350:44
$5cb92bef7577960e$export$177fb62ff3ec1f22<@http://localhost:4000/node_modules/.vite/deps/chunk-CFOSRXW6.js?v=f5c4d1a7:59:151
$5e63c961fc1ce211$var$SlotClone<@http://localhost:4000/node_modules/.vite/deps/chunk-BFO3AUYE.js?v=f5c4d1a7:279:38
$5e63c961fc1ce211$export$8c6ed5c666ac1360<@http://localhost:4000/node_modules/.vite/deps/chunk-BFO3AUYE.js?v=f5c4d1a7:256:38
$8927f6f2acc4f386$export$250ffa63cdc0d034</Node<@http://localhost:4000/node_modules/.vite/deps/chunk-BFO3AUYE.js?v=f5c4d1a7:350:44
$d3863c46a17e8a28$export$20e40289641fbbb6<@http://localhost:4000/node_modules/.vite/deps/chunk-CFOSRXW6.js?v=f5c4d1a7:290:144
$5d3850c4d0b4e6c7$var$DialogContentImpl<@http://localhost:4000/node_modules/.vite/deps/@radix-ui_react-dialog.js?v=6f79c38c:228:92
$5d3850c4d0b4e6c7$var$DialogContentModal<@http://localhost:4000/node_modules/.vite/deps/@radix-ui_react-dialog.js?v=6f79c38c:167:19
$921a889cee6df7e8$export$99c2b779aa4e8b8b@http://localhost:4000/node_modules/.vite/deps/chunk-BFO3AUYE.js?v=f5c4d1a7:382:33
$5d3850c4d0b4e6c7$export$b6d9565de1e068cf<@http://localhost:4000/node_modules/.vite/deps/@radix-ui_react-dialog.js?v=6f79c38c:152:25
withAnimated/<@http://localhost:4000/node_modules/.vite/deps/@react-spring_web.js?v=bda92277:1111:50
$5e63c961fc1ce211$var$SlotClone<@http://localhost:4000/node_modules/.vite/deps/chunk-BFO3AUYE.js?v=f5c4d1a7:279:38
$5e63c961fc1ce211$export$8c6ed5c666ac1360<@http://localhost:4000/node_modules/.vite/deps/chunk-BFO3AUYE.js?v=f5c4d1a7:256:38
$8927f6f2acc4f386$export$250ffa63cdc0d034</Node<@http://localhost:4000/node_modules/.vite/deps/chunk-BFO3AUYE.js?v=f5c4d1a7:350:44
$f1701beae083dbae$export$602eac185826482c<@http://localhost:4000/node_modules/.vite/deps/chunk-CFOSRXW6.js?v=f5c4d1a7:528:225
$921a889cee6df7e8$export$99c2b779aa4e8b8b@http://localhost:4000/node_modules/.vite/deps/chunk-BFO3AUYE.js?v=f5c4d1a7:382:33
Provider@http://localhost:4000/node_modules/.vite/deps/chunk-BFO3AUYE.js?v=f5c4d1a7:78:47
$5d3850c4d0b4e6c7$export$dad7c95542bacce0@http://localhost:4000/node_modules/.vite/deps/@radix-ui_react-dialog.js?v=6f79c38c:95:62
Provider@http://localhost:4000/node_modules/.vite/deps/chunk-BFO3AUYE.js?v=f5c4d1a7:78:47
$5d3850c4d0b4e6c7$export$3ddf2d174ce01153@http://localhost:4000/node_modules/.vite/deps/@radix-ui_react-dialog.js?v=6f79c38c:40:96
SideModal@http://localhost:4000/libs/ui/lib/side-modal/SideModal.tsx:23:26
SideModalForm@http://localhost:4000/app/components/form/SideModalForm.tsx:21:30
CreateProjectSideModalForm@http://localhost:4000/app/forms/project-create.tsx:29:20
RenderedRoute@http://localhost:4000/node_modules/.vite/deps/react-router-dom.js?v=741d9c33:2978:7
Outlet@http://localhost:4000/node_modules/.vite/deps/react-router-dom.js?v=741d9c33:3260:3
ProjectsPage@http://localhost:4000/app/pages/ProjectsPage.tsx:47:20
RenderedRoute@http://localhost:4000/node_modules/.vite/deps/react-router-dom.js?v=741d9c33:2978:7
Outlet@http://localhost:4000/node_modules/.vite/deps/react-router-dom.js?v=741d9c33:3260:3
main
div
div
ContentPane - app/layouts/helpers.tsx
div
Comp@http://localhost:4000/libs/util/classed.tsx:6:18
SiloLayout@http://localhost:4000/app/layouts/SiloLayout.tsx:27:7
RenderedRoute@http://localhost:4000/node_modules/.vite/deps/react-router-dom.js?v=741d9c33:2978:7
RenderedRoute@http://localhost:4000/node_modules/.vite/deps/react-router-dom.js?v=741d9c33:2978:7
RenderErrorBoundary@http://localhost:4000/node_modules/.vite/deps/react-router-dom.js?v=741d9c33:2938:5
Outlet@http://localhost:4000/node_modules/.vite/deps/react-router-dom.js?v=741d9c33:3260:3
RootLayout@http://localhost:4000/app/layouts/RootLayout.tsx:33:3
RenderedRoute@http://localhost:4000/node_modules/.vite/deps/react-router-dom.js?v=741d9c33:2978:7
RenderErrorBoundary@http://localhost:4000/node_modules/.vite/deps/react-router-dom.js?v=741d9c33:2938:5
Routes@http://localhost:4000/node_modules/.vite/deps/react-router-dom.js?v=741d9c33:3322:7
Router@http://localhost:4000/node_modules/.vite/deps/react-router-dom.js?v=741d9c33:3273:7
RouterProvider@http://localhost:4000/node_modules/.vite/deps/react-router-dom.js?v=741d9c33:3159:7
ErrorBoundary2@http://localhost:4000/node_modules/.vite/deps/react-error-boundary.js?v=350c9ba2:47:35
ErrorBoundary@http://localhost:4000/app/components/ErrorBoundary.tsx:57:119
QueryClientProvider@http://localhost:4000/node_modules/.vite/deps/chunk-33TX26KD.js?v=f5c4d1a7:2647:27
```
 
</details>

when opening any side modal. It's because of this `asChild` 

https://github.com/oxidecomputer/console/blob/bec5c9f7849a671d67d08f6d26b4e569be9b061a/libs/ui/lib/side-modal/SideModal.tsx#L60-L62

which means Radix Dialog tries to pass a ref directly to `SideModal.Title`, which is a `classed.h2`. So the `classed` component needs to forward refs.

https://github.com/oxidecomputer/console/blob/bec5c9f7849a671d67d08f6d26b4e569be9b061a/libs/ui/lib/side-modal/SideModal.tsx#L72