### PR TITLE
Only allow API method in `invalidateQueries`

### DIFF
--- a/app/forms/disk-create.tsx
+++ b/app/forms/disk-create.tsx
@@ -68,10 +68,8 @@ export function CreateDiskSideModalForm({
 
   const createDisk = useApiMutation('diskCreate', {
     onSuccess(data) {
-      queryClient.invalidateQueries('diskList', { query: projectSelector })
-      addToast({
-        content: 'Your disk has been created',
-      })
+      queryClient.invalidateQueries('diskList')
+      addToast({ content: 'Your disk has been created' })
       onSuccess?.(data)
       onDismiss(navigate)
     },

--- a/app/forms/firewall-rules-create.tsx
+++ b/app/forms/firewall-rules-create.tsx
@@ -456,7 +456,7 @@ export function CreateFirewallRuleForm({
 
   const updateRules = useApiMutation('vpcFirewallRulesUpdate', {
     onSuccess() {
-      queryClient.invalidateQueries('vpcFirewallRulesView', { query: vpcSelector })
+      queryClient.invalidateQueries('vpcFirewallRulesView')
       onDismiss()
     },
   })

--- a/app/forms/firewall-rules-edit.tsx
+++ b/app/forms/firewall-rules-edit.tsx
@@ -32,7 +32,7 @@ export function EditFirewallRuleForm({
 
   const updateRules = useApiMutation('vpcFirewallRulesUpdate', {
     onSuccess() {
-      queryClient.invalidateQueries('vpcFirewallRulesView', { query: vpcSelector })
+      queryClient.invalidateQueries('vpcFirewallRulesView')
       onDismiss()
     },
   })

--- a/app/forms/idp/create.tsx
+++ b/app/forms/idp/create.tsx
@@ -50,10 +50,8 @@ export function CreateIdpSideModalForm() {
 
   const createIdp = useApiMutation('samlIdentityProviderCreate', {
     onSuccess() {
-      queryClient.invalidateQueries('siloIdentityProviderList', { query: { silo } })
-      addToast({
-        content: 'Your identity provider has been created',
-      })
+      queryClient.invalidateQueries('siloIdentityProviderList')
+      addToast({ content: 'Your identity provider has been created' })
       onDismiss()
     },
   })

--- a/app/forms/image-from-snapshot.tsx
+++ b/app/forms/image-from-snapshot.tsx
@@ -53,10 +53,8 @@ export function CreateImageFromSnapshotSideModalForm() {
 
   const createImage = useApiMutation('imageCreate', {
     onSuccess() {
-      queryClient.invalidateQueries('imageList', { query: { project } })
-      addToast({
-        content: 'Your image has been created',
-      })
+      queryClient.invalidateQueries('imageList')
+      addToast({ content: 'Your image has been created' })
       onDismiss()
     },
   })

--- a/app/forms/instance-create.tsx
+++ b/app/forms/instance-create.tsx
@@ -106,16 +106,14 @@ export function CreateInstanceForm() {
   const createInstance = useApiMutation('instanceCreate', {
     onSuccess(instance) {
       // refetch list of instances
-      queryClient.invalidateQueries('instanceList', { query: projectSelector })
+      queryClient.invalidateQueries('instanceList')
       // avoid the instance fetch when the instance page loads since we have the data
       queryClient.setQueryData(
         'instanceView',
         { path: { instance: instance.name }, query: projectSelector },
         instance
       )
-      addToast({
-        content: 'Your instance has been created',
-      })
+      addToast({ content: 'Your instance has been created' })
       navigate(pb.instancePage({ ...projectSelector, instance: instance.name }))
     },
   })

--- a/app/forms/network-interface-edit.tsx
+++ b/app/forms/network-interface-edit.tsx
@@ -28,9 +28,7 @@ export default function EditNetworkInterfaceForm({
 
   const editNetworkInterface = useApiMutation('instanceNetworkInterfaceUpdate', {
     onSuccess() {
-      queryClient.invalidateQueries('instanceNetworkInterfaceList', {
-        query: instanceSelector,
-      })
+      queryClient.invalidateQueries('instanceNetworkInterfaceList')
       onDismiss()
     },
   })

--- a/app/forms/project-create.tsx
+++ b/app/forms/project-create.tsx
@@ -29,12 +29,10 @@ export function CreateProjectSideModalForm() {
   const createProject = useApiMutation('projectCreate', {
     onSuccess(project) {
       // refetch list of projects in sidebar
-      queryClient.invalidateQueries('projectList', {})
+      queryClient.invalidateQueries('projectList')
       // avoid the project fetch when the project page loads since we have the data
       queryClient.setQueryData('projectView', { path: { project: project.name } }, project)
-      addToast({
-        content: 'Your project has been created',
-      })
+      addToast({ content: 'Your project has been created' })
       navigate(pb.instances({ project: project.name }))
     },
   })

--- a/app/forms/project-edit.tsx
+++ b/app/forms/project-edit.tsx
@@ -37,12 +37,10 @@ export function EditProjectSideModalForm() {
     onSuccess(project) {
       // refetch list of projects in sidebar
       // TODO: check this invalidation
-      queryClient.invalidateQueries('projectList', {})
+      queryClient.invalidateQueries('projectList')
       // avoid the project fetch when the project page loads since we have the data
       queryClient.setQueryData('projectView', { path: { project: project.name } }, project)
-      addToast({
-        content: 'Your project has been updated',
-      })
+      addToast({ content: 'Your project has been updated' })
       onDismiss()
     },
   })

--- a/app/forms/silo-create.tsx
+++ b/app/forms/silo-create.tsx
@@ -47,11 +47,9 @@ export function CreateSiloSideModalForm() {
 
   const createSilo = useApiMutation('siloCreate', {
     onSuccess(silo) {
-      queryClient.invalidateQueries('siloList', {})
+      queryClient.invalidateQueries('siloList')
       queryClient.setQueryData('siloView', { path: { silo: silo.name } }, silo)
-      addToast({
-        content: 'Your silo has been created',
-      })
+      addToast({ content: 'Your silo has been created' })
       onDismiss()
     },
   })

--- a/app/forms/snapshot-create.tsx
+++ b/app/forms/snapshot-create.tsx
@@ -50,10 +50,8 @@ export function CreateSnapshotSideModalForm() {
 
   const createSnapshot = useApiMutation('snapshotCreate', {
     onSuccess() {
-      queryClient.invalidateQueries('snapshotList', { query: projectSelector })
-      addToast({
-        content: 'Your snapshot has been created',
-      })
+      queryClient.invalidateQueries('snapshotList')
+      addToast({ content: 'Your snapshot has been created' })
       onDismiss()
     },
   })

--- a/app/forms/ssh-key-create.tsx
+++ b/app/forms/ssh-key-create.tsx
@@ -28,7 +28,7 @@ export function CreateSSHKeySideModalForm() {
 
   const createSshKey = useApiMutation('currentUserSshKeyCreate', {
     onSuccess() {
-      queryClient.invalidateQueries('currentUserSshKeyList', {})
+      queryClient.invalidateQueries('currentUserSshKeyList')
       onDismiss()
     },
   })

--- a/app/forms/subnet-create.tsx
+++ b/app/forms/subnet-create.tsx
@@ -30,7 +30,7 @@ export function CreateSubnetForm({ onDismiss }: CreateSubnetFormProps) {
 
   const createSubnet = useApiMutation('vpcSubnetCreate', {
     onSuccess() {
-      queryClient.invalidateQueries('vpcSubnetList', { query: vpcSelector })
+      queryClient.invalidateQueries('vpcSubnetList')
       onDismiss()
     },
   })

--- a/app/forms/subnet-edit.tsx
+++ b/app/forms/subnet-edit.tsx
@@ -25,7 +25,7 @@ export function EditSubnetForm({ onDismiss, editing }: EditSubnetFormProps) {
 
   const updateSubnet = useApiMutation('vpcSubnetUpdate', {
     onSuccess() {
-      queryClient.invalidateQueries('vpcSubnetList', { query: vpcSelector })
+      queryClient.invalidateQueries('vpcSubnetList')
       onDismiss()
     },
   })

--- a/app/forms/vpc-edit.tsx
+++ b/app/forms/vpc-edit.tsx
@@ -36,15 +36,13 @@ export function EditVpcSideModalForm() {
 
   const editVpc = useApiMutation('vpcUpdate', {
     async onSuccess(vpc) {
-      queryClient.invalidateQueries('vpcList', { query: { project } })
+      queryClient.invalidateQueries('vpcList')
       queryClient.setQueryData(
         'vpcView',
         { path: { vpc: vpc.name }, query: { project } },
         vpc
       )
-      addToast({
-        content: 'Your VPC has been created',
-      })
+      addToast({ content: 'Your VPC has been created' })
       onDismiss()
     },
   })

--- a/app/forms/vpc-router-create.tsx
+++ b/app/forms/vpc-router-create.tsx
@@ -29,16 +29,14 @@ export function CreateVpcRouterForm({ onDismiss }: CreateVpcRouterFormProps) {
 
   const createRouter = useApiMutation('vpcRouterCreate', {
     onSuccess(router) {
-      queryClient.invalidateQueries('vpcRouterList', { query: vpcSelector })
+      queryClient.invalidateQueries('vpcRouterList')
       // avoid the vpc fetch when the vpc page loads since we have the data
       queryClient.setQueryData(
         'vpcRouterView',
         { path: { router: router.name }, query: vpcSelector },
         router
       )
-      addToast({
-        content: 'Your VPC router has been created',
-      })
+      addToast({ content: 'Your VPC router has been created' })
       onDismiss()
     },
   })

--- a/app/forms/vpc-router-edit.tsx
+++ b/app/forms/vpc-router-edit.tsx
@@ -25,7 +25,7 @@ export function EditVpcRouterForm({ onDismiss, editing }: EditVpcRouterFormProps
 
   const updateRouter = useApiMutation('vpcRouterUpdate', {
     onSuccess() {
-      queryClient.invalidateQueries('vpcRouterList', { query: vpcSelector })
+      queryClient.invalidateQueries('vpcRouterList')
       onDismiss()
     },
   })

--- a/app/pages/ProjectsPage.tsx
+++ b/app/pages/ProjectsPage.tsx
@@ -58,7 +58,7 @@ export default function ProjectsPage() {
     onSuccess() {
       // TODO: figure out if this is invalidating as expected, can we leave out the query
       // altogether, etc. Look at whether limit param matters.
-      queryClient.invalidateQueries('projectList', {})
+      queryClient.invalidateQueries('projectList')
     },
   })
 

--- a/app/pages/project/disks/DisksPage.tsx
+++ b/app/pages/project/disks/DisksPage.tsx
@@ -80,16 +80,14 @@ export function DisksPage() {
 
   const deleteDisk = useApiMutation('diskDelete', {
     onSuccess() {
-      queryClient.invalidateQueries('diskList', { query: projectSelector })
+      queryClient.invalidateQueries('diskList')
     },
   })
 
   const createSnapshot = useApiMutation('snapshotCreate', {
     onSuccess() {
-      queryClient.invalidateQueries('snapshotList', { query: projectSelector })
-      addToast({
-        content: 'Snapshot successfully created',
-      })
+      queryClient.invalidateQueries('snapshotList')
+      addToast({ content: 'Snapshot successfully created' })
     },
   })
 

--- a/app/pages/project/images/ImagesPage.tsx
+++ b/app/pages/project/images/ImagesPage.tsx
@@ -55,10 +55,8 @@ export function ImagesPage() {
 
   const deleteImage = useApiMutation('imageDelete', {
     onSuccess(_data, variables) {
-      addToast({
-        content: `${variables.path.image} has been deleted`,
-      })
-      queryClient.invalidateQueries('imageList', { query: projectSelector })
+      addToast({ content: `${variables.path.image} has been deleted` })
+      queryClient.invalidateQueries('imageList')
     },
     onError: (err) => {
       addToast({ title: 'Error', content: err.message, variant: 'error' })
@@ -128,7 +126,7 @@ const PromoteImageModal = ({ onDismiss, imageName }: PromoteModalProps) => {
           link: '/images',
         },
       })
-      queryClient.invalidateQueries('imageList', { query: projectSelector })
+      queryClient.invalidateQueries('imageList')
     },
     onError: (err) => {
       addToast({ title: 'Error', content: err.message, variant: 'error' })

--- a/app/pages/project/instances/InstancesPage.tsx
+++ b/app/pages/project/instances/InstancesPage.tsx
@@ -54,8 +54,7 @@ export function InstancesPage() {
   const projectSelector = useProjectSelector()
 
   const queryClient = useApiQueryClient()
-  const refetchInstances = () =>
-    queryClient.invalidateQueries('instanceList', { query: projectSelector })
+  const refetchInstances = () => queryClient.invalidateQueries('instanceList')
 
   const makeActions = useMakeInstanceActions(projectSelector, {
     onSuccess: refetchInstances,

--- a/app/pages/project/instances/instance/tabs/NetworkingTab.tsx
+++ b/app/pages/project/instances/instance/tabs/NetworkingTab.tsx
@@ -92,29 +92,23 @@ export function NetworkingTab() {
   const [createModalOpen, setCreateModalOpen] = useState(false)
   const [editing, setEditing] = useState<InstanceNetworkInterface | null>(null)
 
-  const getQuery = ['instanceNetworkInterfaceList', { query: instanceSelector }] as const
-
   const createNic = useApiMutation('instanceNetworkInterfaceCreate', {
     onSuccess() {
-      queryClient.invalidateQueries('instanceNetworkInterfaceList', {
-        query: instanceSelector,
-      })
+      queryClient.invalidateQueries('instanceNetworkInterfaceList')
       setCreateModalOpen(false)
     },
   })
 
   const deleteNic = useApiMutation('instanceNetworkInterfaceDelete', {
     onSuccess() {
-      queryClient.invalidateQueries(...getQuery)
-      addToast({
-        title: 'Network interface deleted',
-      })
+      queryClient.invalidateQueries('instanceNetworkInterfaceList')
+      addToast({ content: 'Network interface deleted' })
     },
   })
 
   const editNic = useApiMutation('instanceNetworkInterfaceUpdate', {
     onSuccess() {
-      queryClient.invalidateQueries(...getQuery)
+      queryClient.invalidateQueries('instanceNetworkInterfaceList')
     },
   })
 
@@ -175,7 +169,9 @@ export function NetworkingTab() {
     />
   )
 
-  const { Table, Column } = useQueryTable(...getQuery)
+  const { Table, Column } = useQueryTable('instanceNetworkInterfaceList', {
+    query: instanceSelector,
+  })
   return (
     <>
       <h2 id="nic-label" className="mb-4 text-mono-sm text-secondary">

--- a/app/pages/project/networking/VpcPage/tabs/VpcFirewallRulesTab.tsx
+++ b/app/pages/project/networking/VpcPage/tabs/VpcFirewallRulesTab.tsx
@@ -63,7 +63,7 @@ export const VpcFirewallRulesTab = () => {
 
   const updateRules = useApiMutation('vpcFirewallRulesUpdate', {
     onSuccess() {
-      queryClient.invalidateQueries('vpcFirewallRulesView', { query: vpcSelector })
+      queryClient.invalidateQueries('vpcFirewallRulesView')
     },
   })
 

--- a/app/pages/project/networking/VpcsPage.tsx
+++ b/app/pages/project/networking/VpcsPage.tsx
@@ -55,7 +55,7 @@ export function VpcsPage() {
 
   const deleteVpc = useApiMutation('vpcDelete', {
     onSuccess() {
-      queryClient.invalidateQueries('vpcList', { query: projectSelector })
+      queryClient.invalidateQueries('vpcList')
     },
   })
 

--- a/app/pages/project/snapshots/SnapshotsPage.tsx
+++ b/app/pages/project/snapshots/SnapshotsPage.tsx
@@ -66,7 +66,7 @@ export function SnapshotsPage() {
 
   const deleteSnapshot = useApiMutation('snapshotDelete', {
     onSuccess() {
-      queryClient.invalidateQueries('snapshotList', { query: projectSelector })
+      queryClient.invalidateQueries('snapshotList')
     },
   })
 

--- a/app/pages/settings/SSHKeysPage.tsx
+++ b/app/pages/settings/SSHKeysPage.tsx
@@ -39,7 +39,7 @@ export function SSHKeysPage() {
 
   const deleteSshKey = useApiMutation('currentUserSshKeyDelete', {
     onSuccess: () => {
-      queryClient.invalidateQueries('currentUserSshKeyList', {})
+      queryClient.invalidateQueries('currentUserSshKeyList')
     },
   })
 

--- a/app/pages/system/SiloImagesPage.tsx
+++ b/app/pages/system/SiloImagesPage.tsx
@@ -95,10 +95,8 @@ const PromoteImageModal = ({ onDismiss }: { onDismiss: () => void }) => {
   const addToast = useToast()
   const promoteImage = useApiMutation('imagePromote', {
     onSuccess(data) {
-      addToast({
-        content: `${data.name} has been promoted`,
-      })
-      queryClient.invalidateQueries('imageList', {})
+      addToast({ content: `${data.name} has been promoted` })
+      queryClient.invalidateQueries('imageList')
     },
     onError: (err) => {
       addToast({ title: 'Error', content: err.message, variant: 'error' })

--- a/app/pages/system/SilosPage.tsx
+++ b/app/pages/system/SilosPage.tsx
@@ -57,7 +57,7 @@ export default function SilosPage() {
 
   const deleteSilo = useApiMutation('siloDelete', {
     onSuccess() {
-      queryClient.invalidateQueries('siloList', {})
+      queryClient.invalidateQueries('siloList')
     },
   })
 

--- a/libs/api/hooks.ts
+++ b/libs/api/hooks.ts
@@ -155,11 +155,15 @@ export const getUseApiMutation =
     )
 
 export const wrapQueryClient = <A extends ApiClient>(api: A, queryClient: QueryClient) => ({
-  invalidateQueries: <M extends keyof A>(
-    method: M,
-    params?: Params<A[M]>,
-    filters?: InvalidateQueryFilters
-  ) => queryClient.invalidateQueries(params ? [method, params] : [method], filters),
+  /**
+   * Note that we only take a single argument, `method`, rather than allowing
+   * the full query key `[query, params]` to be specified. This is to avoid
+   * accidentally overspecifying and therefore failing to match the desired
+   * query. The params argument can be added back in if we ever have a use case
+   * for it.
+   */
+  invalidateQueries: <M extends keyof A>(method: M, filters?: InvalidateQueryFilters) =>
+    queryClient.invalidateQueries([method], filters),
   setQueryData: <M extends keyof A>(method: M, params: Params<A[M]>, data: Result<A[M]>) =>
     queryClient.setQueryData([method, params], data),
   cancelQueries: <M extends keyof A>(


### PR DESCRIPTION
In https://github.com/oxidecomputer/console/pull/1687#discussion_r1269832859 I found and fixed a bug caused by overly specific query invalidations. When we give only the method, RQ will invalidate _all_ calls to that endpoint, not just the specific one. For example if we tell it to invalidate the VPCs list, it will invalidate it for all projects, not the current one. But this is not a problem at all: RQ will only refetch invalidated queries that are actually active, i.e., on the current page. If we invalidate some other project's VPCs list query, that's fine — we were going to refetch that when we got back to that page anyway.