### PR TITLE
Convert some `useApiQuery` to `usePrefetchedApiQuery`

### DIFF
--- a/app/forms/instance-create.tsx
+++ b/app/forms/instance-create.tsx
@@ -18,8 +18,8 @@ import {
   apiQueryClient,
   genName,
   useApiMutation,
-  useApiQuery,
   useApiQueryClient,
+  usePrefetchedApiQuery,
 } from '@oxide/api'
 import {
   EmptyMessage,
@@ -118,9 +118,9 @@ export function CreateInstanceForm() {
     },
   })
 
-  const siloImages = useApiQuery('imageList', {}).data?.items || []
-  const projectImages =
-    useApiQuery('imageList', { query: projectSelector }).data?.items || []
+  const siloImages = usePrefetchedApiQuery('imageList', {}).data.items
+  const projectImages = usePrefetchedApiQuery('imageList', { query: projectSelector }).data
+    .items
   const allImages = [...siloImages, ...projectImages]
 
   const defaultImage = allImages[0]
@@ -377,7 +377,7 @@ export function CreateInstanceForm() {
 }
 
 const SshKeysTable = () => {
-  const keys = useApiQuery('currentUserSshKeyList', {}).data?.items || []
+  const keys = usePrefetchedApiQuery('currentUserSshKeyList', {}).data?.items || []
 
   return (
     <div className="max-w-lg">

--- a/app/forms/project-edit.tsx
+++ b/app/forms/project-edit.tsx
@@ -9,7 +9,12 @@ import { useForm } from 'react-hook-form'
 import type { LoaderFunctionArgs } from 'react-router-dom'
 import { useNavigate } from 'react-router-dom'
 
-import { apiQueryClient, useApiMutation, useApiQuery, useApiQueryClient } from '@oxide/api'
+import {
+  apiQueryClient,
+  useApiMutation,
+  useApiQueryClient,
+  usePrefetchedApiQuery,
+} from '@oxide/api'
 
 import { DescriptionField, NameField, SideModalForm } from 'app/components/form'
 import { pb } from 'app/util/path-builder'
@@ -31,7 +36,7 @@ export function EditProjectSideModalForm() {
 
   const onDismiss = () => navigate(pb.projects())
 
-  const { data: project } = useApiQuery('projectView', { path: projectSelector })
+  const { data: project } = usePrefetchedApiQuery('projectView', { path: projectSelector })
 
   const editProject = useApiMutation('projectUpdate', {
     onSuccess(project) {

--- a/app/forms/vpc-edit.tsx
+++ b/app/forms/vpc-edit.tsx
@@ -9,7 +9,12 @@ import { useForm } from 'react-hook-form'
 import type { LoaderFunctionArgs } from 'react-router-dom'
 import { useNavigate } from 'react-router-dom'
 
-import { apiQueryClient, useApiMutation, useApiQuery, useApiQueryClient } from '@oxide/api'
+import {
+  apiQueryClient,
+  useApiMutation,
+  useApiQueryClient,
+  usePrefetchedApiQuery,
+} from '@oxide/api'
 
 import { DescriptionField, NameField, SideModalForm } from 'app/components/form'
 import { getVpcSelector, useToast, useVpcSelector } from 'app/hooks'
@@ -27,7 +32,7 @@ export function EditVpcSideModalForm() {
   const addToast = useToast()
   const navigate = useNavigate()
 
-  const { data: vpc } = useApiQuery('vpcView', {
+  const { data: vpc } = usePrefetchedApiQuery('vpcView', {
     path: { vpc: vpcName },
     query: { project },
   })

--- a/app/pages/ProjectsPage.tsx
+++ b/app/pages/ProjectsPage.tsx
@@ -10,7 +10,12 @@ import { Outlet } from 'react-router-dom'
 import { Link, useNavigate } from 'react-router-dom'
 
 import type { Project } from '@oxide/api'
-import { apiQueryClient, useApiMutation, useApiQuery, useApiQueryClient } from '@oxide/api'
+import {
+  apiQueryClient,
+  useApiMutation,
+  useApiQueryClient,
+  usePrefetchedApiQuery,
+} from '@oxide/api'
 import type { MenuAction } from '@oxide/table'
 import { DateCell, linkCell, useQueryTable } from '@oxide/table'
 import {
@@ -38,9 +43,7 @@ const EmptyState = () => (
 )
 
 ProjectsPage.loader = async () => {
-  await apiQueryClient.prefetchQuery('projectList', {
-    query: { limit: 10 },
-  })
+  await apiQueryClient.prefetchQuery('projectList', { query: { limit: 10 } })
   return null
 }
 
@@ -49,8 +52,7 @@ export default function ProjectsPage() {
 
   const queryClient = useApiQueryClient()
   const { Table, Column } = useQueryTable('projectList', {})
-
-  const { data: projects } = useApiQuery('projectList', {
+  const { data: projects } = usePrefetchedApiQuery('projectList', {
     query: { limit: 10 }, // limit to match QueryTable
   })
 

--- a/app/pages/project/instances/InstancesPage.tsx
+++ b/app/pages/project/instances/InstancesPage.tsx
@@ -9,7 +9,7 @@ import { useMemo } from 'react'
 import type { LoaderFunctionArgs } from 'react-router-dom'
 import { Link, useNavigate } from 'react-router-dom'
 
-import { apiQueryClient, useApiQuery, useApiQueryClient } from '@oxide/api'
+import { apiQueryClient, useApiQueryClient, usePrefetchedApiQuery } from '@oxide/api'
 import {
   DateCell,
   InstanceResourceCell,
@@ -60,7 +60,7 @@ export function InstancesPage() {
     onSuccess: refetchInstances,
   })
 
-  const { data: instances } = useApiQuery('instanceList', {
+  const { data: instances } = usePrefetchedApiQuery('instanceList', {
     query: { ...projectSelector, limit: 10 }, // to have same params as QueryTable
   })
 

--- a/app/pages/project/instances/instance/tabs/MetricsTab.tsx
+++ b/app/pages/project/instances/instance/tabs/MetricsTab.tsx
@@ -9,7 +9,7 @@ import React, { Suspense, useMemo, useState } from 'react'
 import type { LoaderFunctionArgs } from 'react-router-dom'
 
 import type { Cumulativeint64, DiskMetricName } from '@oxide/api'
-import { apiQueryClient, useApiQuery } from '@oxide/api'
+import { apiQueryClient, useApiQuery, usePrefetchedApiQuery } from '@oxide/api'
 import { EmptyMessage, Listbox, Spinner, Storage24Icon, TableEmptyBox } from '@oxide/ui'
 
 import { useDateTimeRangePicker } from 'app/components/form'
@@ -92,7 +92,7 @@ MetricsTab.loader = async ({ params }: LoaderFunctionArgs) => {
 
 export function MetricsTab() {
   const { project, instance } = useInstanceSelector()
-  const { data } = useApiQuery('instanceDiskList', {
+  const { data } = usePrefetchedApiQuery('instanceDiskList', {
     path: { instance },
     query: { project },
   })

--- a/app/pages/project/networking/VpcsPage.tsx
+++ b/app/pages/project/networking/VpcsPage.tsx
@@ -11,7 +11,12 @@ import { Outlet } from 'react-router-dom'
 import { Link, useNavigate } from 'react-router-dom'
 
 import type { Vpc } from '@oxide/api'
-import { apiQueryClient, useApiMutation, useApiQuery, useApiQueryClient } from '@oxide/api'
+import {
+  apiQueryClient,
+  useApiMutation,
+  useApiQueryClient,
+  usePrefetchedApiQuery,
+} from '@oxide/api'
 import { DateCell, type MenuAction, linkCell, useQueryTable } from '@oxide/table'
 import {
   EmptyMessage,
@@ -48,7 +53,7 @@ VpcsPage.loader = async ({ params }: LoaderFunctionArgs) => {
 export function VpcsPage() {
   const queryClient = useApiQueryClient()
   const projectSelector = useProjectSelector()
-  const { data: vpcs } = useApiQuery('vpcList', {
+  const { data: vpcs } = usePrefetchedApiQuery('vpcList', {
     query: { ...projectSelector, limit: 10 }, // to have same params as QueryTable
   })
   const navigate = useNavigate()
@@ -79,7 +84,7 @@ export function VpcsPage() {
   useQuickActions(
     useMemo(
       () =>
-        (vpcs?.items || []).map((v) => ({
+        vpcs.items.map((v) => ({
           value: v.name,
           onSelect: () => navigate(pb.vpc({ ...projectSelector, vpc: v.name })),
           navGroup: 'Go to VPC',

--- a/app/pages/system/SilosPage.tsx
+++ b/app/pages/system/SilosPage.tsx
@@ -9,8 +9,12 @@ import { useMemo } from 'react'
 import { Link, Outlet, useNavigate } from 'react-router-dom'
 
 import type { Silo } from '@oxide/api'
-import { apiQueryClient } from '@oxide/api'
-import { useApiMutation, useApiQuery, useApiQueryClient } from '@oxide/api'
+import {
+  apiQueryClient,
+  useApiMutation,
+  useApiQueryClient,
+  usePrefetchedApiQuery,
+} from '@oxide/api'
 import type { MenuAction } from '@oxide/table'
 import { linkCell } from '@oxide/table'
 import { BooleanCell } from '@oxide/table'
@@ -51,7 +55,7 @@ export default function SilosPage() {
   const { Table, Column } = useQueryTable('siloList', {})
   const queryClient = useApiQueryClient()
 
-  const { data: silos } = useApiQuery('siloList', {
+  const { data: silos } = usePrefetchedApiQuery('siloList', {
     query: { limit: 10 },
   })
 
@@ -75,7 +79,7 @@ export default function SilosPage() {
     useMemo(
       () => [
         { value: 'New silo', onSelect: () => navigate(pb.siloNew()) },
-        ...(silos?.items || []).map((o) => ({
+        ...silos.items.map((o) => ({
           value: o.name,
           onSelect: () => navigate(pb.silo({ silo: o.name })),
           navGroup: 'Go to silo',

--- a/app/pages/system/inventory/InventoryPage.tsx
+++ b/app/pages/system/inventory/InventoryPage.tsx
@@ -5,7 +5,7 @@
  *
  * Copyright Oxide Computer Company
  */
-import { apiQueryClient, useApiQuery } from '@oxide/api'
+import { apiQueryClient, usePrefetchedApiQuery } from '@oxide/api'
 import { PageHeader, PageTitle, Racks24Icon } from '@oxide/ui'
 
 import { RouteTabs, Tab } from 'app/components/RouteTabs'
@@ -19,7 +19,7 @@ InventoryPage.loader = async () => {
 }
 
 export function InventoryPage() {
-  const { data: racks } = useApiQuery('rackList', { query: { limit: 10 } })
+  const { data: racks } = usePrefetchedApiQuery('rackList', { query: { limit: 10 } })
   const rack = racks?.items[0]
 
   if (!rack) return null

--- a/libs/api/roles.ts
+++ b/libs/api/roles.ts
@@ -15,7 +15,7 @@ import { useMemo } from 'react'
 
 import { lowestBy, sortBy } from '@oxide/util'
 
-import { useApiQuery, usePrefetchedApiQuery } from '.'
+import { usePrefetchedApiQuery } from '.'
 import type { FleetRole, IdentityType, ProjectRole, SiloRole } from './__generated__/Api'
 
 /**
@@ -136,20 +136,17 @@ export type Actor = {
  * Fetch lists of users and groups, filtering out the ones that are already in
  * the given policy.
  */
-export function useActorsNotInPolicy(
-  // allow undefined because this is fetched with RQ
-  policy: Policy | undefined
-): Actor[] {
-  const { data: users } = useApiQuery('userList', {})
-  const { data: groups } = useApiQuery('groupList', {})
+export function useActorsNotInPolicy(policy: Policy): Actor[] {
+  const { data: users } = usePrefetchedApiQuery('userList', {})
+  const { data: groups } = usePrefetchedApiQuery('groupList', {})
   return useMemo(() => {
     // IDs are UUIDs, so no need to include identity type in set value to disambiguate
     const actorsInPolicy = new Set(policy?.roleAssignments.map((ra) => ra.identityId) || [])
-    const allGroups = (groups?.items || []).map((g) => ({
+    const allGroups = groups.items.map((g) => ({
       ...g,
       identityType: 'silo_group' as IdentityType,
     }))
-    const allUsers = (users?.items || []).map((u) => ({
+    const allUsers = users.items.map((u) => ({
       ...u,
       identityType: 'silo_user' as IdentityType,
     }))


### PR DESCRIPTION
Now we have 37 `usePrefetchedApiQuery` and 25 `useApiQuery`. Most of the remaining ones make sense as-is. A few I was on the fence about but decided not to bother. The issue is when the `useQuery` call happens on something that doesn't have its own loader, like a modal that is not loaded through a route.