### PR TITLE
Set default blocksize to 512

### DIFF
--- a/app/forms/disk-create.tsx
+++ b/app/forms/disk-create.tsx
@@ -24,7 +24,7 @@ import { useProjectSelector, useToast } from 'app/hooks'
 
 const blankDiskSource: DiskSource = {
   type: 'blank',
-  blockSize: 4096,
+  blockSize: 512,
 }
 
 const defaultValues: DiskCreate = {
@@ -130,8 +130,9 @@ const DiskSourceField = ({ control }: { control: Control<DiskCreate> }) => {
             control={control}
             parseValue={(val) => parseInt(val, 10) as BlockSize}
             items={[
-              { label: '4096', value: 4096 },
               { label: '512', value: 512 },
+              { label: '2048', value: 2048 },
+              { label: '4096', value: 4096 },
             ]}
           />
         )}

--- a/libs/api-mocks/image.ts
+++ b/libs/api-mocks/image.ts
@@ -7,7 +7,7 @@ import { project } from './project'
 const base = {
   time_created: new Date().toISOString(),
   time_modified: new Date().toISOString(),
-  block_size: 4096,
+  block_size: 512,
 }
 
 export const images: Json<Image>[] = [

--- a/libs/api-mocks/msw/handlers.ts
+++ b/libs/api-mocks/msw/handlers.ts
@@ -105,7 +105,7 @@ export const handlers = makeHandlers({
       size,
       // TODO: for non-blank disk sources, look up image or snapshot by ID and
       // pull block size from there
-      block_size: disk_source.type === 'blank' ? disk_source.block_size : 4096,
+      block_size: disk_source.type === 'blank' ? disk_source.block_size : 512,
       ...getTimestamps(),
     }
     db.disks.push(newDisk)

--- a/libs/api/__tests__/hooks.spec.tsx
+++ b/libs/api/__tests__/hooks.spec.tsx
@@ -183,7 +183,7 @@ describe('useApiMutation', () => {
     const diskCreate: DiskCreate = {
       name: 'will-fail',
       description: '',
-      diskSource: { type: 'blank', blockSize: 4096 },
+      diskSource: { type: 'blank', blockSize: 512 },
       size: 10,
     }
     const diskCreate404Params = {


### PR DESCRIPTION
After some conversations around https://github.com/oxidecomputer/omicron/issues/3648 we realized we were setting the default block size to 4096 which isn't likely what we want. Most cloud images will use 512 so that should be our default. 

It is likely that we'll want some better inline documentation for this option