### PR TITLE
Move toast to bottom left corner

### DIFF
--- a/app/hooks/use-toast/ToastStack.tsx
+++ b/app/hooks/use-toast/ToastStack.tsx
@@ -17,7 +17,7 @@ export function ToastStack() {
   })
 
   return (
-    <div className="fixed bottom-4 left-4 z-50 flex flex-col items-end space-y-2">
+    <div className="pointer-events-auto fixed bottom-4 left-4 z-50 flex flex-col items-end space-y-2">
       {transition((style, item) => (
         <animated.div
           style={{


### PR DESCRIPTION
Fixes #1518

Moved out of the way of the side modal action buttons and overriding the inherited `pointer-events-none` when a modal is open.