### PR TITLE
Tweak playwright config

### DIFF
--- a/.github/workflows/lintBuildTest.yml
+++ b/.github/workflows/lintBuildTest.yml
@@ -96,7 +96,7 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: npx playwright install-deps
       - name: Run Playwright browser tests
-        run: npx playwright test --workers=2 --project=${{matrix.browser}}
+        run: npx playwright test --project=${{matrix.browser}}
       - uses: actions/upload-artifact@v3
         if: always()
         with:

--- a/app/test/e2e/image-upload.e2e.ts
+++ b/app/test/e2e/image-upload.e2e.ts
@@ -186,7 +186,7 @@ test.describe('Image upload', () => {
     // now let's try canceling by clicking out on the background over the side modal
     await page.getByLabel('4096').click()
 
-    await sleep(100)
+    await sleep(300)
 
     // without the onFocusOutside fix this is a higher number
     expect(confirmCount).toEqual(2)

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,8 +18,6 @@ const config: PlaywrightTestConfig = {
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
   timeout: 2 * 60 * 1000, // 2 minutes, surely overkill
   fullyParallel: true,
   use: {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,10 +14,12 @@ import { devices } from '@playwright/test'
 const config: PlaywrightTestConfig = {
   testDir: './app/test/e2e',
   testMatch: /\.e2e\.ts/,
-  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  // Fail the build on CI if you accidentally left test.only in the source code
   forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
+  // Retry on CI only
   retries: process.env.CI ? 2 : 0,
+  // use all available cores (2) on github actions. default is 50%, use that locally
+  workers: process.env.CI ? '100%' : undefined,
   timeout: 2 * 60 * 1000, // 2 minutes, surely overkill
   fullyParallel: true,
   use: {


### PR DESCRIPTION
We were actually overriding the config with `--workers=2` in the command in the workflow config, but I prefer to centralize that in the config. We now tell it to use `'100%'` of available cores ([which is 2 as of right now](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners)).