### PR TITLE
Bump React Router to 6.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "react-hook-form": "^7.43.9",
         "react-is": "^18.2.0",
         "react-merge-refs": "^2.0.2",
-        "react-router-dom": "^6.11.2",
+        "react-router-dom": "^6.14.2",
         "react-stately": "^3.23.0",
         "recharts": "^2.7.2",
         "simplebar-react": "^3.2.4",
@@ -5143,9 +5143,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.6.2.tgz",
-      "integrity": "sha512-LzqpSrMK/3JBAVBI9u3NWtOhWNw5AMQfrUFYB0+bDHTSw17z++WJLsPsxAuK+oSddsxk4d7F/JcdDPM1M5YAhA==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.7.2.tgz",
+      "integrity": "sha512-7Lcn7IqGMV+vizMPoEl5F0XDshcdDYtMI6uJLQdQz5CfZAwy3vvGKYSUk789qndt5dEC4HfSjviSYlSoHGL2+A==",
       "engines": {
         "node": ">=14"
       }
@@ -17152,11 +17152,11 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.11.2.tgz",
-      "integrity": "sha512-74z9xUSaSX07t3LM+pS6Un0T55ibUE/79CzfZpy5wsPDZaea1F8QkrsiyRnA2YQ7LwE/umaydzXZV80iDCPkMg==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.14.2.tgz",
+      "integrity": "sha512-09Zss2dE2z+T1D03IheqAFtK4UzQyX8nFPWx6jkwdYzGLXd5ie06A6ezS2fO6zJfEb/SpG6UocN2O1hfD+2urQ==",
       "dependencies": {
-        "@remix-run/router": "1.6.2"
+        "@remix-run/router": "1.7.2"
       },
       "engines": {
         "node": ">=14"
@@ -17166,12 +17166,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.11.2.tgz",
-      "integrity": "sha512-JNbKtAeh1VSJQnH6RvBDNhxNwemRj7KxCzc5jb7zvDSKRnPWIFj9pO+eXqjM69gQJ0r46hSz1x4l9y0651DKWw==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.14.2.tgz",
+      "integrity": "sha512-5pWX0jdKR48XFZBuJqHosX3AAHjRAzygouMTyimnBPOLdY3WjzUSKhus2FVMihUFWzeLebDgr4r8UeQFAct7Bg==",
       "dependencies": {
-        "@remix-run/router": "1.6.2",
-        "react-router": "6.11.2"
+        "@remix-run/router": "1.7.2",
+        "react-router": "6.14.2"
       },
       "engines": {
         "node": ">=14"
@@ -24879,9 +24879,9 @@
       }
     },
     "@remix-run/router": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.6.2.tgz",
-      "integrity": "sha512-LzqpSrMK/3JBAVBI9u3NWtOhWNw5AMQfrUFYB0+bDHTSw17z++WJLsPsxAuK+oSddsxk4d7F/JcdDPM1M5YAhA=="
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.7.2.tgz",
+      "integrity": "sha512-7Lcn7IqGMV+vizMPoEl5F0XDshcdDYtMI6uJLQdQz5CfZAwy3vvGKYSUk789qndt5dEC4HfSjviSYlSoHGL2+A=="
     },
     "@sinclair/typebox": {
       "version": "0.27.8",
@@ -33551,20 +33551,20 @@
       }
     },
     "react-router": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.11.2.tgz",
-      "integrity": "sha512-74z9xUSaSX07t3LM+pS6Un0T55ibUE/79CzfZpy5wsPDZaea1F8QkrsiyRnA2YQ7LwE/umaydzXZV80iDCPkMg==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.14.2.tgz",
+      "integrity": "sha512-09Zss2dE2z+T1D03IheqAFtK4UzQyX8nFPWx6jkwdYzGLXd5ie06A6ezS2fO6zJfEb/SpG6UocN2O1hfD+2urQ==",
       "requires": {
-        "@remix-run/router": "1.6.2"
+        "@remix-run/router": "1.7.2"
       }
     },
     "react-router-dom": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.11.2.tgz",
-      "integrity": "sha512-JNbKtAeh1VSJQnH6RvBDNhxNwemRj7KxCzc5jb7zvDSKRnPWIFj9pO+eXqjM69gQJ0r46hSz1x4l9y0651DKWw==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.14.2.tgz",
+      "integrity": "sha512-5pWX0jdKR48XFZBuJqHosX3AAHjRAzygouMTyimnBPOLdY3WjzUSKhus2FVMihUFWzeLebDgr4r8UeQFAct7Bg==",
       "requires": {
-        "@remix-run/router": "1.6.2",
-        "react-router": "6.11.2"
+        "@remix-run/router": "1.7.2",
+        "react-router": "6.14.2"
       }
     },
     "react-smooth": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "react-hook-form": "^7.43.9",
     "react-is": "^18.2.0",
     "react-merge-refs": "^2.0.2",
-    "react-router-dom": "^6.11.2",
+    "react-router-dom": "^6.14.2",
     "react-stately": "^3.23.0",
     "recharts": "^2.7.2",
     "simplebar-react": "^3.2.4",


### PR DESCRIPTION
This is a trivial update, but I want to write down some notes on the `future.v7_startTransition` flag added in [6.13](https://github.com/remix-run/react-router/releases/tag/react-router%406.13.0), which I am not turning on because (surprisingly) it breaks scroll restore. [This video](https://twitter.com/remix_run/status/1658976420767604736) is a good demo of what that's about — basically it lets you compose multiple suspensions at navigation time and have them all roll up to a single suspense boundary. Not really something we need, but it's one of those "the way it's _supposed_ to work" things that is good to opt into and means we'll probably get some nice things for free later on.

They initially turned the `startTransition` thing on for everyone in [6.12.0](https://github.com/remix-run/react-router/releases/tag/react-router%406.12.0), but had to revert that and put it behind a flag because it broke people's apps (https://github.com/remix-run/react-router/issues/10579). In theory, the bad thing people are doing that's incompatible with this change (but seems to work otherwise) is calling `React.lazy()` directly inside the render cycle (https://github.com/remix-run/react-router/issues/10579#issuecomment-1584749371). We are not doing that, so I was hopeful that we wouldn't have an issue. And we almost didn't: we don't have a problem with basic navigation, like people were reporting on the issue.

But scroll restore breaks partially. Fortunately the e2e test for scroll restore caught it, so that's great. I haven't looked into why it might be breaking — I'm guessing something about the timing of when the scroll position is retrieved.