### PR TITLE
Make links in tables more clearly clickable

### DIFF
--- a/app/components/ExternalIps.tsx
+++ b/app/components/ExternalIps.tsx
@@ -39,7 +39,7 @@ export function ExternalIps({ project, instance }: InstanceSelector) {
 function IpLink({ ip }: { ip: string }) {
   return (
     <a
-      className="underline text-sans-semi-md text-secondary hover:text-default"
+      className="link-with-underline text-sans-semi-md"
       href={`https://${ip}`}
       target="_blank"
       rel="noreferrer"

--- a/app/pages/project/disks/DisksPage.tsx
+++ b/app/pages/project/disks/DisksPage.tsx
@@ -16,7 +16,7 @@ import {
   useApiQueryClient,
   type Disk,
 } from '@oxide/api'
-import { DateCell, SizeCell, useQueryTable, type MenuAction } from '@oxide/table'
+import { DateCell, linkCell, SizeCell, useQueryTable, type MenuAction } from '@oxide/table'
 import {
   buttonStyle,
   EmptyMessage,
@@ -43,14 +43,12 @@ function AttachedInstance({
   const { data: instance } = useApiQuery('instanceView', {
     path: { instance: instanceId },
   })
-  return instance ? (
-    <Link
-      className="text-sans-semi-md text-accent hover:underline"
-      to={pb.instancePage({ ...projectSelector, instance: instance.name })}
-    >
-      {instance.name}
-    </Link>
-  ) : null
+
+  const instanceLinkCell = linkCell((instanceName) =>
+    pb.instancePage({ ...projectSelector, instance: instanceName })
+  )
+
+  return instance ? instanceLinkCell({ value: instance.name }) : null
 }
 
 const EmptyState = () => (

--- a/app/pages/project/instances/instance/tabs/NetworkingTab.tsx
+++ b/app/pages/project/instances/instance/tabs/NetworkingTab.tsx
@@ -58,7 +58,7 @@ export const VpcNameFromId = ({ value }: { value: string }) => {
   if (!vpc) return <Skeleton />
   return (
     <Link
-      className="underline text-sans-semi-md text-secondary hover:text-default"
+      className="link-with-underline text-sans-semi-md"
       to={pb.vpc({ ...projectSelector, vpc: vpc.name })}
     >
       {vpc.name}

--- a/libs/table/cells/LinkCell.tsx
+++ b/libs/table/cells/LinkCell.tsx
@@ -14,12 +14,12 @@ export const linkCell =
   ({ value }: Cell<string>) => {
     return (
       <Link
-        className="flex h-full w-full items-center underline text-sans-semi-md text-secondary hover:text-default"
+        className="link-with-underline group flex h-full w-full items-center text-sans-semi-md"
         to={makeHref(value)}
       >
-        {value}
         {/* Pushes out the link area to the entire cell for improved clickability™ */}
-        <div className="absolute inset-0" />
+        <div className="absolute inset-0 group-hover:bg-raise" />
+        <div className="relative">{value}</div>
       </Link>
     )
   }

--- a/libs/table/cells/LinkCell.tsx
+++ b/libs/table/cells/LinkCell.tsx
@@ -18,7 +18,7 @@ export const linkCell =
         to={makeHref(value)}
       >
         {/* Pushes out the link area to the entire cell for improved clickability™ */}
-        <div className="absolute inset-0 group-hover:bg-raise" />
+        <div className="absolute inset-0 w-[calc(100%-1px)] group-hover:bg-raise" />
         <div className="relative">{value}</div>
       </Link>
     )

--- a/libs/table/cells/LinkCell.tsx
+++ b/libs/table/cells/LinkCell.tsx
@@ -14,7 +14,7 @@ export const linkCell =
   ({ value }: Cell<string>) => {
     return (
       <Link
-        className="flex h-full w-full items-center text-sans-semi-md text-default hover:underline"
+        className="flex h-full w-full items-center underline text-sans-semi-md text-secondary hover:text-default"
         to={makeHref(value)}
       >
         {value}

--- a/libs/table/cells/LinkCell.tsx
+++ b/libs/table/cells/LinkCell.tsx
@@ -18,7 +18,7 @@ export const linkCell =
         to={makeHref(value)}
       >
         {/* Pushes out the link area to the entire cell for improved clickability™ */}
-        <div className="absolute inset-0 right-[1px] group-hover:bg-raise" />
+        <div className="absolute inset-0 right-px group-hover:bg-raise" />
         <div className="relative">{value}</div>
       </Link>
     )

--- a/libs/table/cells/LinkCell.tsx
+++ b/libs/table/cells/LinkCell.tsx
@@ -18,7 +18,7 @@ export const linkCell =
         to={makeHref(value)}
       >
         {/* Pushes out the link area to the entire cell for improved clickability™ */}
-        <div className="absolute inset-0 w-[calc(100%-1px)] group-hover:bg-raise" />
+        <div className="absolute inset-0 right-[1px] group-hover:bg-raise" />
         <div className="relative">{value}</div>
       </Link>
     )

--- a/libs/ui/lib/date-picker/CalendarCell.tsx
+++ b/libs/ui/lib/date-picker/CalendarCell.tsx
@@ -87,7 +87,7 @@ export function CalendarCell({ state, date }: CalendarCellProps) {
       >
         <div
           className={cn(
-            'pointer-events-none absolute bottom-[0] left-[1px] right-[1px] top-[0] rounded',
+            'pointer-events-none absolute bottom-[0] left-px right-px top-[0] rounded',
             isSelectionStart || isSelectionEnd
               ? isInvalid
                 ? 'border border-error-secondary'

--- a/libs/ui/lib/table/Table.tsx
+++ b/libs/ui/lib/table/Table.tsx
@@ -112,7 +112,7 @@ Table.Cell = ({ height = 'large', className, children, ...props }: TableCellProp
     >
       <div
         className={cn(
-          '-my-[1px] -mr-[2px] flex items-center border-b border-l py-3 pl-3 pr-3 border-secondary',
+          'relative -my-[1px] -mr-[2px] flex items-center border-b border-l py-3 pl-3 pr-3 border-secondary',
           heightClass
         )}
       >

--- a/libs/ui/lib/table/table.css
+++ b/libs/ui/lib/table/table.css
@@ -48,11 +48,6 @@ table.ox-table {
     @apply sticky left-0 z-10 bg-default;
   }
 
-  & tr:hover td,
-  & tr:hover td:last-of-type.action-col {
-    @apply bg-raise;
-  }
-
   /*
   Last column is sticky if it
   is a more actions cell
@@ -69,7 +64,7 @@ table.ox-table {
     Highlight when hovering over the action-col cell
   */
   & td.action-col:hover > div {
-    @apply bg-hover;
+    @apply bg-raise;
   }
 
   /*

--- a/libs/ui/lib/table/table.css
+++ b/libs/ui/lib/table/table.css
@@ -45,7 +45,12 @@ table.ox-table {
   /* First column is sticky */
   & th:first-of-type,
   & td:first-of-type {
-    @apply sticky left-0 bg-default;
+    @apply sticky left-0 z-10 bg-default;
+  }
+
+  & tr:hover td,
+  & tr:hover td:last-of-type.action-col {
+    @apply bg-raise;
   }
 
   /*
@@ -75,7 +80,7 @@ table.ox-table {
   below with a background colour and still keep the styling
   */
   & tr:last-of-type td:last-of-type.action-col {
-    @apply border-b-0 border-r-0 !bg-default;
+    @apply border-b-0 border-r-0;
   }
 
   & tr:last-of-type td:last-of-type.action-col > div {

--- a/libs/ui/lib/table/table.css
+++ b/libs/ui/lib/table/table.css
@@ -32,6 +32,7 @@ table.ox-table {
   & td {
     min-width: fit-content;
     white-space: nowrap;
+    @apply text-secondary;
   }
 
   /*

--- a/libs/ui/styles/index.css
+++ b/libs/ui/styles/index.css
@@ -51,11 +51,6 @@
 }
 
 @layer utilities {
-  .dashed-underline {
-    text-decoration: underline;
-    text-decoration-style: dashed;
-  }
-
   .external-link {
     @apply text-accent-secondary hover:text-accent;
   }
@@ -64,6 +59,16 @@
     width: calc(100% - var(--content-gutter) * 2);
     margin-left: var(--content-gutter);
     margin-right: var(--content-gutter);
+  }
+
+  .link-with-underline {
+    @apply text-secondary hover:text-default;
+    text-decoration: underline;
+    text-decoration-color: var(--content-quinary);
+
+    &:hover {
+      text-decoration-color: var(--content-tertiary);
+    }
   }
 }
 


### PR DESCRIPTION
Follow up from #1886 and feedback from the team.

- Whole row hover state (helps distinguish between rows)
- Link cells are now the same style universally
- Fixed disk cell that was styled differently

![CleanShot 2024-01-22 at 15 56 19](https://github.com/oxidecomputer/console/assets/4020798/7a4b0a56-f1e9-491e-bc88-126783af5fb0)

I'd would have liked to have the first cell be `text-default` but unsure what to do with the hover state in that instance since we don't have a colour brighter than that.
