### PR TITLE
Remove properties table from inventory page

### DIFF
--- a/app/pages/system/inventory/InventoryPage.tsx
+++ b/app/pages/system/inventory/InventoryPage.tsx
@@ -1,7 +1,5 @@
-import { format } from 'date-fns'
-
 import { apiQueryClient, useApiQuery } from '@oxide/api'
-import { Badge, PageHeader, PageTitle, PropertiesTable, Racks24Icon } from '@oxide/ui'
+import { PageHeader, PageTitle, Racks24Icon } from '@oxide/ui'
 
 import { RouteTabs, Tab } from 'app/components/RouteTabs'
 import { pb } from 'app/util/path-builder'
@@ -17,7 +15,6 @@ export function InventoryPage() {
   const { data: racks } = useApiQuery('rackList', { query: { limit: 10 } })
   const rack = racks?.items[0]
 
-  // TODO: Add loading state
   if (!rack) return null
 
   return (
@@ -25,28 +22,6 @@ export function InventoryPage() {
       <PageHeader>
         <PageTitle icon={<Racks24Icon />}>Inventory</PageTitle>
       </PageHeader>
-
-      <PropertiesTable.Group className="mb-16 -mt-8">
-        <PropertiesTable>
-          <PropertiesTable.Row label="rack id">
-            <span className="text-secondary">{rack.id}</span>
-          </PropertiesTable.Row>
-          <PropertiesTable.Row label="location">
-            <span className="text-secondary">Emeryville, CA</span>
-            {/* <span className="ml-1 text-quaternary"> CA</span> */}
-          </PropertiesTable.Row>
-        </PropertiesTable>
-        <PropertiesTable>
-          <PropertiesTable.Row label="installed">
-            <span className="text-secondary">
-              {format(rack.timeCreated, 'MMM d, yyyy')}
-            </span>
-          </PropertiesTable.Row>
-          <PropertiesTable.Row label="status">
-            <Badge>Active</Badge>
-          </PropertiesTable.Row>
-        </PropertiesTable>
-      </PropertiesTable.Group>
 
       <RouteTabs fullWidth>
         <Tab to={pb.sledInventory()}>Sleds</Tab>


### PR DESCRIPTION
The properties table in the inventory page was all fake data except the rack id. Just removing it for now. 