### PR TITLE
Add toast when snapshotting a disk

### DIFF
--- a/app/pages/project/disks/DisksPage.tsx
+++ b/app/pages/project/disks/DisksPage.tsx
@@ -93,6 +93,7 @@ export function DisksPage() {
     {
       label: 'Snapshot',
       onActivate() {
+        addToast({ content: `Creating snapshot of disk '${disk.name}'` })
         createSnapshot.mutate({
           query: projectSelector,
           body: {

--- a/app/pages/project/disks/DisksPage.tsx
+++ b/app/pages/project/disks/DisksPage.tsx
@@ -93,7 +93,7 @@ export function DisksPage() {
     {
       label: 'Snapshot',
       onActivate() {
-        addToast({ content: `Creating snapshot of disk '${disk.name}'` })
+        addToast({ title: `Creating snapshot of disk '${disk.name}'` })
         createSnapshot.mutate({
           query: projectSelector,
           body: {


### PR DESCRIPTION
Fixes #1815.

Adds a toast when snapshotting a disk so the user knows the process has kicked off.

<img width="400" alt="Screenshot 2023-12-12 at 11 17 50 AM" src="https://github.com/oxidecomputer/console/assets/22547/87a61a9c-ffb3-4242-be5a-1bd3b3cb3b21">
