### PR TITLE
Prevent banner from pushing content off screen

### DIFF
--- a/app/components/MswWarning.tsx
+++ b/app/components/MswWarning.tsx
@@ -27,7 +27,8 @@ export function MswWarning() {
   const closeModal = () => setIsOpen(false)
   return (
     <>
-      <label className="absolute flex h-10 w-full items-center justify-center text-sans-md text-info-secondary bg-info-secondary next-sibiling:pt-10">
+      {/* The [&+*]:pt-10 style is to ensure the page container isn't pushed out of screen as it uses 100vh for layout */}
+      <label className="absolute flex h-10 w-full items-center justify-center text-sans-md text-info-secondary bg-info-secondary [&+*]:pt-10">
         <Info16Icon className="mr-2" /> This is a technical preview.
         <button
           className="ml-2 flex items-center gap-0.5 text-sans-md hover:text-info"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -59,7 +59,6 @@ module.exports = {
       addVariant('svg', '& > svg')
       addVariant('children', '& > *')
       addVariant('between', '& > * + *')
-      addVariant('next-sibiling', '& + *')
       addVariant('selected', '.is-selected &')
       addVariant('disabled', '&.visually-disabled, &:disabled')
       addUtilities(


### PR DESCRIPTION
Fixes #1725 

As @david-crespo [pointed out](https://github.com/oxidecomputer/console/issues/1725#issuecomment-1673754373), the page container uses `100vh` for its height to aid in position the footer. Instead of reworking that I've made the banner `absolute` and added a CSS rule that adds padding to the top of its sibling to account for its height which corrects the alignment issues. 