### PR TITLE
Sleep after closing toast in E2E to reduce flake

### DIFF
--- a/app/test/e2e/utils.ts
+++ b/app/test/e2e/utils.ts
@@ -105,8 +105,10 @@ export async function expectRowVisible(
 export async function stopInstance(page: Page) {
   await page.click('role=button[name="Instance actions"]')
   await page.click('role=menuitem[name="Stop"]')
-  // close toast. for some reason it prevents things from happening
+  // close toast and wait for it to fade out. for some reason it prevents things
+  // from working, but only in tests as far as we can tell
   await page.click('role=button[name="Dismiss notification"]')
+  await sleep(2000)
 }
 
 /**


### PR DESCRIPTION
The tests have passed a bunch of times in a row, but flake being flake, that doesn't prove anything. Will revert if we see the flake again.