### PR TITLE
Show mutation error on snapshot-to-image form

### DIFF
--- a/app/components/form/SideModalForm.tsx
+++ b/app/components/form/SideModalForm.tsx
@@ -29,7 +29,7 @@ type SideModalFormProps<TFieldValues extends FieldValues> = {
   /** Must be provided with a reason describing why it's disabled */
   submitDisabled?: string
   /** Error from the API call */
-  submitError?: ApiError | null
+  submitError: ApiError | null
   loading?: boolean
   title: string
   subtitle?: ReactNode

--- a/app/forms/idp/edit.tsx
+++ b/app/forms/idp/edit.tsx
@@ -48,6 +48,8 @@ export function EditIdpSideModalForm() {
           <Access16Icon /> {idp.name}
         </ResourceLabel>
       }
+      // TODO: pass actual error when this form is hooked up
+      submitError={null}
     >
       <PropertiesTable>
         <PropertiesTable.Row label="ID">

--- a/app/forms/image-edit.tsx
+++ b/app/forms/image-edit.tsx
@@ -75,6 +75,8 @@ export function EditImageSideModalForm({
           <Images16Icon /> {image.name}
         </ResourceLabel>
       }
+      // TODO: pass actual error when this form is hooked up
+      submitError={null}
     >
       <PropertiesTable>
         <PropertiesTable.Row label="Shared with">{type}</PropertiesTable.Row>

--- a/app/forms/image-from-snapshot.tsx
+++ b/app/forms/image-from-snapshot.tsx
@@ -78,6 +78,7 @@ export function CreateImageFromSnapshotSideModalForm() {
           body: { ...body, source: { type: 'snapshot', id: data.id } },
         })
       }
+      submitError={createImage.error}
     >
       <PropertiesTable>
         <PropertiesTable.Row label="Snapshot">{data.name}</PropertiesTable.Row>

--- a/app/test/e2e/snapshots.e2e.ts
+++ b/app/test/e2e/snapshots.e2e.ts
@@ -101,3 +101,18 @@ test('Create image from snapshot', async ({ page }) => {
     description: 'image description',
   })
 })
+
+test('Create image from snapshot, name taken', async ({ page }) => {
+  await page.goto('/projects/mock-project/snapshots')
+
+  const row = page.getByRole('row', { name: 'snapshot-1' })
+  await row.getByRole('button', { name: 'Row actions' }).click()
+  await page.getByRole('menuitem', { name: 'Create image' }).click()
+
+  await expectVisible(page, ['role=dialog[name="Create image from snapshot"]'])
+
+  await page.fill('role=textbox[name="Name"]', 'image-1')
+  await page.click('role=button[name="Create image"]')
+
+  await expect(page.getByText('name already exists').nth(0)).toBeVisible()
+})


### PR DESCRIPTION
Closes #1778

Trivial fix. Turns out we can easily make `submitError` a required prop and prevent this in future. In placeholder forms where we don't have a mutation (image edit and IdP edit) we can just pass null.