### PR TITLE
Desktop layout on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <meta charset="utf-8" />
     <title>Oxide Console</title>
 
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=1050" />
 
     <link rel="icon" type="image/svg+xml" href="./app/assets/favicon.svg" />
     <link rel="icon" type="image/png" href="./app/assets/favicon.png" />


### PR DESCRIPTION
We have plans for full responsive layouts — but for the time being it's not the highest priority. For now we present them at a desktop width so the user can zoom in without a broken layout.

Worth checking on a few devices to ensure this works properly on mobile and isn't interfering with any rendering on desktop.