### PR TITLE
Add bg-raised to tooltips

### DIFF
--- a/libs/ui/lib/tooltip/tooltip.css
+++ b/libs/ui/lib/tooltip/tooltip.css
@@ -7,7 +7,7 @@
  */
 
 .ox-tooltip {
-  @apply z-20 rounded border p-2 text-sans-md text-secondary border-secondary elevation-2;
+  @apply z-20 rounded border p-2 text-sans-md text-secondary bg-raise border-secondary elevation-2;
 }
 
 .ox-tooltip-arrow {


### PR DESCRIPTION
Fixes #1697 

I'm not sure exactly what happened here. My theory is perhaps `elevation` used to include a background color but that got dropped? I'd need to dig a bit more into the latest design system changes. This covers us for now though. 