### PR TITLE
Explicit `AuthenticatedLayout`

### DIFF
--- a/app/components/TopBar.tsx
+++ b/app/components/TopBar.tsx
@@ -18,7 +18,7 @@ import {
   buttonStyle,
 } from '@oxide/ui'
 
-import { useCurrentUser } from 'app/layouts/helpers'
+import { useCurrentUser } from 'app/layouts/AuthenticatedLayout'
 import { pb } from 'app/util/path-builder'
 
 export function TopBar({ children }: { children: React.ReactNode }) {

--- a/app/components/TopBarPicker.tsx
+++ b/app/components/TopBarPicker.tsx
@@ -22,7 +22,7 @@ import {
 } from '@oxide/ui'
 
 import { useInstanceSelector, useSiloSelector } from 'app/hooks'
-import { useCurrentUser } from 'app/layouts/helpers'
+import { useCurrentUser } from 'app/layouts/AuthenticatedLayout'
 import { pb } from 'app/util/path-builder'
 
 type TopBarPickerItem = {

--- a/app/hooks/use-quick-actions.tsx
+++ b/app/hooks/use-quick-actions.tsx
@@ -12,7 +12,7 @@ import { create } from 'zustand'
 import { ActionMenu, type QuickActionItem } from '@oxide/ui'
 import { invariant } from '@oxide/util'
 
-import { useCurrentUser } from 'app/layouts/helpers'
+import { useCurrentUser } from 'app/layouts/AuthenticatedLayout'
 import { pb } from 'app/util/path-builder'
 
 import { useKey } from './use-key'

--- a/app/layouts/AuthenticatedLayout.tsx
+++ b/app/layouts/AuthenticatedLayout.tsx
@@ -1,0 +1,72 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
+ */
+import { Outlet } from 'react-router-dom'
+
+import { apiQueryClient, useApiQueryErrorsAllowed, usePrefetchedApiQuery } from '@oxide/api'
+import { invariant } from '@oxide/util'
+
+import { QuickActions } from 'app/hooks'
+
+/**
+ * We use `shouldRevalidate={() => true}` to force this to re-run on every nav,
+ * but the longer-than-default `staleTime` avoids fetching too much.
+ */
+AuthenticatedLayout.loader = async () => {
+  const staleTime = 60000
+  await Promise.all([
+    apiQueryClient.prefetchQuery('currentUserView', {}, { staleTime }),
+    apiQueryClient.prefetchQuery('currentUserGroups', {}, { staleTime }),
+    // Need to prefetch this because every layout hits it when deciding whether
+    // to show the silo/system picker. It's also fetched by the SystemLayout
+    // loader to figure out whether to 404, but RQ dedupes the request.
+    apiQueryClient.prefetchQueryErrorsAllowed(
+      'systemPolicyView',
+      {},
+      {
+        explanation: '/v1/system/policy 403 is expected if user is not a fleet viewer.',
+        expectedStatusCode: 403,
+        staleTime,
+      }
+    ),
+  ])
+  return null
+}
+
+/** Wraps all authenticated routes. */
+export function AuthenticatedLayout() {
+  return (
+    <>
+      <QuickActions />
+      <Outlet />
+    </>
+  )
+}
+
+/**
+ * Access all the data fetched by the loader. Because of the `shouldRevalidate`
+ * trick, that loader runs on every authenticated page, which means callers do
+ * not have to worry about hitting these endpoints themselves in their own
+ * loaders.
+ */
+export function useCurrentUser() {
+  const { data: me } = usePrefetchedApiQuery('currentUserView', {})
+  const { data: myGroups } = usePrefetchedApiQuery('currentUserGroups', {})
+
+  // User can only get to system routes if they have viewer perms (at least) on
+  // the fleet. The natural place to find out whether they have such perms is
+  // the fleet (system) policy, but if the user doesn't have fleet read, we'll
+  // get a 403 from that endpoint. So we simply check whether that endpoint 200s
+  // or not to determine whether the user is a fleet viewer.
+  const { data: systemPolicy } = useApiQueryErrorsAllowed('systemPolicyView', {})
+  // don't use usePrefetchedApiQuery because it's not worth making an errors
+  // allowed version of that
+  invariant(systemPolicy, 'System policy must be prefetched')
+  const isFleetViewer = systemPolicy.type === 'success'
+
+  return { me, myGroups, isFleetViewer }
+}

--- a/app/layouts/SiloLayout.tsx
+++ b/app/layouts/SiloLayout.tsx
@@ -22,7 +22,8 @@ import { ProjectPicker, SiloSystemPicker } from 'app/components/TopBarPicker'
 import { useQuickActions } from 'app/hooks'
 import { pb } from 'app/util/path-builder'
 
-import { ContentPane, PageContainer, useCurrentUser } from './helpers'
+import { useCurrentUser } from './AuthenticatedLayout'
+import { ContentPane, PageContainer } from './helpers'
 
 export function SiloLayout() {
   const navigate = useNavigate()

--- a/app/layouts/SystemLayout.tsx
+++ b/app/layouts/SystemLayout.tsx
@@ -24,7 +24,8 @@ import { SiloPicker, SiloSystemPicker } from 'app/components/TopBarPicker'
 import { useQuickActions } from 'app/hooks'
 import { pb } from 'app/util/path-builder'
 
-import { ContentPane, PageContainer, useCurrentUser } from './helpers'
+import { useCurrentUser } from './AuthenticatedLayout'
+import { ContentPane, PageContainer } from './helpers'
 
 /**
  * If we can see the policy, we're a fleet viewer, and we need to be a fleet

--- a/app/layouts/helpers.tsx
+++ b/app/layouts/helpers.tsx
@@ -8,10 +8,9 @@
 import { useRef } from 'react'
 import { Outlet } from 'react-router-dom'
 
-import { apiQueryClient, useApiQueryErrorsAllowed, usePrefetchedApiQuery } from '@oxide/api'
 import { Pagination } from '@oxide/pagination'
 import { SkipLinkTarget } from '@oxide/ui'
-import { classed, invariant } from '@oxide/util'
+import { classed } from '@oxide/util'
 
 import { PageActionsTarget } from 'app/components/PageActions'
 import { useScrollRestoration } from 'app/hooks/use-scroll-restoration'
@@ -53,53 +52,3 @@ export const SerialConsoleContentPane = () => (
     </div>
   </div>
 )
-
-/**
- * Loader for the `<Route>` that wraps all authenticated routes. We use
- * `shouldRevalidate={() => true}` to force this to re-run on every nav, but the
- * longer-than-default `staleTime` avoids fetching too much.
- */
-export const currentUserLoader = async () => {
-  const staleTime = 60000
-  await Promise.all([
-    apiQueryClient.prefetchQuery('currentUserView', {}, { staleTime }),
-    apiQueryClient.prefetchQuery('currentUserGroups', {}, { staleTime }),
-    // Need to prefetch this because every layout hits it when deciding whether
-    // to show the silo/system picker. It's also fetched by the SystemLayout
-    // loader to figure out whether to 404, but RQ dedupes the request.
-    apiQueryClient.prefetchQueryErrorsAllowed(
-      'systemPolicyView',
-      {},
-      {
-        explanation: '/v1/system/policy 403 is expected if user is not a fleet viewer.',
-        expectedStatusCode: 403,
-        staleTime,
-      }
-    ),
-  ])
-  return null
-}
-
-/**
- * Access all the data fetched by `currentUserLoader`. Because of the
- * `shouldRevalidate` trick, that loader runs on every authenticated page, which
- * means callers do not have to worry about hitting these endpoints themselves
- * in their own loaders.
- */
-export function useCurrentUser() {
-  const { data: me } = usePrefetchedApiQuery('currentUserView', {})
-  const { data: myGroups } = usePrefetchedApiQuery('currentUserGroups', {})
-
-  // User can only get to system routes if they have viewer perms (at least) on
-  // the fleet. The natural place to find out whether they have such perms is
-  // the fleet (system) policy, but if the user doesn't have fleet read, we'll
-  // get a 403 from that endpoint. So we simply check whether that endpoint 200s
-  // or not to determine whether the user is a fleet viewer.
-  const { data: systemPolicy } = useApiQueryErrorsAllowed('systemPolicyView', {})
-  // don't use usePrefetchedApiQuery because it's not worth making an errors
-  // allowed version of that
-  invariant(systemPolicy, 'System policy must be prefetched')
-  const isFleetViewer = systemPolicy.type === 'success'
-
-  return { me, myGroups, isFleetViewer }
-}

--- a/app/main.tsx
+++ b/app/main.tsx
@@ -16,7 +16,7 @@ import { SkipLink } from '@oxide/ui'
 
 import { ConfirmDeleteModal } from './components/ConfirmDeleteModal'
 import { ErrorBoundary } from './components/ErrorBoundary'
-import { QuickActions, ReduceMotion } from './hooks'
+import { ReduceMotion } from './hooks'
 // stripped out by rollup in production
 import { startMockAPI } from './msw-mock-api'
 import { routes } from './routes'
@@ -45,7 +45,6 @@ function render() {
     <StrictMode>
       <QueryClientProvider client={queryClient}>
         <ErrorBoundary>
-          <QuickActions />
           <ConfirmDeleteModal />
           <SkipLink id="skip-nav" />
           <ReduceMotion />

--- a/app/pages/SiloUtilizationPage.tsx
+++ b/app/pages/SiloUtilizationPage.tsx
@@ -16,7 +16,7 @@ import { bytesToGiB, bytesToTiB } from '@oxide/util'
 import { useIntervalPicker } from 'app/components/RefetchIntervalPicker'
 import { SiloMetric } from 'app/components/SystemMetric'
 import { useDateTimeRangePicker } from 'app/components/form'
-import { useCurrentUser } from 'app/layouts/helpers'
+import { useCurrentUser } from 'app/layouts/AuthenticatedLayout'
 
 const toListboxItem = (x: { name: string; id: string }) => ({ label: x.name, value: x.id })
 

--- a/app/pages/settings/ProfilePage.tsx
+++ b/app/pages/settings/ProfilePage.tsx
@@ -12,7 +12,7 @@ import { Table, createColumnHelper, useReactTable } from '@oxide/table'
 import { Settings24Icon } from '@oxide/ui'
 
 import { FullPageForm, TextField } from 'app/components/form'
-import { useCurrentUser } from 'app/layouts/helpers'
+import { useCurrentUser } from 'app/layouts/AuthenticatedLayout'
 
 const colHelper = createColumnHelper<Group>()
 

--- a/app/routes.tsx
+++ b/app/routes.tsx
@@ -28,13 +28,14 @@ import { CreateVpcSideModalForm } from './forms/vpc-create'
 import { EditVpcSideModalForm } from './forms/vpc-edit'
 import type { CrumbFunc } from './hooks/use-crumbs'
 import AuthLayout from './layouts/AuthLayout'
+import { AuthenticatedLayout } from './layouts/AuthenticatedLayout'
 import { LoginLayout } from './layouts/LoginLayout'
 import ProjectLayout from './layouts/ProjectLayout'
 import RootLayout from './layouts/RootLayout'
 import SettingsLayout from './layouts/SettingsLayout'
 import { SiloLayout } from './layouts/SiloLayout'
 import SystemLayout from './layouts/SystemLayout'
-import { SerialConsoleContentPane, currentUserLoader } from './layouts/helpers'
+import { SerialConsoleContentPane } from './layouts/helpers'
 import DeviceAuthSuccessPage from './pages/DeviceAuthSuccessPage'
 import DeviceAuthVerifyPage from './pages/DeviceAuthVerifyPage'
 import { LoginPage } from './pages/LoginPage'
@@ -90,7 +91,8 @@ export const routes = createRoutesFromElements(
 
     {/* This wraps all routes that are supposed to be authenticated */}
     <Route
-      loader={currentUserLoader}
+      element={<AuthenticatedLayout />}
+      loader={AuthenticatedLayout.loader}
       errorElement={<RouterDataErrorBoundary />}
       // very important. see `currentUserLoader` and `useCurrentUser`
       shouldRevalidate={() => true}


### PR DESCRIPTION
I noticed we rendered `<QuickActions />` at top top top level in `main.tsx`, which was fine because we weren't ever calling `useQuickActions` which would have caused it to be populated, but it's still wrong. I made a dedicated `AuthenticatedLayout` to go on the route where we were doing `currentUserLoader` that only renders `<QuickActions>` and an outlet.