### PR TITLE
Turn off contextual alternates in the terminal

### DIFF
--- a/app/components/EquivalentCliCommand.tsx
+++ b/app/components/EquivalentCliCommand.tsx
@@ -32,8 +32,7 @@ export default function EquivalentCliCommand({ command }: { command: string }) {
       </Button>
       <Modal isOpen={isOpen} onDismiss={handleDismiss} title="CLI command">
         <Modal.Section>
-          {/* todo: fix the token to disable contextual alternates in the mono font */}
-          <pre className="flex w-full rounded border px-4 py-3 !normal-case !tracking-normal text-mono-md bg-default border-secondary [font-feature-settings:_'calt'_off]">
+          <pre className="flex w-full rounded border px-4 py-3 !normal-case !tracking-normal text-mono-md bg-default border-secondary">
             <div className="mr-2 select-none text-quaternary">$</div>
             {command}
           </pre>

--- a/app/components/Terminal.tsx
+++ b/app/components/Terminal.tsx
@@ -101,7 +101,10 @@ export const Terminal = ({ ws }: TerminalProps) => {
 
   return (
     <>
-      <div className="h-full w-[calc(100%-3rem)]" ref={terminalRef} />
+      <div
+        className="h-full w-[calc(100%-3rem)] [font-feature-settings:_'calt'_off]"
+        ref={terminalRef}
+      />
       <div className="absolute right-0 top-0 space-y-2 text-secondary">
         <ScrollButton onClick={() => term?.scrollToTop()}>
           <DirectionUpIcon />

--- a/app/components/Terminal.tsx
+++ b/app/components/Terminal.tsx
@@ -101,10 +101,7 @@ export const Terminal = ({ ws }: TerminalProps) => {
 
   return (
     <>
-      <div
-        className="h-full w-[calc(100%-3rem)] [font-feature-settings:_'calt'_off]"
-        ref={terminalRef}
-      />
+      <div className="h-full w-[calc(100%-3rem)] text-mono-code" ref={terminalRef} />
       <div className="absolute right-0 top-0 space-y-2 text-secondary">
         <ScrollButton onClick={() => term?.scrollToTop()}>
           <DirectionUpIcon />

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@floating-ui/react": "^0.26.0",
         "@headlessui/react": "^0.0.0-insiders.a9e8563",
-        "@oxide/design-system": "^1.2.2",
+        "@oxide/design-system": "^1.2.9",
         "@oxide/identicon": "0.0.4",
         "@radix-ui/react-dialog": "^1.0.3",
         "@radix-ui/react-dropdown-menu": "^2.0.4",
@@ -2462,9 +2462,9 @@
       "dev": true
     },
     "node_modules/@oxide/design-system": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@oxide/design-system/-/design-system-1.2.8.tgz",
-      "integrity": "sha512-JNTuZp/OnNlfbF+BUVMhtDdhwNtiOCbjBqWX3f/jXqC10xYZP+nXhqw1NFAXPQsTM5mMxjUVdu9wN6DHi/zZPQ==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@oxide/design-system/-/design-system-1.2.9.tgz",
+      "integrity": "sha512-uLKLFEmr7DTYXqTVhI1rdTRHR2x2tkkEGC2o2gzTse6fqvRxoKGAMhlWt2rMJMCI0hxgUIYuYPCaWO6/6smNBA==",
       "dependencies": {
         "@figma-export/output-components-as-svgr": "^4.7.0",
         "@floating-ui/react": "^0.25.1",
@@ -22450,9 +22450,9 @@
       "dev": true
     },
     "@oxide/design-system": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@oxide/design-system/-/design-system-1.2.8.tgz",
-      "integrity": "sha512-JNTuZp/OnNlfbF+BUVMhtDdhwNtiOCbjBqWX3f/jXqC10xYZP+nXhqw1NFAXPQsTM5mMxjUVdu9wN6DHi/zZPQ==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@oxide/design-system/-/design-system-1.2.9.tgz",
+      "integrity": "sha512-uLKLFEmr7DTYXqTVhI1rdTRHR2x2tkkEGC2o2gzTse6fqvRxoKGAMhlWt2rMJMCI0hxgUIYuYPCaWO6/6smNBA==",
       "requires": {
         "@figma-export/output-components-as-svgr": "^4.7.0",
         "@floating-ui/react": "^0.25.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@floating-ui/react": "^0.26.0",
     "@headlessui/react": "^0.0.0-insiders.a9e8563",
-    "@oxide/design-system": "^1.2.2",
+    "@oxide/design-system": "^1.2.9",
     "@oxide/identicon": "0.0.4",
     "@radix-ui/react-dialog": "^1.0.3",
     "@radix-ui/react-dropdown-menu": "^2.0.4",


### PR DESCRIPTION
Fixes #1840 

Context – many years ago when we cut a new version of the typeface, we (I) thought it might be cute to include the contextual alternate so that "Oxide" or "Ox" would look more brand-like when typed in the console. It's not cute, it's stupid, and that's my cross to bear.

This fixes the issue through an update to the type styles in `@oxide/design-system`. I've also merged in the stylistic sets we're using for the ASCII diagrams on the website, but these don't interfere with regular usage.