### PR TITLE
Get already exists resource name from API error message if possible

### DIFF
--- a/app/test/e2e/instance-create.e2e.ts
+++ b/app/test/e2e/instance-create.e2e.ts
@@ -34,7 +34,7 @@ test('can create an instance', async ({ page }) => {
   await page.getByRole('button', { name: 'Image' }).click()
   await page.getByRole('option', { name: images[2].name }).click()
 
-  await page.locator('button:has-text("Create instance")').click()
+  await page.getByRole('button', { name: 'Create instance' }).click()
 
   await expect(page).toHaveURL(`/projects/mock-project/instances/${instanceName}/storage`)
 
@@ -52,4 +52,13 @@ test('can create an instance', async ({ page }) => {
   await page.fill('input[name=name]', instanceName)
   await page.locator('button:has-text("Create instance")').click()
   await page.getByText('Instance name already exists')
+})
+
+test('with disk name already taken', async ({ page }) => {
+  await page.goto('/projects/mock-project/instances-new')
+  await page.fill('input[name=name]', 'my-instnace')
+  await page.fill('input[name=bootDiskName]', 'disk-1')
+
+  await page.getByRole('button', { name: 'Create instance' }).click()
+  await expectVisible(page, ['text=Disk name already exists'])
 })

--- a/libs/api-mocks/msw/handlers.ts
+++ b/libs/api-mocks/msw/handlers.ts
@@ -37,7 +37,7 @@ export const handlers = makeHandlers({
 
   projectList: (params) => paginated(params.query, db.projects),
   projectCreate({ body }) {
-    errIfExists(db.projects, { name: body.name })
+    errIfExists(db.projects, { name: body.name }, 'project')
 
     const newProject: Json<Api.Project> = {
       id: uuid(),
@@ -256,7 +256,7 @@ export const handlers = makeHandlers({
   instanceCreate({ body, query }) {
     const project = lookup.project(query)
 
-    errIfExists(db.instances, { name: body.name, project_id: project.id })
+    errIfExists(db.instances, { name: body.name, project_id: project.id }, 'instance')
 
     const instanceId = uuid()
 
@@ -266,7 +266,7 @@ export const handlers = makeHandlers({
      */
     for (const diskParams of body.disks || []) {
       if (diskParams.type === 'create') {
-        errIfExists(db.disks, { name: diskParams.name, project_id: project.id })
+        errIfExists(db.disks, { name: diskParams.name, project_id: project.id }, 'disk')
         errIfInvalidDiskSize(diskParams)
       } else {
         lookup.disk({ ...query, disk: diskParams.name })

--- a/libs/api-mocks/msw/util.ts
+++ b/libs/api-mocks/msw/util.ts
@@ -81,14 +81,22 @@ export const NotImplemented = () => {
 
 export const errIfExists = <T extends Record<string, unknown>>(
   collection: T[],
-  match: Partial<{ [key in keyof T]: T[key] }>
+  match: Partial<{ [key in keyof T]: T[key] }>,
+  resourceLabel = 'resource'
 ) => {
   if (
     collection.some((item) =>
       Object.entries(match).every(([key, value]) => item[key] === value)
     )
   ) {
-    throw json({ error_code: 'ObjectAlreadyExists' }, { status: 400 })
+    const name = 'name' in match ? match.name : 'id' in match ? match.id : '<resource>'
+    throw json(
+      {
+        error_code: 'ObjectAlreadyExists',
+        message: `already exists: ${resourceLabel} "${name}"`,
+      },
+      { status: 400 }
+    )
   }
 }
 

--- a/libs/api/__tests__/errors.spec.ts
+++ b/libs/api/__tests__/errors.spec.ts
@@ -18,7 +18,7 @@ const alreadyExists = () => ({
   error: {
     requestId: '2',
     errorCode: 'ObjectAlreadyExists',
-    message: 'whatever',
+    message: 'already exists: instance "instance-name"',
   },
 })
 
@@ -55,23 +55,34 @@ describe('formatServerError', () => {
     )
   })
 
-  it('uses message from code map if error code matches', () => {
-    expect(formatServerError('FakeThingCreate', alreadyExists()).error.message).toEqual(
+  it('pulls from method name if message does not work', () => {
+    const error = alreadyExists()
+    error.error.message = 'whatever'
+    expect(formatServerError('FakeThingCreate', error).error.message).toEqual(
       'Thing name already exists'
     )
   })
 
+  it('uses message from code map if error code matches', () => {
+    expect(formatServerError('FakeThingCreate', alreadyExists()).error.message).toEqual(
+      'Instance name already exists'
+    )
+  })
+
   it('falls back to server error message if code not found', () => {
-    expect(formatServerError('', alreadyExists()).error.message).toEqual('whatever')
+    const error = alreadyExists()
+    error.error.message = 'whatever'
+    expect(formatServerError('', error).error.message).toEqual('whatever')
   })
 })
 
 it.each([
-  ['projectCreate', 'project'],
-  ['projectCreate', 'project'],
-  ['instanceNetworkInterfaceCreate', 'interface'],
-  ['instanceNetworkInterfaceCreate', 'interface'],
-  ['doesNotContainC-reate', null],
-])('getResourceName gets resource names', (method, resource) => {
-  expect(getResourceName(method)).toEqual(resource)
+  ['projectCreate', '', 'project'],
+  ['projectCreate', 'already exists: project "abc"', 'project'],
+  ['instanceCreate', 'already exists: disk "abc"', 'disk'],
+  ['instanceNetworkInterfaceCreate', '', 'interface'],
+  ['instanceNetworkInterfaceCreate', 'already exists: something else', 'something else'],
+  ['doesNotContainC-reate', '', null],
+])('getResourceName gets resource names', (method, message, resource) => {
+  expect(getResourceName(method, message)).toEqual(resource)
 })


### PR DESCRIPTION
Closes https://github.com/oxidecomputer/console/issues/1471

This works, but I hated working with the code and the tests so much that I want to give it another half hour and try to clean it up.