### PR TITLE
Fix sled instances prefetch

### DIFF
--- a/app/layouts/SystemLayout.tsx
+++ b/app/layouts/SystemLayout.tsx
@@ -65,7 +65,7 @@ export default function SystemLayout() {
     const systemLinks = [
       { value: 'Silos', path: pb.silos() },
       { value: 'Utilization', path: pb.systemUtilization() },
-      { value: 'Inventory', path: pb.sledInventory() },
+      { value: 'Inventory', path: pb.inventory() },
     ]
       // filter out the entry for the path we're currently on
       .filter((i) => i.path !== pathname)

--- a/app/routes.tsx
+++ b/app/routes.tsx
@@ -156,7 +156,11 @@ export const routes = createRoutesFromElements(
           loader={SledPage.loader}
           handle={{ crumb: 'Sleds' }}
         >
-          <Route index element={<Navigate to="instances" replace />} />
+          <Route
+            index
+            element={<Navigate to="instances" replace />}
+            loader={SledInstancesTab.loader}
+          />
           <Route
             path="instances"
             element={<SledInstancesTab />}

--- a/app/routes.tsx
+++ b/app/routes.tsx
@@ -147,6 +147,7 @@ export const routes = createRoutesFromElements(
           loader={InventoryPage.loader}
           handle={{ crumb: 'Inventory' }}
         >
+          <Route index element={<Navigate to="sleds" replace />} loader={SledsTab.loader} />
           <Route path="sleds" element={<SledsTab />} loader={SledsTab.loader} />
           <Route path="disks" element={<DisksTab />} loader={DisksTab.loader} />
         </Route>

--- a/app/util/path-builder.spec.ts
+++ b/app/util/path-builder.spec.ts
@@ -37,6 +37,7 @@ test('path builder', () => {
         "instancePage": "/projects/p/instances/i/storage",
         "instanceStorage": "/projects/p/instances/i/storage",
         "instances": "/projects/p/instances",
+        "inventory": "/system/inventory",
         "nics": "/projects/p/instances/i/network-interfaces",
         "profile": "/settings/profile",
         "project": "/projects/p",

--- a/app/util/path-builder.ts
+++ b/app/util/path-builder.ts
@@ -80,6 +80,7 @@ export const pb = {
   systemNetworking: () => '/system/networking',
   systemSettings: () => '/system/settings',
 
+  inventory: () => '/system/inventory',
   rackInventory: () => '/system/inventory/racks',
   sledInventory: () => '/system/inventory/sleds',
   diskInventory: () => '/system/inventory/disks',


### PR DESCRIPTION
I noticed on rack3 that when navigating from sleds list to sled detail (instances tab), there was a delay before the instances table would show up. We were prefetching it, so I figured out it's because the sled detail link goes to `/sleds/abc123`, and then we do a little client-side redirect from there to `/sleds/abc123/instances`, and the loader is on the latter. Strictly speaking I think this might be a bug in React Router, but in the meantime we can fix this either by having the link from the sled list go directly to `/sleds/abc123/instances` or by adding the loader to that redirect route (as I've done here). I vaguely remember there being a problem with this when I tried it before on another page, so I'll leave this up while we mull it over.