### PR TITLE
Add htmlFor to form labels for number and text fields

### DIFF
--- a/app/components/form/fields/NumberField.tsx
+++ b/app/components/form/fields/NumberField.tsx
@@ -33,7 +33,7 @@ export function NumberField<
   return (
     <div className="max-w-lg">
       <div className="mb-2">
-        <FieldLabel id={`${id}-label`} tip={description} optional={!required}>
+        <FieldLabel htmlFor={id} id={`${id}-label`} tip={description} optional={!required}>
           {label} {units && <span className="ml-1 text-secondary">({units})</span>}
         </FieldLabel>
         {helpText && (

--- a/app/components/form/fields/TextField.tsx
+++ b/app/components/form/fields/TextField.tsx
@@ -75,7 +75,7 @@ export function TextField<
   return (
     <div className="max-w-lg">
       <div className="mb-2">
-        <FieldLabel id={`${id}-label`} tip={description} optional={!required}>
+        <FieldLabel htmlFor={id} id={`${id}-label`} tip={description} optional={!required}>
           {label} {units && <span className="ml-1 text-secondary">({units})</span>}
         </FieldLabel>
         {helpText && (


### PR DESCRIPTION
This PR sets up an association by default for the NumberField and TextField components between their \<label>s and \<input>s.

I know you know this; just logging for posterity: Although we already had the association from inputs back to their labels for accessibility, linking them with a `for` (or `htmlFor` for JSX) in the \<label> creates an association in the other direction, meaning clicking on the label will highlight the appropriate input.

Working on getting my .mov → GIF working, but for now, here's a screen recording of the effect:
https://github.com/oxidecomputer/console/assets/22547/dd364154-2a01-4355-98bf-9666eb4e8e3e

