### PR TITLE
Add instance ID to prop table and actions dropdown: fixes #1409

### DIFF
--- a/app/pages/project/instances/actions.tsx
+++ b/app/pages/project/instances/actions.tsx
@@ -76,6 +76,12 @@ export const useMakeInstanceActions = (
             !instanceCan.reboot(instance) && 'Only running instances can be rebooted',
         },
         {
+          label: 'Copy instance ID',
+          onActivate() {
+            window.navigator.clipboard.writeText(instance.id)
+          },
+        },
+        {
           label: 'View serial console',
           onActivate() {
             navigate(pb.serialConsole(instanceSelector))

--- a/app/pages/project/instances/instance/InstancePage.tsx
+++ b/app/pages/project/instances/instance/InstancePage.tsx
@@ -1,3 +1,4 @@
+import { format } from 'date-fns'
 import filesize from 'filesize'
 import { useMemo } from 'react'
 import type { LoaderFunctionArgs } from 'react-router-dom'
@@ -75,13 +76,26 @@ export function InstancePage() {
             <span className="text-secondary">{memory.value}</span>
             <span className="ml-1 text-quaternary"> {memory.unit}</span>
           </PropertiesTable.Row>
+          <PropertiesTable.Row label="status">
+            <InstanceStatusBadge status={instance.runState} />
+          </PropertiesTable.Row>
         </PropertiesTable>
         <PropertiesTable>
           <PropertiesTable.Row label="dns name">
             <span className="text-secondary">{instance.hostname || '–'}</span>
           </PropertiesTable.Row>
-          <PropertiesTable.Row label="status">
-            <InstanceStatusBadge status={instance.runState} />
+          <PropertiesTable.Row label="created">
+            <span className="text-secondary">
+              {format(instance.timeCreated, 'MMM d, yyyy')}{' '}
+            </span>
+            <span className="ml-1 text-quaternary">
+              {format(instance.timeCreated, 'p')}
+            </span>
+          </PropertiesTable.Row>
+          <PropertiesTable.Row label="id">
+            <span className="overflow-hidden text-ellipsis whitespace-nowrap text-secondary">
+              {instance.id}
+            </span>
           </PropertiesTable.Row>
         </PropertiesTable>
       </PropertiesTable.Group>

--- a/libs/ui/lib/properties-table/PropertiesTable.tsx
+++ b/libs/ui/lib/properties-table/PropertiesTable.tsx
@@ -21,7 +21,7 @@ export function PropertiesTable({ className, children }: PropertiesTableProps) {
     <div
       className={cn(
         className,
-        'properties-table grid min-w-min basis-6/12 divide-y rounded-lg border border-default children:p-3 children:border-secondary'
+        'properties-table grid min-w-min basis-6/12 divide-y rounded-lg border border-default children:p-3 children:pr-6 children:border-secondary'
       )}
     >
       {children}
@@ -38,7 +38,9 @@ PropertiesTable.Row = ({ label, children }: PropertiesTableRowProps) => (
     <span className="flex items-center">
       <Badge>{label}</Badge>
     </span>
-    <div className="flex items-center whitespace-nowrap pr-4 text-sans-md">{children}</div>
+    <div className="flex items-center overflow-hidden whitespace-nowrap pr-4 text-sans-md">
+      {children}
+    </div>
   </>
 )
 
@@ -56,7 +58,7 @@ PropertiesTable.Group = ({ children, className }: PropertiesTableGroupProps) => 
     <div
       className={cn(
         className,
-        'flex min-w-min md-:flex-col md-:first:children:rounded-b-none md-:first:children:border-b-secondary md-:last:children:rounded-t-none md-:last:children:border-t-0 lg+:space-x-4'
+        'flex min-w-min md-:flex-col md-:first:children:rounded-b-none md-:first:children:border-b-secondary md-:last:children:rounded-t-none md-:last:children:border-t-0 lg+:gap-x-4'
       )}
     >
       {children}


### PR DESCRIPTION
Also adds `dateCreated` — keeps things balanced and is useful to include.

<img width="605" alt="image" src="https://user-images.githubusercontent.com/4020798/235659670-0071b5f4-ce8b-4995-b31e-810d4be2ccec.png">

Truncates automatically when overflowing.