### PR TITLE
Add quota inputs to silo create form

### DIFF
--- a/app/components/form/fields/TextField.tsx
+++ b/app/components/form/fields/TextField.tsx
@@ -53,6 +53,7 @@ export interface TextFieldProps<
    */
   description?: string
   placeholder?: string
+  tooltip?: string
   units?: string
   validate?: Validate<FieldPathValue<TFieldValues, TName>, TFieldValues>
   control: Control<TFieldValues>

--- a/app/components/form/fields/TextField.tsx
+++ b/app/components/form/fields/TextField.tsx
@@ -53,7 +53,6 @@ export interface TextFieldProps<
    */
   description?: string
   placeholder?: string
-  tooltip?: string
   units?: string
   validate?: Validate<FieldPathValue<TFieldValues, TName>, TFieldValues>
   control: Control<TFieldValues>

--- a/app/forms/silo-create.tsx
+++ b/app/forms/silo-create.tsx
@@ -44,6 +44,10 @@ const defaultValues: SiloCreateFormValues = {
   },
 }
 
+function validateQuota(value: number) {
+  if (value < 0) return 'Must be at least 0'
+}
+
 export function CreateSiloSideModalForm() {
   const navigate = useNavigate()
   const queryClient = useApiQueryClient()
@@ -106,6 +110,7 @@ export function CreateSiloSideModalForm() {
         required
         type="number"
         units="nCPUs"
+        validate={validateQuota}
       />
       <NumberField
         control={form.control}
@@ -114,6 +119,7 @@ export function CreateSiloSideModalForm() {
         required
         type="number"
         units="GiB"
+        validate={validateQuota}
       />
       <NumberField
         control={form.control}
@@ -122,6 +128,7 @@ export function CreateSiloSideModalForm() {
         required
         type="number"
         units="GiB"
+        validate={validateQuota}
       />
       <FormDivider />
       <RadioField

--- a/app/forms/silo-create.tsx
+++ b/app/forms/silo-create.tsx
@@ -117,7 +117,7 @@ export function CreateSiloSideModalForm() {
       />
       <NumberField
         control={form.control}
-        label="Disk quota"
+        label="Storage quota"
         name="quotas.storage"
         required
         type="number"

--- a/app/forms/silo-create.tsx
+++ b/app/forms/silo-create.tsx
@@ -19,6 +19,7 @@ import {
   TextField,
   TlsCertsField,
 } from 'app/components/form'
+import { NumberField } from 'app/components/form/fields/NumberField'
 import { useForm, useToast } from 'app/hooks'
 import { pb } from 'app/util/path-builder'
 
@@ -97,6 +98,32 @@ export function CreateSiloSideModalForm() {
       <CheckboxField name="discoverable" control={form.control}>
         Discoverable
       </CheckboxField>
+      <FormDivider />
+      <NumberField
+        control={form.control}
+        label="CPU quota"
+        name="quotas.cpus"
+        required
+        type="number"
+        units="nCPUs"
+      />
+      <NumberField
+        control={form.control}
+        label="Memory quota"
+        name="quotas.memory"
+        required
+        type="number"
+        units="GiB"
+      />
+      <NumberField
+        control={form.control}
+        label="Disk quota"
+        name="quotas.storage"
+        required
+        type="number"
+        units="GiB"
+      />
+      <FormDivider />
       <RadioField
         name="identityMode"
         label="Identity mode"

--- a/app/test/e2e/silos.e2e.ts
+++ b/app/test/e2e/silos.e2e.ts
@@ -25,7 +25,7 @@ test('Create silo', async ({ page }) => {
 
   await page.click('role=link[name="New silo"]')
 
-  // fill out form and submit
+  // fill out form
   await page.fill('role=textbox[name="Name"]', 'other-silo')
   await page.fill('role=textbox[name="Description"]', 'definitely a silo')
   await expect(page.locator('role=checkbox[name="Discoverable"]')).toBeChecked()
@@ -33,6 +33,9 @@ test('Create silo', async ({ page }) => {
   await page.click('role=radio[name="Local only"]')
   await page.fill('role=textbox[name="Admin group name"]', 'admins')
   await page.click('role=checkbox[name="Grant fleet admin role to silo admins"]')
+  await page.getByRole('textbox', { name: 'CPU quota (nCPUs)' }).fill('3')
+  await page.getByRole('textbox', { name: 'Memory quota (GiB)' }).fill('5')
+  await page.getByRole('textbox', { name: 'Storage quota (GiB)' }).fill('7')
 
   // Add a TLS cert
   const openCertModalButton = page.getByRole('button', { name: 'Add TLS certificate' })


### PR DESCRIPTION
Should have gotten in on my last PR, but I thought there'd be more to this form. There are a few more things we should do to polish it (some tooltip descriptions; smarter defaults), but this at least sets it up so users can set quotas when creating a silo.

![Screenshot 2023-12-14 at 11 32 36 AM](https://github.com/oxidecomputer/console/assets/22547/f4432591-0388-4fb9-a4d7-e29900b37956)
