### PR TITLE
Scripts for scp-ing console to the rack

### DIFF
--- a/tools/dogfood/find-nexus.sh
+++ b/tools/dogfood/find-nexus.sh
@@ -1,0 +1,10 @@
+#! /usr/bin/env bash
+
+set -e
+set -o pipefail
+
+ssh jeeves <<SSH_EOF
+  pilot tp login any # enter switch zone
+  pilot host exec -c "zoneadm list | grep oxz_nexus || true" 0-31
+  exit
+SSH_EOF

--- a/tools/dogfood/scp-assets.sh
+++ b/tools/dogfood/scp-assets.sh
@@ -1,0 +1,44 @@
+#! /usr/bin/env bash
+
+set -e
+set -o pipefail
+
+# What this does:
+#
+# 1. Download console tarball (restricts this to use on commits pushed to console main)
+# 2. SCP tarball to gimlet
+# 3. Over SSH:
+#    a. Extract tarball to tmp dir next to static dir
+#    b. Delete tarball
+#    c. Rename tmp dir to static dir
+#
+# Usage:
+#
+# First use find-nexus.sh to find the gimlet with the nexus zone, then run this
+#
+#   ./scp-assets.sh gc21 1234567890abcdef1234567890abcdef12345678
+
+GIMLET="$1"
+COMMIT="$2"
+
+NEXUS_DIR="/zone/oxz_nexus/root/var/nexus"
+STATIC_DIR="static"
+TMP_DIR="static-tmp"
+TARBALL_URL="https://dl.oxide.computer/releases/console/$COMMIT.tar.gz"
+TARBALL_FILE="/tmp/console.tar.gz"
+
+echo 'downloading console tarball...'
+curl --silent --show-error --fail --location --output $TARBALL_FILE $TARBALL_URL
+echo 'done. now scping it to the gimlet...'
+
+scp -r $TARBALL_FILE "$GIMLET:$NEXUS_DIR/"
+
+ssh $GIMLET <<SSH_EOF
+  cd $NEXUS_DIR
+  mkdir -p $TMP_DIR
+  tar xzf console.tar.gz -C $TMP_DIR
+  rm console.tar.gz
+  rm -rf static
+  mv static-tmp static
+  exit
+SSH_EOF


### PR DESCRIPTION
Not sure if this is a great idea, but it does feel like a great idea. We can trivially swap out the console on the fly in order to add things like debug prints in production when people are having an issue. There are two risks that I can think of

- We fuck it up and the console is broken
  - Also risk of being temporarily broken if changeover isn't fast enough (script is written to avoid this though)
- Confusion about what version is currently deployed. Dogfood reinstalls are announced, so at the very least we should announce if we update the console.