### PR TITLE
Use identicon only for silos

### DIFF
--- a/app/components/TopBarPicker.tsx
+++ b/app/components/TopBarPicker.tsx
@@ -215,7 +215,7 @@ export function ProjectPicker() {
   return (
     <TopBarPicker
       aria-label="Switch project"
-      icon={project ? null : <NoProjectLogo />}
+      icon={project ? undefined : <NoProjectLogo />}
       category="Project"
       current={project}
       to={project ? pb.project({ project }) : undefined}


### PR DESCRIPTION
Identicon was previously used for orgs and now with orgs removed should only be used for silos. This moves the identicon in the top picker.

![image](https://user-images.githubusercontent.com/4020798/227552579-211f5ca5-873b-49f9-8c91-65e6ae82d42a.png)

Note: ignore the commit, should say silos not orgs