### PR TITLE
Enable alternate icon on Message component

### DIFF
--- a/libs/ui/lib/message/Message.tsx
+++ b/libs/ui/lib/message/Message.tsx
@@ -72,7 +72,7 @@ export const Message = ({
   className,
   variant = 'success',
   cta,
-  icon = defaultIcon[variant],
+  icon,
 }: MessageProps) => {
   return (
     <div
@@ -83,7 +83,7 @@ export const Message = ({
         className
       )}
     >
-      <div className="mt-[2px] flex svg:h-3 svg:w-3">{icon}</div>
+      <div className="mt-[2px] flex svg:h-3 svg:w-3">{icon || defaultIcon[variant]}</div>
       <div className="flex-1 pl-2.5">
         {title && <div className="text-sans-semi-md">{title}</div>}
         <div

--- a/libs/ui/lib/message/Message.tsx
+++ b/libs/ui/lib/message/Message.tsx
@@ -27,6 +27,7 @@ export interface MessageProps {
     text: string
     link: To
   }
+  // try to use icons from the ___12Icon set, rather than forcing a 16px or 24px icon
   alternateIcon?: ReactElement
 }
 

--- a/libs/ui/lib/message/Message.tsx
+++ b/libs/ui/lib/message/Message.tsx
@@ -27,6 +27,7 @@ export interface MessageProps {
     text: string
     link: To
   }
+  alternateIcon?: ReactElement
 }
 
 const icon: Record<Variant, ReactElement> = {
@@ -70,6 +71,7 @@ export const Message = ({
   className,
   variant = 'success',
   cta,
+  alternateIcon,
 }: MessageProps) => {
   return (
     <div
@@ -80,7 +82,7 @@ export const Message = ({
         className
       )}
     >
-      <div className="mt-[2px] flex svg:h-3 svg:w-3">{icon[variant]}</div>
+      <div className="mt-[2px] flex svg:h-3 svg:w-3">{alternateIcon || icon[variant]}</div>
       <div className="flex-1 pl-2.5">
         {title && <div className="text-sans-semi-md">{title}</div>}
         <div

--- a/libs/ui/lib/message/Message.tsx
+++ b/libs/ui/lib/message/Message.tsx
@@ -28,10 +28,10 @@ export interface MessageProps {
     link: To
   }
   // try to use icons from the ___12Icon set, rather than forcing a 16px or 24px icon
-  alternateIcon?: ReactElement
+  icon?: ReactElement
 }
 
-const icon: Record<Variant, ReactElement> = {
+const defaultIcon: Record<Variant, ReactElement> = {
   success: <Success12Icon />,
   error: <Error12Icon />,
   notice: <Warning12Icon />,
@@ -72,7 +72,7 @@ export const Message = ({
   className,
   variant = 'success',
   cta,
-  alternateIcon,
+  icon = defaultIcon[variant],
 }: MessageProps) => {
   return (
     <div
@@ -83,7 +83,7 @@ export const Message = ({
         className
       )}
     >
-      <div className="mt-[2px] flex svg:h-3 svg:w-3">{alternateIcon || icon[variant]}</div>
+      <div className="mt-[2px] flex svg:h-3 svg:w-3">{icon}</div>
       <div className="flex-1 pl-2.5">
         {title && <div className="text-sans-semi-md">{title}</div>}
         <div


### PR DESCRIPTION
This came up in conversation with @benjaminleonard earlier and was quick to throw together.

We already have four kinds of Message — 'success' | 'error' | 'notice' | 'info'. Each has a default icon that shows up with it, as seen here:
![Screenshot 2023-12-20 at 11 44 00 AM](https://github.com/oxidecomputer/console/assets/22547/16831c30-2336-47a9-827f-0ea130e9cd38)

In a recent mock from @paryhin, we see the possibility of a different icon, to correspond to the message inside the box:
![Screenshot 2023-12-20 at 11 49 27 AM](https://github.com/oxidecomputer/console/assets/22547/94db61b3-0a3b-4e33-a5b7-30a7761333f7)

This PR adds a new optional prop to the Message component, allowing for an `alternateIcon`.
![Screenshot 2023-12-20 at 11 35 32 AM](https://github.com/oxidecomputer/console/assets/22547/4c4df927-4656-47f1-9eaf-e873513bf75d)
![Screenshot 2023-12-20 at 11 33 37 AM](https://github.com/oxidecomputer/console/assets/22547/c18d7495-c8c5-4e2d-a9a4-85a8ec40bb03)
![Screenshot 2023-12-20 at 11 34 35 AM](https://github.com/oxidecomputer/console/assets/22547/48f9a726-0925-4809-8b05-2c40f69fe14f)
![Screenshot 2023-12-20 at 11 34 58 AM](https://github.com/oxidecomputer/console/assets/22547/fbe1a562-afbc-4719-9530-0f53eba3f6a7)

The color of the icon is controlled by the `variant` prop, so the only thing that needs to be done here is to pass in one of the existing icon components.

One thing to note is that the Message will happily receive a 16px or 24px icon and will appropriately size it to the Message box, which is good from an ease-of-use standpoint, but might yield issues from an "if we're expecting a 12px icon, we should probably use a 12px icon" perspective. I've added a comment to that end.

Feel free to push back on any of it. If we nix the idea in the interest of consistency of message types (or any other reason), no worries.