### PR TITLE
Use context from the *most recent* output sent to the console for the interactive view.

### DIFF
--- a/app/pages/project/instances/instance/SerialConsolePage.tsx
+++ b/app/pages/project/instances/instance/SerialConsolePage.tsx
@@ -56,7 +56,7 @@ export function SerialConsolePage() {
         secure: window.location.protocol === 'https:',
         host: window.location.host + pathPrefix,
         path: { instance },
-        query: { project, fromStart: 0 },
+        query: { project, mostRecent: 262144 },
       })
       ws.current.binaryType = 'arraybuffer' // important!
     }


### PR DESCRIPTION
Using the `from_start` parameter from nexus[^1] really only makes sense for the non-streaming GET endpoint[^2], and I'm working on removing it from Nexus (omicron#3147) and the CLI (oxide.rs#190) accordingly.

[^1]: A non-interactive web console that allows the user to scrub through a timeline of the first megabyte of output using the GET API would be a more appropriate way to present that data; the websocket stream only really needs it for showing what was already there before you arrived.

[^2]: It's needed in propolis-server for the seamless-console handoff to work, but need not be exposed at the nexus level.

As it stands, if an instance lives long enough to output more than 2MiB to its serial port, asking for the stream with ?`from_start=0` will cause it to unconditionally fail. (more details in this comment https://github.com/oxidecomputer/propolis/issues/409#issuecomment-1552351154)

16KiB chosen somewhat arbitrarily here, enough for either eight and a half screenfuls of 80x24 or one screenful of 80x24 with an average seven and a half invisible bytes per character (i.e. ANSI control sequences and/or UTF-8 multi-byte encoding)