### PR TITLE
Error if renaming a project to a name that already exists

### DIFF
--- a/libs/api-mocks/msw/handlers.ts
+++ b/libs/api-mocks/msw/handlers.ts
@@ -59,6 +59,7 @@ export const handlers = makeHandlers({
     const project = lookup.project({ ...path })
     if (body.name) {
       project.name = body.name
+      errIfExists(db.projects, { name: body.name })
     }
     project.description = body.description || ''
 


### PR DESCRIPTION
Little bug I found while testing error states. 