### PR TITLE
Update `start_api` to use new omicron-dev command

### DIFF
--- a/tools/populate_omicron_data.sh
+++ b/tools/populate_omicron_data.sh
@@ -8,7 +8,7 @@ set -o xtrace
 # start_api.sh. if you do run it manually, note that it's meant to be run
 # from inside the omicron repo and it assumes nexus and sled agent are running
 
-# The CLI manual is here: https://docs.oxide.computer/cli/manual
+# The CLI manual is here: https://docs.oxide.computer/cli
 
 ./tools/populate/populate-alpine.sh
 
@@ -98,15 +98,13 @@ oxide instance start --instance db1 --project prod-online
 
 # Create VPCs in prod-online
 
-# TODO: these work, but update them once --dns_name becomes --dns-name
-
 oxide vpc create --name vpc1 \
   --description "The vpc1 VPC." \
   --project prod-online \
-  --dns_name vpc1
+  --dns-name vpc1
 oxide vpc create --name vpc2 \
   --description "The vpc2 VPC." \
   --project prod-online \
-  --dns_name vpc2
+  --dns-name vpc2
 
 echo -e "\n==== API DATA POPULATED ====\n"

--- a/tools/start_api.sh
+++ b/tools/start_api.sh
@@ -3,16 +3,6 @@
 set -o errexit
 set -o pipefail
 
-f_flag=
-while getopts f name
-do
-  case $name in
-    f)  f_flag=1;;
-    ?)  printf "Usage: %s [-f] \n" $0; exit 2;;
-  esac
-done
-shift $(($OPTIND - 1))
-
 # this script assumes it's being run from inside the omicron repo and the console
 # repo shares the same parent directory
 
@@ -29,63 +19,23 @@ run_in_pane() {
   tmux send-keys -t omicron-console:0."$1" "$2" C-m
 }
 
-# unless -f flag is present, refuse to start if we're not on the right omicron commit
-if [ -z "$f_flag" ]; then
-  PINNED_API_VERSION=$(cat ../console/OMICRON_VERSION)
-  CURRENT_API_VERSION=$(git rev-parse HEAD)
-
-  if [ "$CURRENT_API_VERSION" != "$PINNED_API_VERSION" ]; then
-    echo -e "\nERROR: Omicron version pinned in console does not match HEAD\n" >&2
-    echo -e "  pinned:  $PINNED_API_VERSION" >&2
-    echo -e "  HEAD:    $CURRENT_API_VERSION\n" >&2
-    echo -e "Check out the pinned commit and try again.\n" >&2
-    exit 1
-  fi
-fi
-
-tmux new -d -s omicron-console 
+tmux new -d -s omicron-console
 tmux set -t omicron-console pane-border-status top
 tmux set -t omicron-console pane-border-style "bg=#BBBBBB fg=black"
 tmux set -t omicron-console pane-active-border-style "bg=green fg=black"
 
-for p in {1..5}; do
-  tmux split-window
-  tmux select-layout even-vertical
-done
+tmux split-window
+tmux resize-pane -t omicron-console:0.0 -y 20%
 
-# run populate explicitly later so we can tell when it's done
 run_in_pane 0 "$UTILS"
-run_in_pane 0 "set_pane_title cockroach"
-run_in_pane 0 "cargo run --bin=omicron-dev -- db-run --no-populate"
+run_in_pane 0 "set_pane_title omicron-dev"
+run_in_pane 0 "SKIP_ASIC_CONFIG=1 cargo run --bin=omicron-dev -- run-all"
 
 run_in_pane 1 "$UTILS"
-run_in_pane 1 "set_pane_title clickhouse"
-run_in_pane 1 "cargo run --bin omicron-dev -- ch-run"
-
-run_in_pane 2 "$UTILS"
-run_in_pane 2 "set_pane_title nexus"
-run_in_pane 2 "wait_for_up 32221" # cockroach
-run_in_pane 2 "cargo run --bin=omicron-dev -- db-populate --database-url postgresql://root@127.0.0.1:32221/omicron"
-run_in_pane 2 "cargo run --bin=nexus -- nexus/examples/config.toml"
-
-run_in_pane 3 "$UTILS"
-run_in_pane 3 "set_pane_title sled-agent-sim"
-run_in_pane 3 "wait_for_up 12221" # nexus internal
-# env var explanation: https://github.com/oxidecomputer/omicron/issues/2629
-run_in_pane 3 "SKIP_ASIC_CONFIG=1 cargo run --bin=sled-agent-sim -- $(uuidgen) '[::1]:12345' 127.0.0.1:12221"
-
-run_in_pane 4 "$UTILS"
-run_in_pane 4 "set_pane_title oximeter"
-run_in_pane 4 "wait_for_up 8123" # clickhouse
-run_in_pane 4 "wait_for_up 12221" # nexus internal
-run_in_pane 4 "cargo run --bin=oximeter run --id $(uuidgen) --address '[::1]:12223' -- oximeter/collector/config.toml"
-
-run_in_pane 5 "$UTILS"
-run_in_pane 5 "set_pane_title 'seed data'"
-run_in_pane 5 "wait_for_up 12223" # oximeter
-run_in_pane 5 "wait_for_up 12345" # sled agent
-run_in_pane 5 "export OXIDE_HOST='http://127.0.0.1:12220'"
-run_in_pane 5 "export OXIDE_TOKEN='oxide-spoof-001de000-05e4-4000-8000-000000004007'"
-run_in_pane 5 "../console/tools/populate_omicron_data.sh"
+run_in_pane 1 "set_pane_title 'seed data'"
+run_in_pane 1 "wait_for_up 12220" # nexus
+run_in_pane 1 "export OXIDE_HOST='http://127.0.0.1:12220'"
+run_in_pane 1 "export OXIDE_TOKEN='oxide-spoof-001de000-05e4-4000-8000-000000004007'"
+run_in_pane 1 "../console/tools/populate_omicron_data.sh"
 
 tmux attach -t omicron-console

--- a/tools/stop_api.sh
+++ b/tools/stop_api.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-cockroach quit --insecure --url postgresql://127.0.0.1:32221
-tmux kill-session -t omicron-console


### PR DESCRIPTION
See https://github.com/oxidecomputer/omicron/pull/2703. It's nice! Does most of what I was doing in the script automatically, and it will stay up to date because it's the same stack that's used for running integration tests.

I might add a third pane that tails the log file printed in pane 1, or at least add some documentation on how to get them.