### PR TITLE
Use RHF validation mode `onTouched` instead of `all`

### DIFF
--- a/app/forms/disk-attach.tsx
+++ b/app/forms/disk-attach.tsx
@@ -5,13 +5,11 @@
  *
  * Copyright Oxide Computer Company
  */
-import { useForm } from 'react-hook-form'
-
 import type { ApiError } from '@oxide/api'
 import { useApiQuery } from '@oxide/api'
 
 import { ListboxField, SideModalForm } from 'app/components/form'
-import { useProjectSelector } from 'app/hooks'
+import { useForm, useProjectSelector } from 'app/hooks'
 
 const defaultValues = { name: '' }
 
@@ -44,7 +42,7 @@ export function AttachDiskSideModalForm({
       (d) => d.state.state === 'detached'
     ) || []
 
-  const form = useForm({ mode: 'all', defaultValues })
+  const form = useForm({ defaultValues })
 
   return (
     <SideModalForm

--- a/app/forms/disk-create.tsx
+++ b/app/forms/disk-create.tsx
@@ -7,7 +7,6 @@
  */
 import { format } from 'date-fns'
 import type { Control } from 'react-hook-form'
-import { useForm } from 'react-hook-form'
 import { useController } from 'react-hook-form'
 import type { NavigateFunction } from 'react-router-dom'
 import { useNavigate } from 'react-router-dom'
@@ -27,7 +26,7 @@ import {
   SideModalForm,
   toListboxItem,
 } from 'app/components/form'
-import { useProjectSelector, useToast } from 'app/hooks'
+import { useForm, useProjectSelector, useToast } from 'app/hooks'
 
 const blankDiskSource: DiskSource = {
   type: 'blank',
@@ -75,7 +74,7 @@ export function CreateDiskSideModalForm({
     },
   })
 
-  const form = useForm({ mode: 'all', defaultValues })
+  const form = useForm({ defaultValues })
 
   return (
     <SideModalForm

--- a/app/forms/firewall-rules-create.tsx
+++ b/app/forms/firewall-rules-create.tsx
@@ -6,7 +6,6 @@
  * Copyright Oxide Computer Company
  */
 import type { Control } from 'react-hook-form'
-import { useForm } from 'react-hook-form'
 import { useController } from 'react-hook-form'
 
 import {
@@ -33,7 +32,7 @@ import {
   SideModalForm,
   TextField,
 } from 'app/components/form'
-import { useVpcSelector } from 'app/hooks'
+import { useForm, useVpcSelector } from 'app/hooks'
 
 export type FirewallRuleValues = {
   enabled: boolean
@@ -461,7 +460,7 @@ export function CreateFirewallRuleForm({
     },
   })
 
-  const form = useForm({ mode: 'all', defaultValues })
+  const form = useForm({ defaultValues })
 
   return (
     <SideModalForm

--- a/app/forms/firewall-rules-edit.tsx
+++ b/app/forms/firewall-rules-edit.tsx
@@ -5,13 +5,11 @@
  *
  * Copyright Oxide Computer Company
  */
-import { useForm } from 'react-hook-form'
-
 import type { VpcFirewallRule } from '@oxide/api'
 import { firewallRuleGetToPut, useApiMutation, useApiQueryClient } from '@oxide/api'
 
 import { SideModalForm } from 'app/components/form'
-import { useVpcSelector } from 'app/hooks'
+import { useForm, useVpcSelector } from 'app/hooks'
 
 import { CommonFields, valuesToRuleUpdate } from './firewall-rules-create'
 import type { FirewallRuleValues } from './firewall-rules-create'
@@ -53,7 +51,7 @@ export function EditFirewallRuleForm({
     targets: originalRule.targets,
   }
 
-  const form = useForm({ mode: 'all', defaultValues })
+  const form = useForm({ defaultValues })
 
   // TODO: uhhhh how can this happen
   if (Object.keys(originalRule).length === 0) return null

--- a/app/forms/idp/create.tsx
+++ b/app/forms/idp/create.tsx
@@ -5,14 +5,13 @@
  *
  * Copyright Oxide Computer Company
  */
-import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router-dom'
 
 import { useApiMutation, useApiQueryClient } from '@oxide/api'
 
 import { DescriptionField, NameField, SideModalForm, TextField } from 'app/components/form'
 import { FileField } from 'app/components/form/fields'
-import { useSiloSelector, useToast } from 'app/hooks'
+import { useForm, useSiloSelector, useToast } from 'app/hooks'
 import { readBlobAsBase64 } from 'app/util/file'
 import { pb } from 'app/util/path-builder'
 
@@ -56,7 +55,7 @@ export function CreateIdpSideModalForm() {
     },
   })
 
-  const form = useForm({ mode: 'all', defaultValues })
+  const form = useForm({ defaultValues })
 
   return (
     <SideModalForm

--- a/app/forms/idp/edit.tsx
+++ b/app/forms/idp/edit.tsx
@@ -5,7 +5,6 @@
  *
  * Copyright Oxide Computer Company
  */
-import { useForm } from 'react-hook-form'
 import type { LoaderFunctionArgs } from 'react-router-dom'
 import { useNavigate } from 'react-router-dom'
 
@@ -14,7 +13,7 @@ import { Access16Icon, PropertiesTable, ResourceLabel, Truncate } from '@oxide/u
 import { formatDateTime } from '@oxide/util'
 
 import { DescriptionField, NameField, SideModalForm, TextField } from 'app/components/form'
-import { getIdpSelector, useIdpSelector } from 'app/hooks'
+import { getIdpSelector, useForm, useIdpSelector } from 'app/hooks'
 import { pb } from 'app/util/path-builder'
 
 EditIdpSideModalForm.loader = async ({ params }: LoaderFunctionArgs) => {
@@ -36,7 +35,7 @@ export function EditIdpSideModalForm() {
   const navigate = useNavigate()
   const onDismiss = () => navigate(pb.silo({ silo }))
 
-  const form = useForm({ mode: 'all', defaultValues: idp })
+  const form = useForm({ defaultValues: idp })
 
   return (
     <SideModalForm

--- a/app/forms/image-edit.tsx
+++ b/app/forms/image-edit.tsx
@@ -5,7 +5,6 @@
  *
  * Copyright Oxide Computer Company
  */
-import { useForm } from 'react-hook-form'
 import type { LoaderFunctionArgs } from 'react-router-dom'
 import { useNavigate } from 'react-router-dom'
 
@@ -17,6 +16,7 @@ import { DescriptionField, NameField, SideModalForm, TextField } from 'app/compo
 import {
   getProjectImageSelector,
   getSiloImageSelector,
+  useForm,
   useProjectImageSelector,
   useSiloImageSelector,
 } from 'app/hooks'
@@ -62,7 +62,7 @@ export function EditImageSideModalForm({
   type: 'Project' | 'Silo'
 }) {
   const navigate = useNavigate()
-  const form = useForm({ mode: 'all', defaultValues: image })
+  const form = useForm({ defaultValues: image })
 
   return (
     <SideModalForm

--- a/app/forms/image-from-snapshot.tsx
+++ b/app/forms/image-from-snapshot.tsx
@@ -6,7 +6,6 @@
  * Copyright Oxide Computer Company
  */
 import fileSize from 'filesize'
-import { useForm } from 'react-hook-form'
 import type { LoaderFunctionArgs } from 'react-router-dom'
 import { useNavigate } from 'react-router-dom'
 
@@ -20,7 +19,7 @@ import {
 import { PropertiesTable } from '@oxide/ui'
 
 import { DescriptionField, NameField, SideModalForm, TextField } from 'app/components/form'
-import { getProjectSnapshotSelector, useProjectSnapshotSelector } from 'app/hooks'
+import { getProjectSnapshotSelector, useForm, useProjectSnapshotSelector } from 'app/hooks'
 import { addToast } from 'app/stores/toast'
 import { pb } from 'app/util/path-builder'
 
@@ -60,7 +59,6 @@ export function CreateImageFromSnapshotSideModalForm() {
   })
 
   const form = useForm({
-    mode: 'all',
     defaultValues: {
       ...defaultValues,
       name: data.name,

--- a/app/forms/image-upload.tsx
+++ b/app/forms/image-upload.tsx
@@ -10,7 +10,6 @@ import filesize from 'filesize'
 import pMap from 'p-map'
 import pRetry from 'p-retry'
 import { useRef, useState } from 'react'
-import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router-dom'
 
 import type { ApiError, BlockSize, Disk, Snapshot } from '@oxide/api'
@@ -34,7 +33,7 @@ import {
   TextField,
 } from 'app/components/form'
 import { FileField } from 'app/components/form/fields'
-import { useProjectSelector } from 'app/hooks'
+import { useForm, useProjectSelector } from 'app/hooks'
 import { readBlobAsBase64 } from 'app/util/file'
 import { pb } from 'app/util/path-builder'
 
@@ -462,7 +461,7 @@ export function CreateImageSideModalForm() {
     setAllDone(true)
   }
 
-  const form = useForm({ mode: 'all', defaultValues })
+  const form = useForm({ defaultValues })
   const file = form.watch('imageFile')
 
   return (

--- a/app/forms/instance-create.tsx
+++ b/app/forms/instance-create.tsx
@@ -5,7 +5,7 @@
  *
  * Copyright Oxide Computer Company
  */
-import { useForm, useWatch } from 'react-hook-form'
+import { useWatch } from 'react-hook-form'
 import type { LoaderFunctionArgs } from 'react-router-dom'
 import { useNavigate } from 'react-router-dom'
 import type { SetRequired } from 'type-fest'
@@ -50,7 +50,7 @@ import {
   RadioFieldDyn,
   TextField,
 } from 'app/components/form'
-import { getProjectSelector, useProjectSelector, useToast } from 'app/hooks'
+import { getProjectSelector, useForm, useProjectSelector, useToast } from 'app/hooks'
 import { pb } from 'app/util/path-builder'
 
 export type InstanceCreateInput = Assign<
@@ -132,7 +132,7 @@ export function CreateInstanceForm() {
     bootDiskSize: Math.ceil(defaultImage?.size / GiB) * 2 || 10,
   }
 
-  const form = useForm({ mode: 'all', defaultValues })
+  const form = useForm({ defaultValues })
   const { control, setValue } = form
 
   const imageInput = useWatch({ control: control, name: 'image' })

--- a/app/forms/network-interface-create.tsx
+++ b/app/forms/network-interface-create.tsx
@@ -6,7 +6,6 @@
  * Copyright Oxide Computer Company
  */
 import { useMemo } from 'react'
-import { useForm } from 'react-hook-form'
 
 import type { ApiError, InstanceNetworkInterfaceCreate } from '@oxide/api'
 import { useApiQuery } from '@oxide/api'
@@ -20,7 +19,7 @@ import {
   SubnetListbox,
   TextField,
 } from 'app/components/form'
-import { useProjectSelector } from 'app/hooks'
+import { useForm, useProjectSelector } from 'app/hooks'
 
 const defaultValues: InstanceNetworkInterfaceCreate = {
   name: '',
@@ -52,7 +51,7 @@ export default function CreateNetworkInterfaceForm({
   const { data: vpcsData } = useApiQuery('vpcList', { query: projectSelector })
   const vpcs = useMemo(() => vpcsData?.items || [], [vpcsData])
 
-  const form = useForm({ mode: 'all', defaultValues })
+  const form = useForm({ defaultValues })
 
   return (
     <SideModalForm

--- a/app/forms/network-interface-edit.tsx
+++ b/app/forms/network-interface-edit.tsx
@@ -5,14 +5,12 @@
  *
  * Copyright Oxide Computer Company
  */
-import { useForm } from 'react-hook-form'
-
 import type { InstanceNetworkInterface } from '@oxide/api'
 import { useApiMutation, useApiQueryClient } from '@oxide/api'
 import { pick } from '@oxide/util'
 
 import { DescriptionField, NameField, SideModalForm } from 'app/components/form'
-import { useInstanceSelector } from 'app/hooks'
+import { useForm, useInstanceSelector } from 'app/hooks'
 
 type EditNetworkInterfaceFormProps = {
   editing: InstanceNetworkInterface
@@ -35,7 +33,7 @@ export default function EditNetworkInterfaceForm({
 
   const defaultValues = pick(editing, 'name', 'description') // satisfies NetworkInterfaceUpdate
 
-  const form = useForm({ mode: 'all', defaultValues })
+  const form = useForm({ defaultValues })
 
   return (
     <SideModalForm

--- a/app/forms/project-access.tsx
+++ b/app/forms/project-access.tsx
@@ -5,8 +5,6 @@
  *
  * Copyright Oxide Computer Company
  */
-import { useForm } from 'react-hook-form'
-
 import {
   updateRole,
   useActorsNotInPolicy,
@@ -15,7 +13,7 @@ import {
 } from '@oxide/api'
 
 import { ListboxField, SideModalForm } from 'app/components/form'
-import { useProjectSelector } from 'app/hooks'
+import { useForm, useProjectSelector } from 'app/hooks'
 
 import type { AddRoleModalProps, EditRoleModalProps } from './access-util'
 import { actorToItem, defaultValues, roleItems } from './access-util'
@@ -33,7 +31,7 @@ export function ProjectAccessAddUserSideModal({ onDismiss, policy }: AddRoleModa
     },
   })
 
-  const form = useForm({ mode: 'all', defaultValues })
+  const form = useForm({ defaultValues })
 
   return (
     <SideModalForm
@@ -93,7 +91,7 @@ export function ProjectAccessEditUserSideModal({
     },
   })
 
-  const form = useForm({ mode: 'all', defaultValues })
+  const form = useForm({ defaultValues })
 
   return (
     <SideModalForm

--- a/app/forms/project-create.tsx
+++ b/app/forms/project-create.tsx
@@ -5,13 +5,13 @@
  *
  * Copyright Oxide Computer Company
  */
-import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router-dom'
 
 import type { ProjectCreate } from '@oxide/api'
 import { useApiMutation, useApiQueryClient } from '@oxide/api'
 
 import { DescriptionField, NameField, SideModalForm } from 'app/components/form'
+import { useForm } from 'app/hooks'
 import { addToast } from 'app/stores/toast'
 import { pb } from 'app/util/path-builder'
 
@@ -39,7 +39,7 @@ export function CreateProjectSideModalForm() {
 
   // TODO: RHF docs warn about the performance impact of validating on every
   // change
-  const form = useForm({ mode: 'all', defaultValues })
+  const form = useForm({ defaultValues })
 
   return (
     <SideModalForm

--- a/app/forms/project-edit.tsx
+++ b/app/forms/project-edit.tsx
@@ -5,7 +5,6 @@
  *
  * Copyright Oxide Computer Company
  */
-import { useForm } from 'react-hook-form'
 import type { LoaderFunctionArgs } from 'react-router-dom'
 import { useNavigate } from 'react-router-dom'
 
@@ -17,6 +16,7 @@ import {
 } from '@oxide/api'
 
 import { DescriptionField, NameField, SideModalForm } from 'app/components/form'
+import { useForm } from 'app/hooks'
 import { pb } from 'app/util/path-builder'
 
 import { getProjectSelector, useProjectSelector, useToast } from '../hooks'
@@ -50,7 +50,7 @@ export function EditProjectSideModalForm() {
     },
   })
 
-  const form = useForm({ mode: 'all', defaultValues: project })
+  const form = useForm({ defaultValues: project })
 
   return (
     <SideModalForm

--- a/app/forms/silo-access.tsx
+++ b/app/forms/silo-access.tsx
@@ -5,8 +5,6 @@
  *
  * Copyright Oxide Computer Company
  */
-import { useForm } from 'react-hook-form'
-
 import {
   updateRole,
   useActorsNotInPolicy,
@@ -15,6 +13,7 @@ import {
 } from '@oxide/api'
 
 import { ListboxField, SideModalForm } from 'app/components/form'
+import { useForm } from 'app/hooks'
 
 import { actorToItem, defaultValues, roleItems } from './access-util'
 import type { AddRoleModalProps, EditRoleModalProps } from './access-util'
@@ -30,7 +29,7 @@ export function SiloAccessAddUserSideModal({ onDismiss, policy }: AddRoleModalPr
     },
   })
 
-  const form = useForm({ mode: 'all', defaultValues })
+  const form = useForm({ defaultValues })
 
   return (
     <SideModalForm
@@ -87,7 +86,7 @@ export function SiloAccessEditUserSideModal({
       onDismiss()
     },
   })
-  const form = useForm({ mode: 'all', defaultValues })
+  const form = useForm({ defaultValues })
 
   return (
     <SideModalForm

--- a/app/forms/silo-create.tsx
+++ b/app/forms/silo-create.tsx
@@ -5,7 +5,6 @@
  *
  * Copyright Oxide Computer Company
  */
-import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router-dom'
 
 import type { SiloCreate } from '@oxide/api'
@@ -19,7 +18,7 @@ import {
   SideModalForm,
   TextField,
 } from 'app/components/form'
-import { useToast } from 'app/hooks'
+import { useForm, useToast } from 'app/hooks'
 import { pb } from 'app/util/path-builder'
 
 type FormValues = Omit<SiloCreate, 'mappedFleetRoles'> & {
@@ -54,7 +53,7 @@ export function CreateSiloSideModalForm() {
     },
   })
 
-  const form = useForm({ mode: 'all', defaultValues })
+  const form = useForm({ defaultValues })
 
   return (
     <SideModalForm

--- a/app/forms/snapshot-create.tsx
+++ b/app/forms/snapshot-create.tsx
@@ -5,7 +5,6 @@
  *
  * Copyright Oxide Computer Company
  */
-import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router-dom'
 
 import type { PathParams as PP, SnapshotCreate } from '@oxide/api'
@@ -18,7 +17,7 @@ import {
   NameField,
   SideModalForm,
 } from 'app/components/form'
-import { useProjectSelector, useToast } from 'app/hooks'
+import { useForm, useProjectSelector, useToast } from 'app/hooks'
 import { pb } from 'app/util/path-builder'
 
 const useSnapshotDiskItems = (projectSelector: PP.Project) => {
@@ -56,7 +55,7 @@ export function CreateSnapshotSideModalForm() {
     },
   })
 
-  const form = useForm({ mode: 'all', defaultValues })
+  const form = useForm({ defaultValues })
 
   return (
     <SideModalForm

--- a/app/forms/ssh-key-create.tsx
+++ b/app/forms/ssh-key-create.tsx
@@ -5,13 +5,13 @@
  *
  * Copyright Oxide Computer Company
  */
-import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router-dom'
 
 import type { SshKeyCreate } from '@oxide/api'
 import { useApiMutation, useApiQueryClient } from '@oxide/api'
 
 import { DescriptionField, NameField, SideModalForm, TextField } from 'app/components/form'
+import { useForm } from 'app/hooks'
 import { pb } from 'app/util/path-builder'
 
 const defaultValues: SshKeyCreate = {
@@ -32,7 +32,7 @@ export function CreateSSHKeySideModalForm() {
       onDismiss()
     },
   })
-  const form = useForm({ mode: 'all', defaultValues })
+  const form = useForm({ defaultValues })
 
   return (
     <SideModalForm

--- a/app/forms/subnet-create.tsx
+++ b/app/forms/subnet-create.tsx
@@ -5,14 +5,12 @@
  *
  * Copyright Oxide Computer Company
  */
-import { useForm } from 'react-hook-form'
-
 import type { VpcSubnetCreate } from '@oxide/api'
 import { useApiMutation, useApiQueryClient } from '@oxide/api'
 import { FormDivider } from '@oxide/ui'
 
 import { DescriptionField, NameField, SideModalForm, TextField } from 'app/components/form'
-import { useVpcSelector } from 'app/hooks'
+import { useForm, useVpcSelector } from 'app/hooks'
 
 const defaultValues: VpcSubnetCreate = {
   name: '',
@@ -35,7 +33,7 @@ export function CreateSubnetForm({ onDismiss }: CreateSubnetFormProps) {
     },
   })
 
-  const form = useForm({ mode: 'all', defaultValues })
+  const form = useForm({ defaultValues })
 
   return (
     <SideModalForm

--- a/app/forms/subnet-edit.tsx
+++ b/app/forms/subnet-edit.tsx
@@ -5,14 +5,12 @@
  *
  * Copyright Oxide Computer Company
  */
-import { useForm } from 'react-hook-form'
-
 import type { VpcSubnet } from '@oxide/api'
 import { useApiMutation, useApiQueryClient } from '@oxide/api'
 import { pick } from '@oxide/util'
 
 import { DescriptionField, NameField, SideModalForm } from 'app/components/form'
-import { useVpcSelector } from 'app/hooks'
+import { useForm, useVpcSelector } from 'app/hooks'
 
 type EditSubnetFormProps = {
   onDismiss: () => void
@@ -32,7 +30,7 @@ export function EditSubnetForm({ onDismiss, editing }: EditSubnetFormProps) {
 
   const defaultValues = pick(editing, 'name', 'description') /* satisfies VpcSubnetUpdate */
 
-  const form = useForm({ mode: 'all', defaultValues })
+  const form = useForm({ defaultValues })
 
   return (
     <SideModalForm

--- a/app/forms/vpc-create.tsx
+++ b/app/forms/vpc-create.tsx
@@ -5,14 +5,13 @@
  *
  * Copyright Oxide Computer Company
  */
-import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router-dom'
 
 import type { VpcCreate } from '@oxide/api'
 import { useApiMutation, useApiQueryClient } from '@oxide/api'
 
 import { DescriptionField, NameField, SideModalForm, TextField } from 'app/components/form'
-import { useProjectSelector, useToast } from 'app/hooks'
+import { useForm, useProjectSelector, useToast } from 'app/hooks'
 import { pb } from 'app/util/path-builder'
 
 const defaultValues: VpcCreate = {
@@ -41,7 +40,7 @@ export function CreateVpcSideModalForm() {
     },
   })
 
-  const form = useForm({ mode: 'all', defaultValues })
+  const form = useForm({ defaultValues })
 
   return (
     <SideModalForm

--- a/app/forms/vpc-edit.tsx
+++ b/app/forms/vpc-edit.tsx
@@ -5,7 +5,6 @@
  *
  * Copyright Oxide Computer Company
  */
-import { useForm } from 'react-hook-form'
 import type { LoaderFunctionArgs } from 'react-router-dom'
 import { useNavigate } from 'react-router-dom'
 
@@ -17,7 +16,7 @@ import {
 } from '@oxide/api'
 
 import { DescriptionField, NameField, SideModalForm } from 'app/components/form'
-import { getVpcSelector, useToast, useVpcSelector } from 'app/hooks'
+import { getVpcSelector, useForm, useToast, useVpcSelector } from 'app/hooks'
 import { pb } from 'app/util/path-builder'
 
 EditVpcSideModalForm.loader = async ({ params }: LoaderFunctionArgs) => {
@@ -52,7 +51,7 @@ export function EditVpcSideModalForm() {
     },
   })
 
-  const form = useForm({ mode: 'all', defaultValues: vpc })
+  const form = useForm({ defaultValues: vpc })
 
   return (
     <SideModalForm

--- a/app/forms/vpc-router-create.tsx
+++ b/app/forms/vpc-router-create.tsx
@@ -5,13 +5,11 @@
  *
  * Copyright Oxide Computer Company
  */
-import { useForm } from 'react-hook-form'
-
 import type { VpcRouterCreate } from '@oxide/api'
 import { useApiMutation, useApiQueryClient } from '@oxide/api'
 
 import { DescriptionField, NameField, SideModalForm } from 'app/components/form'
-import { useToast, useVpcSelector } from 'app/hooks'
+import { useForm, useToast, useVpcSelector } from 'app/hooks'
 
 const defaultValues: VpcRouterCreate = {
   name: '',
@@ -41,7 +39,7 @@ export function CreateVpcRouterForm({ onDismiss }: CreateVpcRouterFormProps) {
     },
   })
 
-  const form = useForm({ mode: 'all', defaultValues })
+  const form = useForm({ defaultValues })
 
   return (
     <SideModalForm

--- a/app/forms/vpc-router-edit.tsx
+++ b/app/forms/vpc-router-edit.tsx
@@ -5,14 +5,12 @@
  *
  * Copyright Oxide Computer Company
  */
-import { useForm } from 'react-hook-form'
-
 import type { VpcRouter } from '@oxide/api'
 import { useApiMutation, useApiQueryClient } from '@oxide/api'
 import { pick } from '@oxide/util'
 
 import { DescriptionField, NameField, SideModalForm } from 'app/components/form'
-import { useVpcSelector } from 'app/hooks'
+import { useForm, useVpcSelector } from 'app/hooks'
 
 type EditVpcRouterFormProps = {
   onDismiss: () => void
@@ -31,7 +29,7 @@ export function EditVpcRouterForm({ onDismiss, editing }: EditVpcRouterFormProps
   })
 
   const defaultValues = pick(editing, 'name', 'description') /* satisfies VpcRouterUpdate */
-  const form = useForm({ mode: 'all', defaultValues })
+  const form = useForm({ defaultValues })
 
   return (
     <SideModalForm

--- a/app/hooks/index.ts
+++ b/app/hooks/index.ts
@@ -6,9 +6,10 @@
  * Copyright Oxide Computer Company
  */
 
-export * from './use-quick-actions'
+export * from './use-form'
+export * from './use-is-overflow'
 export * from './use-key'
 export * from './use-params'
-export * from './use-toast'
+export * from './use-quick-actions'
 export * from './use-reduce-motion'
-export * from './use-is-overflow'
+export * from './use-toast'

--- a/app/hooks/use-form.ts
+++ b/app/hooks/use-form.ts
@@ -1,0 +1,21 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
+ */
+import { type FieldValues, type UseFormProps, useForm as _useForm } from 'react-hook-form'
+
+/**
+ * Same as built-in `useForm` except `mode: 'onTouched'` is hard-coded and the
+ * caller can't set it. `onTouched` means the first validation on a field is
+ * triggered by blur, after which it updates with every change.
+ *
+ * See https://react-hook-form.com/docs/useform#mode
+ */
+export function useForm<TFieldValues extends FieldValues = FieldValues>(
+  props?: Omit<UseFormProps<TFieldValues>, 'mode'>
+) {
+  return _useForm({ mode: 'onTouched', ...props })
+}

--- a/app/pages/LoginPage.tsx
+++ b/app/pages/LoginPage.tsx
@@ -6,7 +6,6 @@
  * Copyright Oxide Computer Company
  */
 import { useEffect } from 'react'
-import { useForm } from 'react-hook-form'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 
 import type { UsernamePasswordCredentials } from '@oxide/api'
@@ -15,6 +14,7 @@ import { Button, Identicon } from '@oxide/ui'
 
 import { TextFieldInner } from 'app/components/form'
 import 'app/components/login-page.css'
+import { useForm } from 'app/hooks'
 import { pb } from 'app/util/path-builder'
 
 import { useSiloSelector, useToast } from '../hooks'

--- a/app/pages/settings/ProfilePage.tsx
+++ b/app/pages/settings/ProfilePage.tsx
@@ -5,13 +5,12 @@
  *
  * Copyright Oxide Computer Company
  */
-import { useForm } from 'react-hook-form'
-
 import type { Group } from '@oxide/api'
 import { Table, createColumnHelper, useReactTable } from '@oxide/table'
 import { Settings24Icon } from '@oxide/ui'
 
 import { FullPageForm, TextField } from 'app/components/form'
+import { useForm } from 'app/hooks'
 import { useCurrentUser } from 'app/layouts/AuthenticatedLayout'
 
 const colHelper = createColumnHelper<Group>()
@@ -27,7 +26,6 @@ export function ProfilePage() {
   const groupsTable = useReactTable({ columns, data: myGroups.items })
 
   const form = useForm({
-    mode: 'all',
     defaultValues: {
       id: me.id,
     },

--- a/app/pages/system/SiloImagesPage.tsx
+++ b/app/pages/system/SiloImagesPage.tsx
@@ -6,7 +6,7 @@
  * Copyright Oxide Computer Company
  */
 import { useMemo, useState } from 'react'
-import { type FieldValues, useForm } from 'react-hook-form'
+import { type FieldValues } from 'react-hook-form'
 import { Outlet } from 'react-router-dom'
 
 import {
@@ -29,7 +29,7 @@ import {
 } from '@oxide/ui'
 
 import { ListboxField, toListboxItem } from 'app/components/form'
-import { useToast } from 'app/hooks'
+import { useForm, useToast } from 'app/hooks'
 import { pb } from 'app/util/path-builder'
 
 const EmptyState = () => (

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "react-aria": "^3.25.0",
         "react-dom": "^18.2.0",
         "react-error-boundary": "^4.0.4",
-        "react-hook-form": "^7.43.9",
+        "react-hook-form": "^7.47.0",
         "react-is": "^18.2.0",
         "react-merge-refs": "^2.0.2",
         "react-router-dom": "^6.14.2",
@@ -15817,9 +15817,9 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.43.9",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.43.9.tgz",
-      "integrity": "sha512-AUDN3Pz2NSeoxQ7Hs6OhQhDr6gtF9YRuutGDwPQqhSUAHJSgGl2VeY3qN19MG0SucpjgDiuMJ4iC5T5uB+eaNQ==",
+      "version": "7.47.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.47.0.tgz",
+      "integrity": "sha512-F/TroLjTICipmHeFlMrLtNLceO2xr1jU3CyiNla5zdwsGUGu2UOxxR4UyJgLlhMwLW/Wzp4cpJ7CPfgJIeKdSg==",
       "engines": {
         "node": ">=12.22.0"
       },
@@ -30564,9 +30564,9 @@
       }
     },
     "react-hook-form": {
-      "version": "7.43.9",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.43.9.tgz",
-      "integrity": "sha512-AUDN3Pz2NSeoxQ7Hs6OhQhDr6gtF9YRuutGDwPQqhSUAHJSgGl2VeY3qN19MG0SucpjgDiuMJ4iC5T5uB+eaNQ==",
+      "version": "7.47.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.47.0.tgz",
+      "integrity": "sha512-F/TroLjTICipmHeFlMrLtNLceO2xr1jU3CyiNla5zdwsGUGu2UOxxR4UyJgLlhMwLW/Wzp4cpJ7CPfgJIeKdSg==",
       "requires": {}
     },
     "react-hotkeys-hook": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "react-aria": "^3.25.0",
     "react-dom": "^18.2.0",
     "react-error-boundary": "^4.0.4",
-    "react-hook-form": "^7.43.9",
+    "react-hook-form": "^7.47.0",
     "react-is": "^18.2.0",
     "react-merge-refs": "^2.0.2",
     "react-router-dom": "^6.14.2",


### PR DESCRIPTION
Closes #1761 

Does not do #1289 because it still validates on that first blur even if you didn't type anything.

`onTouched` validates first on blur, and after that on change. I think I like that, but I'm flexible. `onBlur` is almost the same except it always validates on blur instead of change. The annoying thing to me about blur only is that if you go into a field with a validation error and correct it, the error won't go away until you blur. I find that a little surprising.

On the implementation side I considered just replacing `mode: 'all'` with `mode: 'onTouched'` in all the call sites, and could definitely change it to that, but it feels slightly less error-prone to me to use the shared wrapper, and then you don't have the noise of the `mode` at every call site.

<details>
<summary>Full table of <code>mode</code> options from the RFD docs</summary>
<img width="781" alt="image" src="https://github.com/oxidecomputer/console/assets/3612203/bf801841-30d5-4469-bd89-5f24d48746be">
</details>


https://github.com/oxidecomputer/console/assets/3612203/278b0098-cde6-44bc-8c40-40326781350e


