### PR TITLE
Add `console.log` explaining expected 403 and 404

### DIFF
--- a/app/forms/image-upload.tsx
+++ b/app/forms/image-upload.tsx
@@ -486,7 +486,12 @@ export function CreateImageSideModalForm() {
           })
           .catch((e) => {
             // eat a 404 since that's what we want. anything else should still blow up
-            if (e.statusCode === 404) return null
+            if (e.statusCode === 404) {
+              console.log(
+                '/api/v1/images 404 is expected. It means the image name is not taken.'
+              )
+              return null
+            }
             throw e
           })
         if (image) {

--- a/app/layouts/helpers.tsx
+++ b/app/layouts/helpers.tsx
@@ -52,7 +52,9 @@ export const userLoader = async () => {
     // Need to prefetch this because every layout hits it when deciding whether
     // to show the silo/system picker. It's also fetched by the SystemLayout
     // loader to figure out whether to 404, but RQ dedupes the request.
-    apiQueryClient.prefetchQuery('systemPolicyView', {}),
+    apiQueryClient.fetchQuery('systemPolicyView', {}).catch(() => {
+      console.log('/api/v1/system/policy 403 is expected if user is not a fleet viewer.')
+    }),
   ])
   return null
 }

--- a/libs/api/errors.ts
+++ b/libs/api/errors.ts
@@ -34,13 +34,10 @@ const msgFromCode = (
 
 export function formatServerError(method: string, resp: ErrorResult): ErrorResult {
   // TODO: I don't like that this function works by modifying
-  // resp.error.message, which means the real message disappears. For now I'm
-  // logging it here before it gets modified, but eventually this should work
-  // altogether differently, maybe by preserving the original message while
-  // adding on a user-facing message that our error boundary can display.
-  if (process.env.NODE_ENV !== 'test') {
-    console.log('Error from API client: ', resp)
-  }
+  // resp.error.message, which means the real message disappears. Eventually
+  // this should work altogether differently, maybe by preserving the original
+  // message while adding on a user-facing message that our error boundary can
+  // display.
 
   // client error is a JSON parse or processing error and is highly unlikely to
   // be end-user readable


### PR DESCRIPTION
Closes #1465

<img width="647" alt="image" src="https://github.com/oxidecomputer/console/assets/3612203/bf206ebf-6561-473b-8a80-2d679f53a581">