### PR TITLE
Bump recharts to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "react-merge-refs": "^2.0.2",
         "react-router-dom": "^6.11.2",
         "react-stately": "^3.23.0",
-        "recharts": "^2.4.3",
+        "recharts": "^2.7.2",
         "simplebar-react": "^3.2.4",
         "tiny-invariant": "^1.2.0",
         "ts-dedent": "^2.2.0",
@@ -17240,9 +17240,9 @@
       }
     },
     "node_modules/react-resize-detector": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-7.1.2.tgz",
-      "integrity": "sha512-zXnPJ2m8+6oq9Nn8zsep/orts9vQv3elrpA+R8XTcW7DVVUJ9vwDwMXaBtykAYjMnkCIaOoK9vObyR7ZgFNlOw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-8.1.0.tgz",
+      "integrity": "sha512-S7szxlaIuiy5UqLhLL1KY3aoyGHbZzsTpYal9eYMwCyKqoqoVLCmIgAgNyIM1FhnP2KyBygASJxdhejrzjMb+w==",
       "dependencies": {
         "lodash": "^4.17.21"
       },
@@ -17424,16 +17424,16 @@
       }
     },
     "node_modules/recharts": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.4.3.tgz",
-      "integrity": "sha512-/hkRHTQShEOKDYd2OlKLIvGA0X9v/XVO/mNeRoDHg0lgFRL2KbGzeqVnStI3mMfORUZ6Hak4JbQ+uDiin1Foqg==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.7.2.tgz",
+      "integrity": "sha512-HMKRBkGoOXHW+7JcRa6+MukPSifNtJlqbc+JreGVNA407VLE/vOP+8n3YYjprDVVIF9E2ZgwWnL3D7K/LUFzBg==",
       "dependencies": {
         "classnames": "^2.2.5",
         "eventemitter3": "^4.0.1",
         "lodash": "^4.17.19",
         "react-is": "^16.10.2",
-        "react-resize-detector": "^7.1.2",
-        "react-smooth": "^2.0.1",
+        "react-resize-detector": "^8.0.4",
+        "react-smooth": "^2.0.2",
         "recharts-scale": "^0.4.4",
         "reduce-css-calc": "^2.1.8",
         "victory-vendor": "^36.6.8"
@@ -33490,9 +33490,9 @@
       }
     },
     "react-resize-detector": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-7.1.2.tgz",
-      "integrity": "sha512-zXnPJ2m8+6oq9Nn8zsep/orts9vQv3elrpA+R8XTcW7DVVUJ9vwDwMXaBtykAYjMnkCIaOoK9vObyR7ZgFNlOw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-8.1.0.tgz",
+      "integrity": "sha512-S7szxlaIuiy5UqLhLL1KY3aoyGHbZzsTpYal9eYMwCyKqoqoVLCmIgAgNyIM1FhnP2KyBygASJxdhejrzjMb+w==",
       "requires": {
         "lodash": "^4.17.21"
       }
@@ -33623,16 +33623,16 @@
       }
     },
     "recharts": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.4.3.tgz",
-      "integrity": "sha512-/hkRHTQShEOKDYd2OlKLIvGA0X9v/XVO/mNeRoDHg0lgFRL2KbGzeqVnStI3mMfORUZ6Hak4JbQ+uDiin1Foqg==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.7.2.tgz",
+      "integrity": "sha512-HMKRBkGoOXHW+7JcRa6+MukPSifNtJlqbc+JreGVNA407VLE/vOP+8n3YYjprDVVIF9E2ZgwWnL3D7K/LUFzBg==",
       "requires": {
         "classnames": "^2.2.5",
         "eventemitter3": "^4.0.1",
         "lodash": "^4.17.19",
         "react-is": "^16.10.2",
-        "react-resize-detector": "^7.1.2",
-        "react-smooth": "^2.0.1",
+        "react-resize-detector": "^8.0.4",
+        "react-smooth": "^2.0.2",
         "recharts-scale": "^0.4.4",
         "reduce-css-calc": "^2.1.8",
         "victory-vendor": "^36.6.8"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "react-merge-refs": "^2.0.2",
     "react-router-dom": "^6.11.2",
     "react-stately": "^3.23.0",
-    "recharts": "^2.4.3",
+    "recharts": "^2.7.2",
     "simplebar-react": "^3.2.4",
     "tiny-invariant": "^1.2.0",
     "ts-dedent": "^2.2.0",


### PR DESCRIPTION
I had been holding off on this out of fear, but everything seems to work fine. Our current is only from February, so it's not _that_ old. There are some interesting bugfixes in the [release notes](https://github.com/recharts/recharts/releases), though nothing I can see that fixes issues we're aware of.