### PR TITLE
`type=number` inputs use actual numbers

### DIFF
--- a/app/forms/firewall-rules-create.tsx
+++ b/app/forms/firewall-rules-create.tsx
@@ -30,7 +30,7 @@ import { useVpcSelector } from 'app/hooks'
 
 export type FirewallRuleValues = {
   enabled: boolean
-  priority: string
+  priority: number
   name: string
   description: string
   action: VpcFirewallRule['action']
@@ -54,7 +54,7 @@ export const valuesToRuleUpdate = (values: FirewallRuleValues): VpcFirewallRuleU
     ports: values.ports,
     protocols: values.protocols,
   },
-  priority: parseInt(values.priority, 10),
+  priority: values.priority,
   targets: values.targets,
 })
 
@@ -63,7 +63,7 @@ const defaultValues: FirewallRuleValues = {
   name: '',
   description: '',
 
-  priority: '',
+  priority: 0,
   action: 'allow',
   direction: 'inbound',
 

--- a/app/forms/firewall-rules-edit.tsx
+++ b/app/forms/firewall-rules-edit.tsx
@@ -35,7 +35,7 @@ export function EditFirewallRuleForm({
     name: originalRule.name,
     description: originalRule.description,
 
-    priority: originalRule.priority.toString(),
+    priority: originalRule.priority,
     action: originalRule.action,
     direction: originalRule.direction,
 

--- a/app/forms/instance-create.tsx
+++ b/app/forms/instance-create.tsx
@@ -138,12 +138,8 @@ export function CreateInstanceForm() {
 
         if (values['type'] === 'custom') {
           instance = {
-            memory:
-              typeof values.memory === 'string'
-                ? parseInt(values.memory, 10)
-                : values.memory,
-            ncpus:
-              typeof values.ncpus === 'string' ? parseInt(values.ncpus, 10) : values.ncpus,
+            memory: values.memory,
+            ncpus: values.ncpus,
           }
         } else if (preset) {
           instance = {

--- a/libs/ui/lib/text-input/TextInput.tsx
+++ b/libs/ui/lib/text-input/TextInput.tsx
@@ -66,20 +66,6 @@ export const TextInput = React.forwardRef<
   )
 })
 
-// TODO: do this properly: extract a NumberField that styles the up and down
-// buttons for when we do want them *and* add a flag to hide them using
-// appearance-textfield
-export const NumberInput = ({
-  fieldClassName,
-  ...props
-}: Omit<TextInputBaseProps, 'type'>) => (
-  <TextInput
-    type="number"
-    {...props}
-    fieldClassName={cn(fieldClassName, 'appearance-textfield')}
-  />
-)
-
 type HintProps = {
   // ID required as a reminder to pass aria-describedby on TextField
   id: string


### PR DESCRIPTION
I kind of hate it, but it does work — it makes the calling code simpler. Features/annoying characteristics:

- Non-numeric characters are ignored
  - The browser is supposed to handle this for you, but in Firefox it does not, so I handle it explicitly.
- Field cannot be empty. If you press backspace on a single digit, it becomes zero. If you then type a digit, it becomes that digit.
  - Kinda weird, but unfortunately a necessary consequence of the source of truth being a number. If we really hate this, we can go the other way, leave it as a string, and leave it to the calling code to handle the empty string case. I think that would be more error-prone though — we don't have time for that.