### PR TITLE
Fix firewall rule host field help label and help text

### DIFF
--- a/app/forms/firewall-rules-create.tsx
+++ b/app/forms/firewall-rules-create.tsx
@@ -109,7 +109,7 @@ type CommonFieldsProps = {
   control: Control<FirewallRuleValues>
 }
 
-function getHostValueProps(hostType: VpcFirewallRuleHostFilter['type']) {
+function getFilterValueProps(hostType: VpcFirewallRuleHostFilter['type']) {
   switch (hostType) {
     case 'vpc':
       return { label: 'VPC name' }
@@ -194,7 +194,12 @@ export const CommonFields = ({ error, control }: CommonFieldsProps) => {
         required
         control={targetForm.control}
       />
-      <TextField name="value" label="Target name" required control={targetForm.control} />
+      <TextField
+        name="value"
+        {...getFilterValueProps(targetForm.watch('type'))}
+        required
+        control={targetForm.control}
+      />
 
       <div className="flex justify-end">
         <Button
@@ -277,7 +282,7 @@ export const CommonFields = ({ error, control }: CommonFieldsProps) => {
           not a block. */}
       <TextField
         name="value"
-        {...getHostValueProps(hostForm.watch('type'))}
+        {...getFilterValueProps(hostForm.watch('type'))}
         required
         control={hostForm.control}
       />

--- a/app/pages/project/networking/VpcPage/VpcPage.e2e.ts
+++ b/app/pages/project/networking/VpcPage/VpcPage.e2e.ts
@@ -76,12 +76,12 @@ test.describe('VpcPage', () => {
 
     // add target VPC "my-target-vpc"
     await page.locator('role=button[name="Target type"]').click()
-    await page.locator('role=option[name="VPC"]').click()
-    await page.fill('role=textbox[name="Target name"]', 'my-target-vpc')
+    await page.locator('role=option[name="IP"]').click()
+    await page.fill('role=textbox[name="IP address"]', '192.168.0.1')
     await page.locator('text="Add target"').click()
 
     // target is added to targets table
-    await expect(page.locator('td:has-text("my-target-vpc")')).toBeVisible()
+    await expect(page.locator('td:has-text("192.168.0.1")')).toBeVisible()
 
     // add host filter instance "host-filter-instance"
     await page.locator('role=button[name="Host type"]').click()
@@ -111,7 +111,7 @@ test.describe('VpcPage', () => {
     // table refetches and now includes the new rule as well as the originals
     await expect(page.locator('td >> text="my-new-rule"')).toBeVisible()
     // target shows up in target cell
-    await expect(page.locator('text=vpcmy-target-vpc')).toBeVisible()
+    await expect(page.locator('text=ip192.168.0.1')).toBeVisible()
     // other stuff filled out shows up in the filters column
     await expect(page.locator('text=instancehost-filter-instanceUDP123-456')).toBeVisible()
 


### PR DESCRIPTION
Closes #1441

Definite improvement. I noticed the listbox is not resetting like it's supposed to. This bug is already there on main, we just don't notice it because the label on the input doesn't change. So I'm going to say this is mergeable as-is since it doesn't _introduce_ the bug and make a separate issue for the bug: https://github.com/oxidecomputer/console/issues/1499.

![2023-05-17-firewall-rule-host](https://github.com/oxidecomputer/console/assets/3612203/058178ce-de80-4071-bfde-a8f260960e85)

### Same type reset bug on main

![2023-05-17-firewall-rule-host-bug](https://github.com/oxidecomputer/console/assets/3612203/2e622bac-1a62-480a-a023-1306ab6e068b)

