### PR TITLE
Revalidate `currentUserLoader` on every nav, use special hook everywhere

### DIFF
--- a/app/components/TopBar.tsx
+++ b/app/components/TopBar.tsx
@@ -8,7 +8,7 @@
 import React from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import { navToLogin, useApiMutation, usePrefetchedApiQuery } from '@oxide/api'
+import { navToLogin, useApiMutation } from '@oxide/api'
 import {
   Button,
   DirectionDownIcon,
@@ -17,6 +17,7 @@ import {
   Profile16Icon,
 } from '@oxide/ui'
 
+import { useCurrentUser } from 'app/layouts/helpers'
 import { pb } from 'app/util/path-builder'
 
 export function TopBar({ children }: { children: React.ReactNode }) {
@@ -30,9 +31,9 @@ export function TopBar({ children }: { children: React.ReactNode }) {
     },
   })
   // fetch happens in loader wrapping all authed pages
-  const { data: user } = usePrefetchedApiQuery('currentUserView', {})
+  const { me } = useCurrentUser()
 
-  const loggedIn = !!user
+  const loggedIn = !!me
 
   // toArray filters out nulls, which is essential because the silo/system
   // picker is going to come in null when the user isn't supposed to see it
@@ -71,7 +72,7 @@ export function TopBar({ children }: { children: React.ReactNode }) {
                 >
                   <Profile16Icon className="text-quaternary" />
                   <span className="normal-case text-sans-md text-secondary">
-                    {user?.displayName || 'User'}
+                    {me.displayName || 'User'}
                   </span>
                   <DirectionDownIcon className="!w-2.5" />
                 </Button>

--- a/app/components/TopBarPicker.tsx
+++ b/app/components/TopBarPicker.tsx
@@ -9,7 +9,7 @@ import cn from 'classnames'
 import { Link } from 'react-router-dom'
 
 import type { Project } from '@oxide/api'
-import { useApiQuery, useApiQueryErrorsAllowed, usePrefetchedApiQuery } from '@oxide/api'
+import { useApiQuery } from '@oxide/api'
 import {
   DropdownMenu,
   Folder16Icon,
@@ -19,9 +19,9 @@ import {
   Truncate,
   Wrap,
 } from '@oxide/ui'
-import { invariant } from '@oxide/util'
 
 import { useInstanceSelector, useSiloSelector } from 'app/hooks'
+import { useCurrentUser } from 'app/layouts/helpers'
 import { pb } from 'app/util/path-builder'
 
 type TopBarPickerItem = {
@@ -154,22 +154,11 @@ const BigIdenticon = ({ name }: { name: string }) => (
  * current silo.
  */
 export function SiloSystemPicker({ value }: { value: 'silo' | 'system' }) {
-  const { data: me } = usePrefetchedApiQuery('currentUserView', {})
-
-  // User can only get to system routes if they have viewer perms (at least) on
-  // the fleet. The natural place to find out whether they have such perms is
-  // the fleet (system) policy, but if the user doesn't have fleet read, we'll
-  // get a 403 from that endpoint. So we simply check whether that endpoint 200s
-  // or not to determine whether the user is a fleet viewer.
-  const { data: systemPolicy } = useApiQueryErrorsAllowed('systemPolicyView', {})
-  // don't use usePrefetchedApiQuery because it's not worth making an errors
-  // allowed version of that
-  invariant(systemPolicy, 'System policy must be prefetched')
-  const canSeeSystemPolicy = systemPolicy.type === 'success'
+  const { me, isFleetViewer } = useCurrentUser()
 
   // if the user can't see the picker, show a placeholder control with their
   // silo name that links to root/home
-  if (!canSeeSystemPolicy) {
+  if (!isFleetViewer) {
     return (
       <TopBarPicker
         aria-label={`${me.siloName} - Oxide Web Console`}

--- a/app/layouts/SiloLayout.tsx
+++ b/app/layouts/SiloLayout.tsx
@@ -8,7 +8,6 @@
 import { useMemo } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
-import { apiQueryClient, usePrefetchedApiQuery } from '@oxide/api'
 import {
   Access16Icon,
   Divider,
@@ -23,17 +22,12 @@ import { ProjectPicker, SiloSystemPicker } from 'app/components/TopBarPicker'
 import { useQuickActions } from 'app/hooks'
 import { pb } from 'app/util/path-builder'
 
-import { ContentPane, PageContainer } from './helpers'
-
-SiloLayout.loader = async () => {
-  await apiQueryClient.prefetchQuery('currentUserView', {})
-  return null
-}
+import { ContentPane, PageContainer, useCurrentUser } from './helpers'
 
 export function SiloLayout() {
   const navigate = useNavigate()
   const { pathname } = useLocation()
-  const { data: user } = usePrefetchedApiQuery('currentUserView', {})
+  const { me } = useCurrentUser()
 
   useQuickActions(
     useMemo(
@@ -47,11 +41,11 @@ export function SiloLayout() {
           // filter out the entry for the path we're currently on
           .filter((i) => i.path !== pathname)
           .map((i) => ({
-            navGroup: `Silo '${user.siloName}'`,
+            navGroup: `Silo '${me.siloName}'`,
             value: i.value,
             onSelect: () => navigate(i.path),
           })),
-      [pathname, navigate, user.siloName]
+      [pathname, navigate, me.siloName]
     )
   )
 
@@ -66,7 +60,7 @@ export function SiloLayout() {
           <DocsLinkItem />
         </Sidebar.Nav>
         <Divider />
-        <Sidebar.Nav heading={user.siloName}>
+        <Sidebar.Nav heading={me.siloName}>
           <NavLinkItem to={pb.projects()}>
             <Folder16Icon /> Projects
           </NavLinkItem>

--- a/app/layouts/SystemLayout.tsx
+++ b/app/layouts/SystemLayout.tsx
@@ -8,7 +8,7 @@
 import { useMemo } from 'react'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
 
-import { apiQueryClient, usePrefetchedApiQuery } from '@oxide/api'
+import { apiQueryClient } from '@oxide/api'
 import {
   Cloud16Icon,
   Divider,
@@ -24,7 +24,7 @@ import { SiloPicker, SiloSystemPicker } from 'app/components/TopBarPicker'
 import { useQuickActions } from 'app/hooks'
 import { pb } from 'app/util/path-builder'
 
-import { ContentPane, PageContainer } from './helpers'
+import { ContentPane, PageContainer, useCurrentUser } from './helpers'
 
 /**
  * If we can see the policy, we're a fleet viewer, and we need to be a fleet
@@ -46,7 +46,6 @@ SystemLayout.loader = async () => {
   // pretty unlikely.
   if (!isFleetViewer) throw trigger404
 
-  await apiQueryClient.prefetchQuery('currentUserView', {})
   return null
 }
 
@@ -59,7 +58,7 @@ export default function SystemLayout() {
   const navigate = useNavigate()
   const { pathname } = useLocation()
 
-  const { data: user } = usePrefetchedApiQuery('currentUserView', {})
+  const { me } = useCurrentUser()
 
   const actions = useMemo(() => {
     const systemLinks = [
@@ -76,12 +75,12 @@ export default function SystemLayout() {
       }))
 
     const backToSilo = {
-      navGroup: `Back to current silo '${user.siloName}'`,
+      navGroup: `Back to current silo '${me.siloName}'`,
       value: 'Projects',
       onSelect: () => navigate(pb.projects()),
     }
     return [...systemLinks, backToSilo]
-  }, [pathname, navigate, user.siloName])
+  }, [pathname, navigate, me.siloName])
 
   useQuickActions(actions)
 

--- a/app/layouts/helpers.tsx
+++ b/app/layouts/helpers.tsx
@@ -8,10 +8,10 @@
 import { useRef } from 'react'
 import { Outlet } from 'react-router-dom'
 
-import { apiQueryClient } from '@oxide/api'
+import { apiQueryClient, useApiQueryErrorsAllowed, usePrefetchedApiQuery } from '@oxide/api'
 import { Pagination } from '@oxide/pagination'
 import { SkipLinkTarget } from '@oxide/ui'
-import { classed } from '@oxide/util'
+import { classed, invariant } from '@oxide/util'
 
 import { PageActionsTarget } from 'app/components/PageActions'
 import { useScrollRestoration } from 'app/hooks/use-scroll-restoration'
@@ -54,11 +54,16 @@ export const SerialConsoleContentPane = () => (
   </div>
 )
 
-/** Loader for the `<Route>` that wraps all authenticated routes. */
-export const userLoader = async () => {
+/**
+ * Loader for the `<Route>` that wraps all authenticated routes. We use
+ * `shouldRevalidate={() => true}` to force this to re-run on every nav, but the
+ * longer-than-default `staleTime` avoids fetching too much.
+ */
+export const currentUserLoader = async () => {
+  const staleTime = 60000
   await Promise.all([
-    apiQueryClient.prefetchQuery('currentUserView', {}),
-    apiQueryClient.prefetchQuery('currentUserGroups', {}),
+    apiQueryClient.prefetchQuery('currentUserView', {}, { staleTime }),
+    apiQueryClient.prefetchQuery('currentUserGroups', {}, { staleTime }),
     // Need to prefetch this because every layout hits it when deciding whether
     // to show the silo/system picker. It's also fetched by the SystemLayout
     // loader to figure out whether to 404, but RQ dedupes the request.
@@ -68,8 +73,33 @@ export const userLoader = async () => {
       {
         explanation: '/v1/system/policy 403 is expected if user is not a fleet viewer.',
         expectedStatusCode: 403,
+        staleTime,
       }
     ),
   ])
   return null
+}
+
+/**
+ * Access all the data fetched by `currentUserLoader`. Because of the
+ * `shouldRevalidate` trick, that loader runs on every authenticated page, which
+ * means callers do not have to worry about hitting these endpoints themselves
+ * in their own loaders.
+ */
+export function useCurrentUser() {
+  const { data: me } = usePrefetchedApiQuery('currentUserView', {})
+  const { data: myGroups } = usePrefetchedApiQuery('currentUserGroups', {})
+
+  // User can only get to system routes if they have viewer perms (at least) on
+  // the fleet. The natural place to find out whether they have such perms is
+  // the fleet (system) policy, but if the user doesn't have fleet read, we'll
+  // get a 403 from that endpoint. So we simply check whether that endpoint 200s
+  // or not to determine whether the user is a fleet viewer.
+  const { data: systemPolicy } = useApiQueryErrorsAllowed('systemPolicyView', {})
+  // don't use usePrefetchedApiQuery because it's not worth making an errors
+  // allowed version of that
+  invariant(systemPolicy, 'System policy must be prefetched')
+  const isFleetViewer = systemPolicy.type === 'success'
+
+  return { me, myGroups, isFleetViewer }
 }

--- a/app/pages/SiloUtilizationPage.tsx
+++ b/app/pages/SiloUtilizationPage.tsx
@@ -16,19 +16,17 @@ import { bytesToGiB, bytesToTiB } from '@oxide/util'
 import { useIntervalPicker } from 'app/components/RefetchIntervalPicker'
 import { SiloMetric } from 'app/components/SystemMetric'
 import { useDateTimeRangePicker } from 'app/components/form'
+import { useCurrentUser } from 'app/layouts/helpers'
 
 const toListboxItem = (x: { name: string; id: string }) => ({ label: x.name, value: x.id })
 
 SiloUtilizationPage.loader = async () => {
-  await Promise.all([
-    apiQueryClient.prefetchQuery('projectList', {}),
-    apiQueryClient.prefetchQuery('currentUserView', {}),
-  ])
+  await apiQueryClient.prefetchQuery('projectList', {})
   return null
 }
 
 export function SiloUtilizationPage() {
-  const { data: me } = usePrefetchedApiQuery('currentUserView', {})
+  const { me } = useCurrentUser()
 
   const siloId = me.siloId
 

--- a/app/pages/settings/ProfilePage.tsx
+++ b/app/pages/settings/ProfilePage.tsx
@@ -8,11 +8,11 @@
 import { useForm } from 'react-hook-form'
 
 import type { Group } from '@oxide/api'
-import { apiQueryClient, usePrefetchedApiQuery } from '@oxide/api'
 import { Table, createColumnHelper, useReactTable } from '@oxide/table'
 import { Settings24Icon } from '@oxide/ui'
 
 import { FullPageForm, TextField } from 'app/components/form'
+import { useCurrentUser } from 'app/layouts/helpers'
 
 const colHelper = createColumnHelper<Group>()
 
@@ -21,24 +21,15 @@ const columns = [
   colHelper.accessor('displayName', { header: 'Name' }),
 ]
 
-ProfilePage.loader = async () => {
-  await Promise.all([
-    apiQueryClient.prefetchQuery('currentUserView', {}),
-    apiQueryClient.prefetchQuery('currentUserGroups', {}),
-  ])
-  return null
-}
-
 export function ProfilePage() {
-  const { data: user } = usePrefetchedApiQuery('currentUserView', {})
-  const { data: groups } = usePrefetchedApiQuery('currentUserGroups', {})
+  const { me, myGroups } = useCurrentUser()
 
-  const groupsTable = useReactTable({ columns, data: groups.items })
+  const groupsTable = useReactTable({ columns, data: myGroups.items })
 
   const form = useForm({
     mode: 'all',
     defaultValues: {
-      id: user.id,
+      id: me.id,
     },
   })
 
@@ -57,7 +48,7 @@ export function ProfilePage() {
         required
         disabled
         fieldClassName="!cursor-default"
-        value={user?.id}
+        value={me.id}
         control={form.control}
       />
       <h2>Groups</h2>

--- a/app/routes.tsx
+++ b/app/routes.tsx
@@ -34,7 +34,7 @@ import RootLayout from './layouts/RootLayout'
 import SettingsLayout from './layouts/SettingsLayout'
 import { SiloLayout } from './layouts/SiloLayout'
 import SystemLayout from './layouts/SystemLayout'
-import { SerialConsoleContentPane, userLoader } from './layouts/helpers'
+import { SerialConsoleContentPane, currentUserLoader } from './layouts/helpers'
 import DeviceAuthSuccessPage from './pages/DeviceAuthSuccessPage'
 import DeviceAuthVerifyPage from './pages/DeviceAuthVerifyPage'
 import { LoginPage } from './pages/LoginPage'
@@ -89,14 +89,14 @@ export const routes = createRoutesFromElements(
     </Route>
 
     {/* This wraps all routes that are supposed to be authenticated */}
-    <Route loader={userLoader} errorElement={<RouterDataErrorBoundary />}>
+    <Route
+      loader={currentUserLoader}
+      errorElement={<RouterDataErrorBoundary />}
+      // very important. see `currentUserLoader` and `useCurrentUser`
+      shouldRevalidate={() => true}
+    >
       <Route path="settings" handle={{ crumb: 'settings' }} element={<SettingsLayout />}>
-        <Route
-          path="profile"
-          element={<ProfilePage />}
-          loader={ProfilePage.loader}
-          handle={{ crumb: 'Profile' }}
-        />
+        <Route path="profile" element={<ProfilePage />} handle={{ crumb: 'Profile' }} />
         <Route element={<SSHKeysPage />} loader={SSHKeysPage.loader}>
           <Route path="ssh-keys" handle={{ crumb: 'SSH Keys' }} element={null} />
           <Route
@@ -172,7 +172,7 @@ export const routes = createRoutesFromElements(
       {/* These are done here instead of nested so we don't flash a layout on 404s */}
       <Route path="projects/:project" element={<Navigate to="instances" replace />} />
 
-      <Route element={<SiloLayout />} loader={SiloLayout.loader}>
+      <Route element={<SiloLayout />}>
         <Route
           path="images"
           element={<SiloImagesPage />}


### PR DESCRIPTION
I always have #1703 in the back of my mind, and one of the biggest problems there (one instance of which was fixed in #1674) is that the top-level loader wrapping all authenticated pages (fetch current user and groups and check if they're a fleet viewer)  does not run again for every nav. I thought this meant every page relying on those resources (mostly user and `isFleetViewer`) would have to do those fetches in their own loader to make sure those fetches are redone whenever they're needed. However! I remembered RR routes have [`shouldRevalidate`](https://reactrouter.com/en/main/route/should-revalidate) just like Remix, which means we can force the loader to re-run on every nav. The beautiful part is that because we're running everything through React Query, if the data is cached and not stale, the loader re-run is near-instant (like 20ms). So this is all upside in terms of correctness and ease of use.

The changes:

- Add `shouldRevalidate={() => true}` to the `currentUserLoader` route
- Add special hook `useCurrentUser` that fetches the same data as `currentUserLoader`: `{ me, myGroups, isFleetViewer }` and use that everywhere we look at those things 