### PR TITLE
Try caching Playwright install

### DIFF
--- a/.github/workflows/lintBuildTest.yml
+++ b/.github/workflows/lintBuildTest.yml
@@ -88,11 +88,11 @@ jobs:
       # Install browser binaries & OS dependencies if cache missed
       - name: Install Playwright
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: sudo apt-get update && npx playwright install --with-deps
+        run: npx playwright install --with-deps
       # Install only the OS dependencies if cache hit
       - name: 🏗 Install Playwright OS dependencies
         if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: sudo apt-get update && npx playwright install-deps
+        run: npx playwright install-deps
       - name: Run Playwright browser tests
         run: npx playwright test --workers=2 --project=${{matrix.browser}}
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
Sometimes the install step takes 45 seconds, sometimes it takes several minutes. If it's usually 45 seconds then there's not much point in caching. The tests take about 4 minutes anyway.