### PR TITLE
Don't try to fetch sleds on silo utilization (fix 403)

### DIFF
--- a/app/components/SystemMetric.tsx
+++ b/app/components/SystemMetric.tsx
@@ -56,7 +56,7 @@ type SystemMetricProps = {
   /** Should be statically defined or memoized to avoid extra renders */
   valueTransform?: (n: number) => number
   /** hard-coded max y */
-  capacity: number
+  capacity: number | undefined
   refetchInterval?: number | false
 }
 
@@ -138,7 +138,7 @@ export function SystemMetric({
             unit={unit !== 'count' ? unit : undefined}
           />
         </div>
-        {firstPoint && lastPoint && (
+        {firstPoint && lastPoint && capacity !== undefined && (
           <div className="mt-3 flex min-w-min flex-col gap-3 lg+:flex-row">
             <MetricStatistic
               label="In-use"

--- a/app/pages/SiloUtilizationPage.tsx
+++ b/app/pages/SiloUtilizationPage.tsx
@@ -9,10 +9,7 @@ import { UtilizationPage } from './system/CapacityUtilizationPage'
 const toListboxItem = (x: { name: string; id: string }) => ({ label: x.name, value: x.id })
 
 SiloUtilizationPage.loader = async () => {
-  await Promise.all([
-    apiQueryClient.prefetchQuery('projectList', {}),
-    ...UtilizationPage.getLoaderPromises(),
-  ])
+  await apiQueryClient.prefetchQuery('projectList', {})
   return null
 }
 

--- a/app/test/e2e/utilization.e2e.ts
+++ b/app/test/e2e/utilization.e2e.ts
@@ -10,6 +10,8 @@ test('System utilization', async ({ page }) => {
     page.getByText('Disk capacity'),
     page.getByText('CPU capacity'),
     page.getByText('Memory capacity'),
+    // stats under the graph which require capacity info
+    page.getByText('In-use').first(),
   ])
 })
 
@@ -20,5 +22,7 @@ test('Silo utilization', async ({ page }) => {
     page.getByText('Disk capacity'),
     page.getByText('CPU capacity'),
     page.getByText('Memory capacity'),
+    // stats under the graph which require capacity info
+    page.getByText('In-use'),
   ])
 })

--- a/libs/api/util.ts
+++ b/libs/api/util.ts
@@ -95,9 +95,15 @@ export const FLEET_ID = '001de000-1334-4000-8000-000000000000'
 const TBtoTiB = 0.909
 const FUDGE = 0.7
 
+export type Capacity = {
+  disk_tib: number
+  ram_gib: number
+  cpu: number
+}
+
 export function totalCapacity(
   sleds: Pick<Sled, 'usableHardwareThreads' | 'usablePhysicalRam'>[]
-) {
+): Capacity {
   return {
     disk_tib: Math.ceil(FUDGE * 32 * TBtoTiB), // TODO: make more real
     ram_gib: Math.ceil(bytesToGiB(FUDGE * sumBy(sleds, (s) => s.usablePhysicalRam))),


### PR DESCRIPTION
User doesn't necessarily (probably does not) have fleet viewer permission required to fetch sleds. Also artificial silo capacity limits are going to be what's relevant here anyway. When we get that, we can fetch it at the page level and pass it in.