### PR TITLE
Ensure error messages show up when attaching a nic to an instance

### DIFF
--- a/app/pages/project/instances/instance/tabs/NetworkingTab.tsx
+++ b/app/pages/project/instances/instance/tabs/NetworkingTab.tsx
@@ -228,6 +228,7 @@ export function NetworkingTab() {
         <CreateNetworkInterfaceForm
           onDismiss={() => setCreateModalOpen(false)}
           onSubmit={(body) => createNic.mutate({ query: instanceSelector, body })}
+          submitError={createNic.error}
         />
       )}
       {editing && (


### PR DESCRIPTION
This fixes part of #1438 

I was looking through the NIC attach form and noticed `submitError` was optional. That's fine on the whole given that this form is often embedded in more complex flows. Unfortunately in the case where the flow is stand alone (attaching a nic to an instance after the fact) we weren't plumbing through the error. 