### PR TITLE
Bump simplebar to drop core-js dep, cut bundle by 5%

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "react-router-dom": "^6.9.0",
         "react-stately": "^3.20.0",
         "recharts": "^2.4.3",
-        "simplebar-react": "^2.4.3",
+        "simplebar-react": "^3.2.4",
         "tiny-invariant": "^1.2.0",
         "ts-dedent": "^2.2.0",
         "tslib": "^2.5.0",
@@ -2614,11 +2614,6 @@
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
-    },
-    "node_modules/@juggle/resize-observer": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
-      "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA=="
     },
     "node_modules/@ladle/react": {
       "version": "2.9.0",
@@ -5856,8 +5851,15 @@
     "node_modules/@types/lodash": {
       "version": "4.14.191",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
-      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
-      "dev": true
+      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ=="
+    },
+    "node_modules/@types/lodash-es": {
+      "version": "4.17.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.7.tgz",
+      "integrity": "sha512-z0ptr6UI10VlU6l5MYhGwS4mC8DZyYer2mCoyysZtSF7p26zOX8UpbrV0YpNYLGS8K4PUFIyEr62IMFFjveSiQ==",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/lodash.throttle": {
       "version": "4.1.7",
@@ -8103,16 +8105,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/core-js": {
-      "version": "3.26.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.26.1.tgz",
-      "integrity": "sha512-21491RRQVzUn0GGM9Z1Jrpr6PNPxPi+Za8OM9q4tksTSnlbXXGKK1nXNg/QvwFYettXvSX6zWKCtHHfjN4puyA==",
-      "hasInstallScript": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/core-js-compat": {
@@ -13518,15 +13510,16 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
-    },
-    "node_modules/lodash.memoize": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag=="
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -18028,30 +18021,26 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
-    "node_modules/simplebar": {
-      "version": "5.3.9",
-      "resolved": "https://registry.npmjs.org/simplebar/-/simplebar-5.3.9.tgz",
-      "integrity": "sha512-1vIIpjDvY9sVH14e0LGeiCiTFU3ILqAghzO6OI9axeG+mvU/vMSrvXeAXkBolqFFz3XYaY8n5ahH9MeP3sp2Ag==",
+    "node_modules/simplebar-core": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/simplebar-core/-/simplebar-core-1.2.4.tgz",
+      "integrity": "sha512-P+Sqshef4fq3++gQ82TgNYcgl3qZFSCP5jS2/8NMmw18oagXOijMzs1G+vm6RUY3oMvpwH3wGoqh9u6SyDjHfQ==",
       "dependencies": {
-        "@juggle/resize-observer": "^3.3.1",
+        "@types/lodash-es": "^4.17.6",
         "can-use-dom": "^0.1.0",
-        "core-js": "^3.0.1",
-        "lodash.debounce": "^4.0.8",
-        "lodash.memoize": "^4.1.2",
-        "lodash.throttle": "^4.1.1"
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21"
       }
     },
     "node_modules/simplebar-react": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/simplebar-react/-/simplebar-react-2.4.3.tgz",
-      "integrity": "sha512-Ep8gqAUZAS5IC2lT5RE4t1ZFUIVACqbrSRQvFV9a6NbVUzXzOMnc4P82Hl8Ak77AnPQvmgUwZS7aUKLyBoMAcg==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/simplebar-react/-/simplebar-react-3.2.4.tgz",
+      "integrity": "sha512-ogLN79e7JUm82wJChD7NSUB+4EHCFvDkjXpiu8hT1Alk7DnCekUWds61NXcsP9jC97KOgF5To/AVjYFbX0olgg==",
       "dependencies": {
-        "prop-types": "^15.6.1",
-        "simplebar": "^5.3.9"
+        "simplebar-core": "^1.2.4"
       },
       "peerDependencies": {
-        "react": "^0.14.9 || ^15.3.0 || ^16.0.0-rc || ^16.0 || ^17.0 || ^18.0.0",
-        "react-dom": "^0.14.9 || ^15.3.0 || ^16.0.0-rc || ^16.0 || ^17.0 || ^18.0.0"
+        "react": ">=16.8.0"
       }
     },
     "node_modules/slash": {
@@ -22488,11 +22477,6 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
-    "@juggle/resize-observer": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
-      "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA=="
-    },
     "@ladle/react": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/@ladle/react/-/react-2.9.0.tgz",
@@ -24940,8 +24924,15 @@
     "@types/lodash": {
       "version": "4.14.191",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
-      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
-      "dev": true
+      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ=="
+    },
+    "@types/lodash-es": {
+      "version": "4.17.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.7.tgz",
+      "integrity": "sha512-z0ptr6UI10VlU6l5MYhGwS4mC8DZyYer2mCoyysZtSF7p26zOX8UpbrV0YpNYLGS8K4PUFIyEr62IMFFjveSiQ==",
+      "requires": {
+        "@types/lodash": "*"
+      }
     },
     "@types/lodash.throttle": {
       "version": "4.1.7",
@@ -26638,11 +26629,6 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==",
       "dev": true
-    },
-    "core-js": {
-      "version": "3.26.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.26.1.tgz",
-      "integrity": "sha512-21491RRQVzUn0GGM9Z1Jrpr6PNPxPi+Za8OM9q4tksTSnlbXXGKK1nXNg/QvwFYettXvSX6zWKCtHHfjN4puyA=="
     },
     "core-js-compat": {
       "version": "3.26.0",
@@ -30592,15 +30578,16 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
-    },
-    "lodash.memoize": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag=="
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true
     },
     "lodash.merge": {
       "version": "4.6.2",
@@ -33777,26 +33764,23 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
-    "simplebar": {
-      "version": "5.3.9",
-      "resolved": "https://registry.npmjs.org/simplebar/-/simplebar-5.3.9.tgz",
-      "integrity": "sha512-1vIIpjDvY9sVH14e0LGeiCiTFU3ILqAghzO6OI9axeG+mvU/vMSrvXeAXkBolqFFz3XYaY8n5ahH9MeP3sp2Ag==",
+    "simplebar-core": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/simplebar-core/-/simplebar-core-1.2.4.tgz",
+      "integrity": "sha512-P+Sqshef4fq3++gQ82TgNYcgl3qZFSCP5jS2/8NMmw18oagXOijMzs1G+vm6RUY3oMvpwH3wGoqh9u6SyDjHfQ==",
       "requires": {
-        "@juggle/resize-observer": "^3.3.1",
+        "@types/lodash-es": "^4.17.6",
         "can-use-dom": "^0.1.0",
-        "core-js": "^3.0.1",
-        "lodash.debounce": "^4.0.8",
-        "lodash.memoize": "^4.1.2",
-        "lodash.throttle": "^4.1.1"
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21"
       }
     },
     "simplebar-react": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/simplebar-react/-/simplebar-react-2.4.3.tgz",
-      "integrity": "sha512-Ep8gqAUZAS5IC2lT5RE4t1ZFUIVACqbrSRQvFV9a6NbVUzXzOMnc4P82Hl8Ak77AnPQvmgUwZS7aUKLyBoMAcg==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/simplebar-react/-/simplebar-react-3.2.4.tgz",
+      "integrity": "sha512-ogLN79e7JUm82wJChD7NSUB+4EHCFvDkjXpiu8hT1Alk7DnCekUWds61NXcsP9jC97KOgF5To/AVjYFbX0olgg==",
       "requires": {
-        "prop-types": "^15.6.1",
-        "simplebar": "^5.3.9"
+        "simplebar-core": "^1.2.4"
       }
     },
     "slash": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "react-router-dom": "^6.9.0",
     "react-stately": "^3.20.0",
     "recharts": "^2.4.3",
-    "simplebar-react": "^2.4.3",
+    "simplebar-react": "^3.2.4",
     "tiny-invariant": "^1.2.0",
     "ts-dedent": "^2.2.0",
     "tslib": "^2.5.0",


### PR DESCRIPTION
Lol. Note the height of the bar changed, ~~we probably want to fix that?~~ and it is now correct. Ok.

### Before

<img width="812" alt="image" src="https://github.com/oxidecomputer/console/assets/3612203/9f09d809-85d0-4071-b882-fd273e3b43ff">

<img width="479" alt="image" src="https://github.com/oxidecomputer/console/assets/3612203/c3f83aaf-d7b1-4ddf-96ad-cb307ac219aa">

### After

<img width="816" alt="image" src="https://github.com/oxidecomputer/console/assets/3612203/c4278f3a-d488-4e35-a781-fc7f9087cbb5">

<img width="467" alt="image" src="https://github.com/oxidecomputer/console/assets/3612203/6dcc1c1c-35b3-4e0d-be4c-bcdb5aac2a30">
