### PR TITLE
Improve clickability of link cells

### DIFF
--- a/libs/table/cells/LinkCell.tsx
+++ b/libs/table/cells/LinkCell.tsx
@@ -18,6 +18,7 @@ export const linkCell =
         to={makeHref(value)}
       >
         {value}
+        {/* Pushes out the link area to the entire cell for improved clickability™ */}
         <div className="absolute inset-0" />
       </Link>
     )

--- a/libs/table/cells/LinkCell.tsx
+++ b/libs/table/cells/LinkCell.tsx
@@ -13,8 +13,14 @@ export const linkCell =
   (makeHref: (value: string) => string) =>
   ({ value }: Cell<string>) => {
     return (
-      <Link className="text-sans-semi-md text-default hover:underline" to={makeHref(value)}>
-        {value}
-      </Link>
+      <>
+        <Link
+          className="link-cell absolute inset-0 flex h-full w-full"
+          to={makeHref(value)}
+        />
+        <span className="text-sans-semi-md text-default group-hover/cell:underline">
+          {value}
+        </span>
+      </>
     )
   }

--- a/libs/table/cells/LinkCell.tsx
+++ b/libs/table/cells/LinkCell.tsx
@@ -13,9 +13,14 @@ export const linkCell =
   (makeHref: (value: string) => string) =>
   ({ value }: Cell<string>) => {
     return (
-      <>
-        <Link className="peer absolute inset-0 flex h-full w-full" to={makeHref(value)} />
-        <span className="text-sans-semi-md text-default peer-hover:underline">{value}</span>
-      </>
+      <Link
+        className="flex h-full w-full items-center text-sans-semi-md text-default hover:underline"
+        aria-label={value}
+        to={makeHref(value)}
+      >
+        {value}
+
+        <div className="absolute inset-0" />
+      </Link>
     )
   }

--- a/libs/table/cells/LinkCell.tsx
+++ b/libs/table/cells/LinkCell.tsx
@@ -15,11 +15,9 @@ export const linkCell =
     return (
       <Link
         className="flex h-full w-full items-center text-sans-semi-md text-default hover:underline"
-        aria-label={value}
         to={makeHref(value)}
       >
         {value}
-
         <div className="absolute inset-0" />
       </Link>
     )

--- a/libs/table/cells/LinkCell.tsx
+++ b/libs/table/cells/LinkCell.tsx
@@ -14,13 +14,8 @@ export const linkCell =
   ({ value }: Cell<string>) => {
     return (
       <>
-        <Link
-          className="link-cell absolute inset-0 flex h-full w-full"
-          to={makeHref(value)}
-        />
-        <span className="text-sans-semi-md text-default group-hover/cell:underline">
-          {value}
-        </span>
+        <Link className="peer absolute inset-0 flex h-full w-full" to={makeHref(value)} />
+        <span className="text-sans-semi-md text-default peer-hover:underline">{value}</span>
       </>
     )
   }

--- a/libs/ui/lib/table/Table.tsx
+++ b/libs/ui/lib/table/Table.tsx
@@ -112,7 +112,7 @@ Table.Cell = ({ height = 'large', className, children, ...props }: TableCellProp
     >
       <div
         className={cn(
-          '-my-[1px] -mr-[2px] flex items-center border-b border-l py-3 pl-3 pr-3 border-secondary',
+          'group/cell -my-[1px] -mr-[2px] flex items-center border-b border-l py-3 pl-3 pr-3 border-secondary',
           heightClass
         )}
       >

--- a/libs/ui/lib/table/Table.tsx
+++ b/libs/ui/lib/table/Table.tsx
@@ -112,7 +112,7 @@ Table.Cell = ({ height = 'large', className, children, ...props }: TableCellProp
     >
       <div
         className={cn(
-          'group/cell -my-[1px] -mr-[2px] flex items-center border-b border-l py-3 pl-3 pr-3 border-secondary',
+          '-my-[1px] -mr-[2px] flex items-center border-b border-l py-3 pl-3 pr-3 border-secondary',
           heightClass
         )}
       >


### PR DESCRIPTION
Draft because I want to get people's thoughts on it. I think it might be easier to discover and a nicer experience to make the entire link cell clickable. Presently just the text is clickable.

![CleanShot 2024-01-15 at 17 06 57](https://github.com/oxidecomputer/console/assets/4020798/00565d4f-b44c-4bf3-a35d-bbf7e3d1e71f)

