### PR TITLE
Add a tooltip with absolute datetime to relative time element

### DIFF
--- a/app/components/TimeAgo.tsx
+++ b/app/components/TimeAgo.tsx
@@ -1,0 +1,33 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
+ */
+
+import { format } from 'date-fns'
+
+import { Tooltip } from '@oxide/ui'
+
+import { timeAgoAbbr } from 'app/util/date'
+
+export const TimeAgo = ({
+  datetime,
+  description,
+}: {
+  datetime: Date
+  description?: string
+}): JSX.Element => {
+  const content = (
+    <div className="flex flex-col">
+      <span className="text-tertiary">{description}</span>
+      <span>{format(datetime, 'MMM d, yyyy p')}</span>
+    </div>
+  )
+  return (
+    <Tooltip content={content} placement="top">
+      <div className="text-sans-sm text-tertiary">{timeAgoAbbr(datetime)}</div>
+    </Tooltip>
+  )
+}

--- a/app/components/TimeAgo.tsx
+++ b/app/components/TimeAgo.tsx
@@ -5,7 +5,7 @@
  *
  * Copyright Oxide Computer Company
  */
-
+import type { Placement } from '@floating-ui/react'
 import { format } from 'date-fns'
 
 import { Tooltip } from '@oxide/ui'
@@ -15,9 +15,11 @@ import { timeAgoAbbr } from 'app/util/date'
 export const TimeAgo = ({
   datetime,
   description,
+  placement = 'top',
 }: {
   datetime: Date
   description?: string
+  placement?: Placement
 }): JSX.Element => {
   const content = (
     <div className="flex flex-col">
@@ -26,8 +28,10 @@ export const TimeAgo = ({
     </div>
   )
   return (
-    <Tooltip content={content} placement="top">
-      <div className="text-sans-sm text-tertiary">{timeAgoAbbr(datetime)}</div>
-    </Tooltip>
+    <span className="mt-0.5">
+      <Tooltip content={content} placement={placement}>
+        <span className="text-sans-sm text-tertiary">{timeAgoAbbr(datetime)}</span>
+      </Tooltip>
+    </span>
   )
 }

--- a/libs/table/cells/InstanceStatusCell.tsx
+++ b/libs/table/cells/InstanceStatusCell.tsx
@@ -8,21 +8,17 @@
 import type { Instance } from '@oxide/api'
 
 import { InstanceStatusBadge } from 'app/components/StatusBadge'
-import { timeAgoAbbr } from 'app/util/date'
+import { TimeAgo } from 'app/components/TimeAgo'
 
 import type { Cell } from './Cell'
-import { TwoLineCell } from './TwoLineCell'
 
 export const InstanceStatusCell = ({
   value,
 }: Cell<Pick<Instance, 'runState' | 'timeRunStateUpdated'>>) => {
   return (
-    <TwoLineCell
-      detailsClass="text-sans-sm"
-      value={[
-        <InstanceStatusBadge key="run-state" status={value.runState} />,
-        timeAgoAbbr(value.timeRunStateUpdated),
-      ]}
-    ></TwoLineCell>
+    <div className="space-y-0.5">
+      <InstanceStatusBadge key="run-state" status={value.runState} />
+      <TimeAgo description="Run state updated" datetime={value.timeRunStateUpdated} />
+    </div>
   )
 }

--- a/libs/table/cells/InstanceStatusCell.tsx
+++ b/libs/table/cells/InstanceStatusCell.tsx
@@ -16,7 +16,7 @@ export const InstanceStatusCell = ({
   value,
 }: Cell<Pick<Instance, 'runState' | 'timeRunStateUpdated'>>) => {
   return (
-    <div className="space-y-0.5">
+    <div className="flex flex-col">
       <InstanceStatusBadge key="run-state" status={value.runState} />
       <TimeAgo description="Run state updated" datetime={value.timeRunStateUpdated} />
     </div>


### PR DESCRIPTION
Fixes #641 

This PR pulls the formatted "X {seconds|minutes|hours|days|etc.} ago" relative time into a new component that also wraps it in a tooltip that renders the absolute value of that timestamp.

For example:
![Screenshot 2024-01-11 at 12 05 57 PM](https://github.com/oxidecomputer/console/assets/22547/e5aa1dd7-5ff5-4587-853b-57d784e8e9a6)

The description is optional; a relative time without that label still renders the absolute time appropriately:
![Screenshot 2024-01-11 at 12 06 44 PM](https://github.com/oxidecomputer/console/assets/22547/5e7be8d8-7ebb-45a9-a3a9-996c95962052)
