### PR TITLE
Remove link to nonexistent Serial Console doc

### DIFF
--- a/app/pages/project/instances/instance/tabs/ConnectTab.tsx
+++ b/app/pages/project/instances/instance/tabs/ConnectTab.tsx
@@ -16,7 +16,6 @@ export function ConnectTab() {
   return (
     <SettingsGroup
       title="Serial Console"
-      docs={{ text: 'Serial Console', link: '/' }}
       cta={pb.serialConsole({ project, instance })}
       ctaText="Connect"
     >


### PR DESCRIPTION
Fixes #1870 

We can add the link back in once we have a working doc/guide for Serial Console