### PR TITLE
Fetch 3000 data points in the graphs

### DIFF
--- a/app/components/SystemMetric.tsx
+++ b/app/components/SystemMetric.tsx
@@ -46,7 +46,10 @@ export function SiloMetric({
   // Fetch multiple pages if 10k is not enough? That's a bit much.
   const inRange = useApiQuery(
     'siloMetric',
-    { path: { metricName }, query: { project, startTime, endTime } },
+    {
+      path: { metricName },
+      query: { project, startTime, endTime, limit: 3000 },
+    },
     { keepPreviousData: true }
   )
 
@@ -123,7 +126,10 @@ export function SystemMetric({
   // Fetch multiple pages if 10k is not enough? That's a bit much.
   const inRange = useApiQuery(
     'systemMetric',
-    { path: { metricName }, query: { silo, startTime, endTime } },
+    {
+      path: { metricName },
+      query: { silo, startTime, endTime, limit: 3000 },
+    },
     { keepPreviousData: true }
   )
 

--- a/app/pages/project/instances/instance/tabs/MetricsTab.tsx
+++ b/app/pages/project/instances/instance/tabs/MetricsTab.tsx
@@ -38,7 +38,7 @@ function DiskMetric({
     'diskMetricsList',
     {
       path: { disk, metric },
-      query: { project, startTime, endTime, limit: 1000 },
+      query: { project, startTime, endTime, limit: 3000 },
     },
     // avoid graphs flashing blank while loading when you change the time
     { keepPreviousData: true }


### PR DESCRIPTION
It doesn't fundamentally solve the problem but it buys us time to think about it.

Closes #1626 

The default in Dropshot, which we are not overriding in Nexus, is in fact 100, not 1000.

https://github.com/oxidecomputer/dropshot/blame/904d53019896a7efe4f699520022614195c29cb0/dropshot/src/server.rs#L129