### PR TITLE
Upgrade google github actions

### DIFF
--- a/.github/workflows/upload-assets.yaml
+++ b/.github/workflows/upload-assets.yaml
@@ -4,7 +4,6 @@ name: Upload assets to dl.oxide.computer
 on:
   push:
     branches: [main]
-  pull_request:
 
 jobs:
   build-and-upload:


### PR DESCRIPTION
I'm guessing this warning will go away if we upgrade the action, since we're not explicitly doing the thing it's complaining about.

https://github.com/oxidecomputer/console/actions/runs/5651325211/job/15309249015

<img width="748" alt="image" src="https://github.com/oxidecomputer/console/assets/3612203/a6a6ad9f-b7fb-4e22-949d-95a97e2e4b5b">
