### PR TITLE
WIP on making progress bars looks good in serial console

### DIFF
--- a/tools/deno/mock-serial-console.ts
+++ b/tools/deno/mock-serial-console.ts
@@ -1,4 +1,4 @@
-#! /usr/bin/env -S deno run --allow-run --allow-net
+#! /usr/bin/env -S deno run --watch --allow-run --allow-net
 import { delay } from 'https://deno.land/std@0.181.0/async/delay.ts'
 import { serve } from 'https://deno.land/std@0.181.0/http/server.ts'
 
@@ -7,10 +7,39 @@ import { serve } from 'https://deno.land/std@0.181.0/http/server.ts'
  * run this little server and configure Vite to proxy WS requests to it.
  */
 
+const enc = new TextEncoder()
+
 async function streamString(socket: WebSocket, s: string, delayMs = 50) {
   for (const c of s) {
-    socket.send(new TextEncoder().encode(c))
+    socket.send(enc.encode(c))
     await delay(delayMs)
+  }
+}
+
+// ANSI escape codes
+const RESET_FMT = '\x1b[0m' // reset all formatting
+const SET_GREEN = '\x1b[32m' // setting the foreground color to green
+const CURSOR_HOME = '\x1b[1G' // move cursor to the beginning of the line
+
+function generateProgressBar(progress: number) {
+  const width = 30
+  const filledWidth = Math.floor(progress * width)
+  const emptyWidth = width - filledWidth
+
+  const filledPart = SET_GREEN + '#'.repeat(filledWidth) + RESET_FMT
+  const emptyPart = '-'.repeat(emptyWidth)
+  const percentage = Math.floor(progress * 100)
+
+  return `[${filledPart}${emptyPart}] ${percentage}%`
+}
+
+async function displayProgressBar(socket: WebSocket) {
+  for (let progress = 0; progress <= 1; progress += 0.02) {
+    if (socket.readyState !== WebSocket.OPEN) return
+
+    const progressBar = generateProgressBar(progress)
+    socket.send(enc.encode(CURSOR_HOME + progressBar))
+    await delay(100)
   }
 }
 
@@ -22,10 +51,11 @@ async function serialConsole(req: Request) {
   console.log(`New client connected`)
 
   // send hello as a binary frame for xterm to display
-  socket.onopen = () => {
-    setTimeout(() => {
-      streamString(socket, 'Wake up Neo...')
-    }, 200)
+  socket.onopen = async () => {
+    await delay(200)
+    await streamString(socket, 'Wake up Neo...\n')
+    await displayProgressBar(socket)
+    await streamString(socket, '\n' + CURSOR_HOME + 'Done!\n' + CURSOR_HOME)
   }
 
   // echo back binary data


### PR DESCRIPTION
I have the mock sever displaying a progress bar. If the bar is wider than the terminal, it looks bad, as expected. However, I think James was seeing bad output if the window was _too wide_ also. Maybe the stream is filling out the line with whitespace first before resetting? My mock progress bar is not bothered by a too-wide screen. 

![2023-04-10-serial-console-progress-2](https://user-images.githubusercontent.com/3612203/230960888-193d9f17-8f71-4b87-8c15-33da9a001425.gif)
