### PR TITLE
Don't keep submit button disabled after error

### DIFF
--- a/app/components/form/SideModalForm.tsx
+++ b/app/components/form/SideModalForm.tsx
@@ -46,7 +46,7 @@ export function SideModalForm<TFieldValues extends FieldValues>({
   // change
   const form = useForm({ mode: 'all', ...formOptions })
 
-  const { isSubmitting, isSubmitSuccessful } = form.formState
+  const { isSubmitting } = form.formState
 
   /**
    * Only animate the modal in when we're navigating by a client-side click.
@@ -93,7 +93,7 @@ export function SideModalForm<TFieldValues extends FieldValues>({
             size="sm"
             disabled={!!submitDisabled}
             disabledReason={submitDisabled}
-            loading={loading || isSubmitting || isSubmitSuccessful}
+            loading={loading || isSubmitting}
             form={id}
           >
             {submitLabel || title}


### PR DESCRIPTION
The `|| isSubmitSuccessful` was introduced [here](https://github.com/oxidecomputer/console/commit/06298aa5461b472c0286011d5725382f904c5b84#diff-7c141329d1ec013bbf13611639e2db4d575e6ad046c0888693a98c5702f96f78R49), but I don't understand why. The [RHF docs](https://react-hook-form.com/api/useform/formstate/) say this property

> Indicate[s] the form was successfully submitted without any runtime error.

Thinking about it more, maybe this was supposed to keep the button disabled after a successful _response_, so there wasn't a brief window where the button is enabled before the modal closes but after the request has succeeded. But `isSubmitSuccessful` is a form state thing, so it doesn't know if the response was good, it only knows whether the form itself was submitted.

It is up to the calling code to cause the modal to close in the `onSuccess` callback on the mutation, and there generally isn't any gap between successful response and that callback running. Even if we wanted it to stay loading, that could still be handled by the calling code through the `loading` prop. So I think this change is all good.

### The bug being fixed

This is what it does on submit error without this change:

![2023-03-23-form-error](https://user-images.githubusercontent.com/3612203/227310931-a573cea2-1ac0-4edb-8325-8ac643de1470.gif)
