### PR TITLE
Add title to sled detail page

### DIFF
--- a/app/routes.tsx
+++ b/app/routes.tsx
@@ -148,6 +148,7 @@ export const routes = createRoutesFromElements(
           path="inventory/sleds/:sledId"
           element={<SledPage />}
           loader={SledPage.loader}
+          handle={{ crumb: 'Sleds' }}
         >
           <Route index element={<Navigate to="instances" replace />} />
           <Route


### PR DESCRIPTION
Fixes #1597 

@benjaminleonard given the sleds page uses a UUID parameter I just left the title as `Sleds` instead of putting in the actual UUID. 