### PR TITLE
Fix loading bar to handle longer requests, god forbid

### DIFF
--- a/libs/ui/styles/components/loading-bar.css
+++ b/libs/ui/styles/components/loading-bar.css
@@ -5,7 +5,9 @@
 
 .global-loading-bar.loading {
   animation-name: loading-bar-loading;
-  animation-duration: 1.5s;
+  animation-duration: 4s;
+  /* don't reset to zero at 100%, just sit there */
+  animation-fill-mode: forwards;
 }
 
 .global-loading-bar.done {
@@ -19,21 +21,26 @@
     width: 0%;
   }
 
-  10% {
+  4% {
     opacity: 1;
     width: 20%;
   }
 
-  100% {
+  40% {
     opacity: 1;
     width: 40%;
+  }
+
+  100% {
+    opacity: 1;
+    width: 45%;
   }
 }
 
 @keyframes loading-bar-done {
   0% {
     opacity: 1;
-    width: 40%;
+    width: 45%;
   }
 
   100% {


### PR DESCRIPTION
Fixes #1657. Two main changes:

- Use `animation-fill-mode: forwards` to make the bar sit in place when it runs out of time instead of resetting to 0
- Stretch out the time of the `loading` part of the animation from 1.5s to 4s, adjusting the % location of the keyframes to make it so it looks the same as before for short requests, but for longer ones can spend a bit more time creeping forward rather than sitting still

The video is too long, I did not feel like editing out the useless parts.

- `main` with fast request (good)
- `main` with 2000ms request (bad, bar disappears at 1.5s, reappears for _whoosh_ done animation)
- This PR with 2000ms request (good, bar hangs out in the middle, moving slowly, then finishes with `whoosh` out)
- This PR with fast request (good, looks about the same as main)

https://github.com/oxidecomputer/console/assets/3612203/1afba777-7c23-4758-8ab6-2e2fb5ef3fa4

