### PR TITLE
Add loading state to ok button in confirm delete modal

### DIFF
--- a/app/test/e2e/images.e2e.ts
+++ b/app/test/e2e/images.e2e.ts
@@ -125,9 +125,13 @@ test('can delete an image from a project', async ({ page }) => {
   await page.goto('/projects/mock-project/images')
 
   await clickRowAction(page, 'image-3', 'Delete')
+  const spinner = page.getByRole('dialog').getByLabel('Spinner')
+  await expect(spinner).toBeHidden()
   await page.getByRole('button', { name: 'Confirm' }).click()
+  await expect(spinner).toBeVisible()
 
   // Check deletion was successful
   await expectVisible(page, ['text="image-3 has been deleted"'])
   await expectNotVisible(page, ['role=cell[name="image-3"]'])
+  await expect(spinner).toBeHidden()
 })

--- a/app/test/e2e/snapshots.e2e.ts
+++ b/app/test/e2e/snapshots.e2e.ts
@@ -63,7 +63,11 @@ test('Error on delete snapshot', async ({ page }) => {
   const modal = page.getByRole('dialog', { name: 'Confirm delete' })
   await expect(modal).toBeVisible()
 
+  const spinner = page.getByRole('dialog').getByLabel('Spinner')
+  await expect(spinner).toBeHidden()
+
   await page.getByRole('button', { name: 'Confirm' }).click()
+  await expect(spinner).toBeVisible()
 
   // modal closes, but row is not gone and error toast is visible
   await expect(modal).toBeHidden()

--- a/libs/ui/lib/modal/Modal.tsx
+++ b/libs/ui/lib/modal/Modal.tsx
@@ -118,6 +118,7 @@ Modal.Footer = ({
   onAction,
   actionType = 'primary',
   actionText,
+  actionLoading,
   cancelText,
   disabled = false,
 }: {
@@ -126,6 +127,7 @@ Modal.Footer = ({
   onAction: () => void
   actionType?: 'primary' | 'danger'
   actionText: React.ReactNode
+  actionLoading?: boolean
   cancelText?: string
   disabled?: boolean
 }) => (
@@ -135,7 +137,13 @@ Modal.Footer = ({
       <Button variant="secondary" size="sm" onClick={onDismiss}>
         {cancelText || 'Cancel'}
       </Button>
-      <Button size="sm" variant={actionType} onClick={onAction} disabled={disabled}>
+      <Button
+        size="sm"
+        variant={actionType}
+        onClick={onAction}
+        disabled={disabled}
+        loading={actionLoading}
+      >
         {actionText}
       </Button>
     </div>

--- a/libs/ui/lib/spinner/Spinner.tsx
+++ b/libs/ui/lib/spinner/Spinner.tsx
@@ -38,7 +38,7 @@ export const Spinner = ({
       viewBox={`0 0 ${frameSize + ' ' + frameSize}`}
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
-      aria-labelledby="Spinner"
+      aria-label="Spinner"
       className={cn('spinner', `spinner-${variant}`, `spinner-${size}`, className)}
     >
       <circle


### PR DESCRIPTION
Closes #1748. This covers all deletes, not just instance create.

![2023-09-05-confirm-delete-spinner](https://github.com/oxidecomputer/console/assets/3612203/6337b504-b909-4d07-9edd-119b28a9a6ed)
