### PR TITLE
Skip empty chunks during image upload

### DIFF
--- a/app/forms/all-zeros.spec.ts
+++ b/app/forms/all-zeros.spec.ts
@@ -1,0 +1,30 @@
+import { isAllZeros } from './image-upload'
+
+function numberToUint8Array(num: number) {
+  const bytes = []
+  while (num > 0) {
+    bytes.unshift(num & 0xff)
+    // eslint-disable-next-line no-param-reassign
+    num >>= 4
+  }
+  return new Uint8Array(bytes)
+}
+
+test('isAllZeros', () => {
+  expect(isAllZeros('AAAA')).toBeTruthy()
+  expect(Array.from(Buffer.from('AAAA', 'base64'))).toEqual([0, 0, 0])
+
+  expect(isAllZeros('AAAB')).toBeFalsy()
+  expect(Array.from(Buffer.from('AAAB', 'base64'))).toEqual([0, 0, 1])
+
+  const allZeros = Buffer.alloc(20).toString('base64')
+  expect(isAllZeros(allZeros)).toBeTruthy()
+
+  const notAllZeros = Buffer.alloc(20, 1).toString('base64')
+  expect(isAllZeros(notAllZeros)).toBeFalsy()
+
+  for (let i = 1; i < 100000; i++) {
+    const s = Buffer.from(numberToUint8Array(i)).toString('base64')
+    expect(isAllZeros(s)).toBeFalsy()
+  }
+})

--- a/app/pages/__tests__/image-upload.e2e.ts
+++ b/app/pages/__tests__/image-upload.e2e.ts
@@ -12,7 +12,9 @@ async function chooseFile(page: Page, size = 5 * MiB) {
   await fileChooser.setFiles({
     name: 'my-image.iso',
     mimeType: 'application/octet-stream',
-    buffer: Buffer.alloc(size),
+    // fill with nonzero content, otherwise we'll skip the whole thing, which
+    // makes the test too fast for playwright to catch anything
+    buffer: Buffer.alloc(size, 'a'),
   })
 }
 


### PR DESCRIPTION
Most OS disks (e.g. Debian's images) are mostly zero, most of the time. Disks in Crucible start out all-zero, so we only need to write chunks of disks that contain anything else.

Similar behavior in recently-landed image upload in the CLI: https://github.com/oxidecomputer/oxide.rs/blob/a04fc60d6d80060e90192c966315be91acabfb35/cli/src/cmd_disk.rs#L405

I tested this with a local Nexus uploading a Debian image, which is 2 GiB in size, but contains only 770 MiB of actual data:

```
$ du -sh ~/tmp/disk.raw
770M    /Users/iliana/tmp/disk.raw
```

Uploading the image was noticeably faster, with points at which the progress was filling up rapidly. Firefox tells me it uploaded a little over 1 GiB, which is about right. The image also booted just fine, although I have not gone as far as taking a checksum of the resulting image yet.

![image](https://github.com/oxidecomputer/console/assets/52814/c16a4151-7c6d-4cca-ab60-ae432b6b9647)

The test of whether a chunk is all-zero is kind of a hack? A regex on the base64 output is awful but seemed to be the least intrusive way to do this, as this allows the content to be read from the `File` into our code only once. Performance does not appear to be abysmal but I could be wrong.