### PR TITLE
Fix: chart tooltip didn't show up on points with value=0

### DIFF
--- a/app/components/TimeSeriesChart.tsx
+++ b/app/components/TimeSeriesChart.tsx
@@ -75,7 +75,7 @@ function renderTooltip(props: TooltipProps<number, string>, unit?: string) {
     name,
     payload: { timestamp, value },
   } = payload[0]
-  if (!timestamp || !value) return null
+  if (!timestamp || typeof value !== 'number') return null
   return (
     <div className="rounded border outline-0 text-sans-md text-tertiary bg-raise border-secondary elevation-2">
       <div className="border-b py-2 px-3 pr-6 border-secondary">


### PR DESCRIPTION
JavaScript!

### Bug on dogfood

![2023-06-29-metrics-chart-bug](https://github.com/oxidecomputer/console/assets/3612203/ebe37136-ffc5-4d71-88e3-df189256ba33)

### Fix demo

![2023-06-29-metrics-chart-bug-fix](https://github.com/oxidecomputer/console/assets/3612203/7a75cb6f-c301-4835-a534-734fe7e1c54e)
