### PR TITLE
Confirm delete hook

### DIFF
--- a/app/components/ConfirmDelete.tsx
+++ b/app/components/ConfirmDelete.tsx
@@ -50,16 +50,6 @@ export function useConfirmDeleteModal() {
     setIsOpen(false)
   }
 
-  const createModal = () => (
-    <ConfirmDeleteModal
-      isOpen={isOpen}
-      onDismiss={() => setIsOpen(false)}
-      onAction={handleAction}
-      resourceName={(message && message.resourceName) || ''}
-      warning={message && message.warning ? message.warning : undefined}
-    />
-  )
-
   return {
     isOpen,
     shouldConfirmDelete: (fn: () => void, message: ModalMessageProps) => {
@@ -67,6 +57,14 @@ export function useConfirmDeleteModal() {
       setMessage(message)
       setIsOpen(true)
     },
-    ConfirmDeleteModal: createModal,
+    confirmDeleteModal: (
+      <ConfirmDeleteModal
+        isOpen={isOpen}
+        onDismiss={() => setIsOpen(false)}
+        onAction={handleAction}
+        resourceName={(message && message.resourceName) || ''}
+        warning={message && message.warning ? message.warning : undefined}
+      />
+    ),
   }
 }

--- a/app/pages/project/snapshots/SnapshotsPage.tsx
+++ b/app/pages/project/snapshots/SnapshotsPage.tsx
@@ -61,7 +61,7 @@ export function SnapshotsPage() {
     },
   })
 
-  const { shouldConfirmDelete, ConfirmDeleteModal } = useConfirmDeleteModal()
+  const { shouldConfirmDelete, confirmDeleteModal } = useConfirmDeleteModal()
 
   const makeActions = (snapshot: Snapshot): MenuAction[] => [
     {
@@ -100,7 +100,7 @@ export function SnapshotsPage() {
         <Column accessor="size" cell={SizeCell} />
         <Column accessor="timeCreated" id="Created" cell={DateCell} />
       </Table>
-      <ConfirmDeleteModal />
+      {confirmDeleteModal}
       <Outlet />
     </>
   )


### PR DESCRIPTION
Added a component and hook for a confirm delete modal. Otherwise replicating the code for managing this everywhere we have a delete action would be a _paaaaain_.

![CleanShot 2023-06-14 at 15 28 02](https://github.com/oxidecomputer/console/assets/4020798/386f4118-bb91-4eb3-9f2a-c17f21eddcde)
