### PR TITLE
Add snapshot action to instance disks list

### DIFF
--- a/app/test/e2e/instance/disks.e2e.ts
+++ b/app/test/e2e/instance/disks.e2e.ts
@@ -5,7 +5,15 @@
  *
  * Copyright Oxide Computer Company
  */
-import { expect, expectNotVisible, expectVisible, stopInstance, test } from '../utils'
+import {
+  clickRowAction,
+  expect,
+  expectNotVisible,
+  expectRowVisible,
+  expectVisible,
+  stopInstance,
+  test,
+} from '../utils'
 
 test('Attach disk', async ({ page }) => {
   await page.goto('/projects/mock-project/instances/db1')
@@ -56,4 +64,24 @@ test('Attach disk', async ({ page }) => {
 
   await page.click('role=button[name="Attach Disk"]')
   await expectVisible(page, ['role=cell[name="disk-3"]'])
+})
+
+test('Snapshot disk', async ({ page }) => {
+  await page.goto('/projects/mock-project/instances/db1')
+
+  // have to use nth with toasts because the text shows up in multiple spots
+  const successMsg = page.getByText('Snapshot successfully created').nth(0)
+  await expect(successMsg).toBeHidden()
+
+  await clickRowAction(page, 'disk-2', 'Snapshot')
+
+  await expect(successMsg).toBeVisible() // we see the toast!
+
+  // now go see the snapshot on the snapshots page
+  await page.getByRole('link', { name: 'Snapshots' }).click()
+  const table = page.getByRole('table')
+  await expectRowVisible(table, {
+    name: expect.stringMatching(/^disk-2-/),
+    disk: 'disk-2',
+  })
 })

--- a/app/test/e2e/utils.ts
+++ b/app/test/e2e/utils.ts
@@ -47,6 +47,12 @@ export async function expectNotVisible(page: Page, selectors: Selector[]) {
   }
 }
 
+// Technically this has type AsymmetricMatcher, which is not exported by
+// Playwright and is (surprisingly) just Record<string, any>. Rather than use
+// that, I think it's smarter to do the following in case they ever make the
+// type more interesting; this will still do what it's supposed to.
+type StringMatcher = ReturnType<typeof expect.stringMatching>
+
 /**
  * Assert that a row matching `expectedRow` is present in `table`. The match
  * uses `objectContaining`, so `expectedRow` does not need to contain every
@@ -55,7 +61,7 @@ export async function expectNotVisible(page: Page, selectors: Selector[]) {
  */
 export async function expectRowVisible(
   table: Locator,
-  expectedRow: Record<string, string>
+  expectedRow: Record<string, string | StringMatcher>
 ) {
   // wait for header and rows to avoid flake town
   const headerLoc = table.locator('thead >> role=cell')


### PR DESCRIPTION
Closes #1771 

Confirmation toast continues to be unimpressive. That will be addressed with #1211.

![2023-10-05-instance-disk-snapshot](https://github.com/oxidecomputer/console/assets/3612203/0de63ae8-a346-47db-881e-b4ff2a125a18)
