### PR TITLE
Update width of time picker to account for wider datetimes

### DIFF
--- a/libs/ui/lib/date-picker/DateRangePicker.tsx
+++ b/libs/ui/lib/date-picker/DateRangePicker.tsx
@@ -68,7 +68,7 @@ export function DateRangePicker(props: DateRangePickerProps) {
               : 'border-default ring-accent-secondary'
           )}
         >
-          <div className={cn('relative flex w-[16rem] items-center px-3 text-sans-md')}>
+          <div className={cn('relative flex w-[17rem] items-center px-3 text-sans-md')}>
             {label}
             {state.isInvalid && (
               <div className="absolute bottom-0 right-2 top-0 flex items-center text-error">


### PR DESCRIPTION
This PR just updates the width of the datetime picker container so it can handle wider values. Although [the original bug report ](https://github.com/oxidecomputer/console/issues/1728) shows the split line when the local datetime uses a leading zero, we'd see this same bug for certain datetimes with "wider" two-digit numbers in locales, as in the screenshots here.

Broken / split:
![Screenshot 2023-11-28 at 4 12 59 PM](https://github.com/oxidecomputer/console/assets/22547/191cc7e8-dfb5-490b-9085-f22826ec7edf)

Fixed / single-line:
![Screenshot 2023-11-28 at 4 35 49 PM](https://github.com/oxidecomputer/console/assets/22547/8c1d46ad-4a2e-4b60-a082-dd54ce7c5648)