### PR TITLE
Fix missing modal backdrop

### DIFF
--- a/libs/ui/lib/modal/Modal.tsx
+++ b/libs/ui/lib/modal/Modal.tsx
@@ -58,7 +58,7 @@ export function Modal({ children, onDismiss, title, isOpen }: ModalProps) {
             >
               <Dialog.Portal>
                 <div
-                  className="DialogOverlay pointer-events-auto relative"
+                  className="DialogOverlay pointer-events-auto"
                   onClick={onDismiss}
                   aria-hidden
                 />


### PR DESCRIPTION
Noticed on the MSW preview. The `relative` class (unsure why it was there) was overriding `fixed` so it wasn't showing up properly.