### PR TITLE
Add silo charts to Utilization Page

### DIFF
--- a/app/components/CapacityBar.tsx
+++ b/app/components/CapacityBar.tsx
@@ -26,10 +26,17 @@ export const CapacityBar = ({
   includeUnit?: boolean
 }) => {
   const percentOfAllocatedUsed = (provisioned / allocated) * 100
-
   const [wholeNumber, decimal] = splitDecimal(percentOfAllocatedUsed)
-
   const formattedPercentUsed = `${percentOfAllocatedUsed}%`
+  const warningThreshold = 66
+  const errorThreshold = 75
+
+  const barColor =
+    percentOfAllocatedUsed > errorThreshold
+      ? 'bg-destructive-secondary border-destructive-secondary'
+      : percentOfAllocatedUsed > warningThreshold
+      ? 'bg-notice-secondary border-notice-secondary'
+      : 'bg-accent-secondary border-accent-secondary'
 
   return (
     <div className="w-full min-w-min rounded-lg border border-default">
@@ -51,7 +58,7 @@ export const CapacityBar = ({
         {/* the bar */}
         <div className="flex w-full gap-0.5">
           <div
-            className="h-3 rounded-l border bg-accent-secondary border-accent-secondary"
+            className={`h-3 rounded-l border ${barColor}`}
             style={{ width: formattedPercentUsed }}
           ></div>
           <div className="h-3 grow rounded-r border bg-info-secondary border-info-secondary"></div>

--- a/app/pages/system/UtilizationPage.tsx
+++ b/app/pages/system/UtilizationPage.tsx
@@ -51,23 +51,46 @@ export function SystemUtilizationPage() {
         <PageTitle icon={<Metrics24Icon />}>Utilization</PageTitle>
       </PageHeader>
 
+      <h2 className="p-3 text-mono-sm text-secondary">Total used across fleet</h2>
       <CapacityBars
         allocated={totalAllocated}
         provisioned={totalProvisioned}
         allocatedLabel="Quota (Total)"
       />
-      <QueryParamTabs defaultValue="summary" className="full-width">
+      <QueryParamTabs defaultValue="charts" className="full-width">
         <Tabs.List>
-          <Tabs.Trigger value="summary">Summary</Tabs.Trigger>
-          <Tabs.Trigger value="metrics">Metrics</Tabs.Trigger>
+          <Tabs.Trigger value="charts">Silo Charts</Tabs.Trigger>
+          <Tabs.Trigger value="table">Silo Table</Tabs.Trigger>
+          <Tabs.Trigger value="metrics">Fleet Metrics</Tabs.Trigger>
         </Tabs.List>
-        <Tabs.Content value="summary">
+        <Tabs.Content value="charts">
+          <ChartsTab />
+        </Tabs.Content>
+        <Tabs.Content value="table">
           <UsageTab />
         </Tabs.Content>
         <Tabs.Content value="metrics">
           <MetricsTab />
         </Tabs.Content>
       </QueryParamTabs>
+    </>
+  )
+}
+
+function ChartsTab() {
+  const { data: siloUtilizations } = usePrefetchedApiQuery('siloUtilizationList', {})
+  return (
+    <>
+      {siloUtilizations.items.map((silo) => (
+        <>
+          <h2 className="p-3 text-mono-sm text-secondary">{silo.siloName}</h2>
+          <CapacityBars
+            allocated={silo.allocated}
+            provisioned={silo.provisioned}
+            allocatedLabel="Quota"
+          />
+        </>
+      ))}
     </>
   )
 }

--- a/app/test/e2e/utilization.e2e.ts
+++ b/app/test/e2e/utilization.e2e.ts
@@ -12,7 +12,7 @@ import { expect, expectRowVisible, getPageAsUser, test } from './utils'
 
 test.describe('System utilization', () => {
   test('Works for fleet viewer', async ({ page }) => {
-    await page.goto('/system/utilization')
+    await page.goto('/system/utilization?tab=table')
 
     await expect(page.getByRole('heading', { name: 'Utilization' })).toBeVisible()
     await expect(page.getByText('Provisioned384 GiB')).toBeVisible()
@@ -45,7 +45,7 @@ test.describe('System utilization', () => {
 
 test.describe('Silo utilization', () => {
   test('works for fleet viewer', async ({ page }) => {
-    await page.goto('/utilization')
+    await page.goto('/utilization?tab=table')
     await expect(
       page.getByRole('heading', { name: 'Capacity & Utilization' })
     ).toBeVisible()


### PR DESCRIPTION
I floated this idea while chatting with @david-crespo and @zephraph, and wanted to create a quick proof of concept.

Essentially, this creates a page of silo-level charts, either to enhance or replace the existing table of silo data. The PR also puts it as the default view, which might or might not be what we want. I think it might be a little easier to understand it at a glance than the table, and has a bit of an "ooh shiny" appeal to it as well.

![Screenshot 2023-12-15 at 1 31 47 PM](https://github.com/oxidecomputer/console/assets/22547/77b861ad-dfd6-4829-8fcb-25fba8ac1f1e)

You'll note that it has a red bar for the element that's at a high threshold. Similarly, if we had bars over the warning threshold, we could make them yellow, similar to how we have the "ResourceMeter" component on the table data. (In time, we'll likely want to make those thresholds configurable by operators?)

Here's how it'd look if some of the data were over the "warning" threshold:
![image](https://github.com/oxidecomputer/console/assets/22547/fdd40bcd-e65f-4812-b782-ed20697dd9a6)
(this was an earlier screenshot, so some of the tab text and other small details in this screenshot are out-of-date with the PR)

I'm holding lightly to this, so if it goes nowhere, cool cool, but wanted to share it here for discussion.