### PR TITLE
Stick the api client on `window` 

### DIFF
--- a/libs/api/index.ts
+++ b/libs/api/index.ts
@@ -25,6 +25,13 @@ export const api = new Api({
   host: process.env.NODE_ENV === 'test' ? 'http://testhost' : '',
 })
 
+// add the API client to window for use from the browser JS console. requests
+// will use the session cookie, same as normal API calls
+if (typeof window !== 'undefined') {
+  // @ts-expect-error
+  window.oxide = api.methods
+}
+
 export type ApiMethods = typeof api.methods
 
 export const useApiQuery = getUseApiQuery(api.methods)


### PR DESCRIPTION
Kinda fun, kinda handy. Uses your session cookie like all other API requests.

<img width="329" alt="image" src="https://github.com/oxidecomputer/console/assets/3612203/cc9f4e4b-c826-4ea0-8619-927283ab3187">

<img width="978" alt="image" src="https://github.com/oxidecomputer/console/assets/3612203/92c2f720-894c-4157-a007-f5928ef2d0d7">
