### PR TITLE
Show image size on image picker; clean up empty metadata; small color fix

### DIFF
--- a/app/components/form/fields/ImageSelectField.tsx
+++ b/app/components/form/fields/ImageSelectField.tsx
@@ -9,7 +9,7 @@ import { useController, type Control } from 'react-hook-form'
 
 import type { Image } from '@oxide/api'
 import type { ListboxItem } from '@oxide/ui'
-import { GiB } from '@oxide/util'
+import { bytesToGiB, GiB } from '@oxide/util'
 
 import type { InstanceCreateInput } from 'app/forms/instance-create'
 
@@ -44,20 +44,48 @@ export function ImageSelectField({ images, control }: ImageSelectFieldProps) {
 const Slash = () => <span className="mx-0.5 text-quinary">/</span>
 
 export function toListboxItem(i: Image, includeProjectSiloIndicator = false): ListboxItem {
-  const projectSiloIndicator = includeProjectSiloIndicator ? (
+  const { name, os, projectId, size, version } = i
+  const formattedSize = `${bytesToGiB(size, 1)} GiB`
+
+  // filter out any undefined metadata and create a comma-separated list
+  // for the selected listbox item (shown in labelString)
+  const condensedImageMetadata = [os, version, formattedSize].filter((i) => !!i).join(', ')
+  const metadataForLabelString = condensedImageMetadata.length
+    ? ` (${condensedImageMetadata})`
+    : ''
+
+  // for metadata showing in the dropdown's options, include the project / silo indicator if requested
+  const versionInfo = includeProjectSiloIndicator ? (
     <>
-      <Slash /> {i.projectId ? 'Project image' : 'Silo image'}
+      {version} <Slash /> {projectId ? 'Project image' : 'Silo image'}
     </>
-  ) : null
+  ) : (
+    version
+  )
+  // filter out undefined metadata here, as well, and create a `<Slash />`-separated list
+  // for the listbox item (shown for each item in the dropdown)
+  const metadataForLabel = [os, versionInfo, formattedSize]
+    .filter((i) => !!i)
+    .map((i, index) => (
+      <span key={`${i}`}>
+        {index > 0 ? (
+          <>
+            {' '}
+            <Slash />{' '}
+          </>
+        ) : (
+          ''
+        )}
+        {i}
+      </span>
+    ))
   return {
     value: i.id,
-    labelString: `${i.name} (${i.os}, ${i.version})`,
+    labelString: `${name}${metadataForLabelString}`,
     label: (
       <>
-        <div>{i.name}</div>
-        <div className="text-secondary">
-          {i.os} <Slash /> {i.version} {projectSiloIndicator}
-        </div>
+        <div>{name}</div>
+        <div>{metadataForLabel}</div>
       </>
     ),
   }

--- a/libs/util/math.spec.ts
+++ b/libs/util/math.spec.ts
@@ -7,7 +7,20 @@
  */
 import { expect, it } from 'vitest'
 
-import { splitDecimal } from './math'
+import { GiB } from '.'
+import { round, splitDecimal } from './math'
+
+it('rounds properly', () => {
+  expect(round(123.456, 0)).toEqual(123)
+  expect(round(123.456, 1)).toEqual(123.5)
+  expect(round(123.456, 2)).toEqual(123.46)
+  expect(round(123.456, 3)).toEqual(123.456)
+  expect(round(123.456, 4)).toEqual(123.456) // trailing zeros are culled
+  expect(round(1.9, 0)).toEqual(2)
+  expect(round(1.9, 1)).toEqual(1.9)
+  expect(round(5 / 2, 2)).toEqual(2.5) // math expressions are resolved
+  expect(round(1879048192 / GiB, 2)).toEqual(1.75) // constants can be evaluated
+})
 
 it.each([
   [1.23, ['1', '.23']],

--- a/libs/util/units.ts
+++ b/libs/util/units.ts
@@ -12,5 +12,5 @@ export const MiB = 1024 * KiB
 export const GiB = 1024 * MiB
 export const TiB = 1024 * GiB
 
-export const bytesToGiB = (b: number) => round(b / GiB, 2)
-export const bytesToTiB = (b: number) => round(b / TiB, 2)
+export const bytesToGiB = (b: number, precision = 2) => round(b / GiB, precision)
+export const bytesToTiB = (b: number, precision = 2) => round(b / TiB, precision)

--- a/libs/util/units.ts
+++ b/libs/util/units.ts
@@ -12,5 +12,5 @@ export const MiB = 1024 * KiB
 export const GiB = 1024 * MiB
 export const TiB = 1024 * GiB
 
-export const bytesToGiB = (b: number, precision = 2) => round(b / GiB, precision)
-export const bytesToTiB = (b: number, precision = 2) => round(b / TiB, precision)
+export const bytesToGiB = (b: number, digits = 2) => round(b / GiB, digits)
+export const bytesToTiB = (b: number, digits = 2) => round(b / TiB, digits)


### PR DESCRIPTION
This PR does a few things:
1. Per https://github.com/oxidecomputer/console/issues/1824, it adds the size of the image to the option in the image picker. It rounds the image size to one decimal place. (We already had a `bytesToGiB` function that defaulted to 2 decimal points; I updated that function to receive a `digits` prop (like the `round` function's prop) and set it, in this case, to 1 decimal point.) Note: Late in testing I noticed … it appears that the API is sending back an already-rounded-to-the-next-largest-GiB value, so we should look into whether that behavior is expected/wanted, though we can do that in a separate PR. 
2. Per https://github.com/oxidecomputer/console/issues/1777, it cleans up the label when data is missing from the image metadata (e.g. os, version). There might be some changes to the image upload form to change how that metadata is handled, but this at least makes it less awkward if data is missing. As there'll be the image's size now, there'll probably always be _some_ data, but we won't have the awkward comma delineation we currently have when some data is missing.
3.  Per https://github.com/oxidecomputer/console/issues/1830, it fixes the color of the metadata in the selected listbox item.

When decimals are showing below, it's because I forced a larger size. But these screenshots show what would happen:
<img width="531" alt="Screenshot 2023-12-05 at 7 27 38 PM" src="https://github.com/oxidecomputer/console/assets/22547/1af74c91-09c2-4040-a7d8-4ab4e97d2e21">
<img width="540" alt="Screenshot 2023-12-05 at 8 59 54 PM" src="https://github.com/oxidecomputer/console/assets/22547/57414fe2-b881-4d24-b8ae-1ded948388ac">

---

Up in item 1, I noted that the API is reporting image sizes as the next GiB up. Here you can see the API response calling the images, with this particular file reporting a size of 1073741824:
<img width="386" alt="Screenshot 2023-12-05 at 9 16 32 PM" src="https://github.com/oxidecomputer/console/assets/22547/4db4c11d-9861-426c-9589-33b0058e4653">