### PR TITLE
Remove `invariant` on disk metrics, fix instance disks prefetch

### DIFF
--- a/app/test/e2e/instance/attach-disk.e2e.ts
+++ b/app/test/e2e/instance/attach-disk.e2e.ts
@@ -28,9 +28,9 @@ test('Attach disk', async ({ page }) => {
   await expectVisible(page, ['role=dialog >> text="Disk name is required"'])
 
   await page.click('role=button[name*="Disk name"]')
-  await expectVisible(page, ['role=option[name="disk-4"]', 'role=option[name="disk-5"]'])
-  await page.click('role=option[name="disk-4"]')
+  await expectVisible(page, ['role=option[name="disk-3"]', 'role=option[name="disk-4"]'])
+  await page.click('role=option[name="disk-3"]')
 
   await page.click('role=button[name="Attach Disk"]')
-  await expectVisible(page, ['role=cell[name="disk-4"]'])
+  await expectVisible(page, ['role=cell[name="disk-3"]'])
 })

--- a/libs/api-mocks/disk.ts
+++ b/libs/api-mocks/disk.ts
@@ -1,7 +1,7 @@
 import type { Disk } from '@oxide/api'
 import { GiB } from '@oxide/util'
 
-import { failedInstance, instance } from './instance'
+import { instance } from './instance'
 import type { Json } from './json-type'
 import { project } from './project'
 
@@ -37,7 +37,7 @@ export const disks: Json<Disk>[] = [
     project_id: project.id,
     time_created: new Date().toISOString(),
     time_modified: new Date().toISOString(),
-    state: { state: 'attached', instance: failedInstance.id },
+    state: { state: 'detached' },
     device_path: '/ghi',
     size: 6 * GiB,
     block_size: 2048,

--- a/libs/api-mocks/instance.ts
+++ b/libs/api-mocks/instance.ts
@@ -17,7 +17,7 @@ export const instance: Json<Instance> = {
   time_run_state_updated: new Date().toISOString(),
 }
 
-export const failedInstance: Json<Instance> = {
+const failedInstance: Json<Instance> = {
   id: 'b5946edc-5bed-4597-88ab-9a8beb9d32a4',
   name: 'you-fail',
   ncpus: 7,


### PR DESCRIPTION
Here's the little message I put in, but I wouldn't think too hard about it because it's not going to be that common in production. We only noticed it because our mock failed instance has no disks. It is possible in production because you can detach disks from a failed instance (I have another PR on the way to fix our client-side prohibition on that).

<img width="834" alt="Screenshot 2023-07-12 at 5 22 29 PM" src="https://github.com/oxidecomputer/console/assets/3612203/d1c3cd42-c9f0-418a-8a9f-064e0eaaa93d">
