### PR TITLE
Remove 'Settings' link from sidebar nav

### DIFF
--- a/app/layouts/SystemLayout.tsx
+++ b/app/layouts/SystemLayout.tsx
@@ -9,13 +9,7 @@ import { useMemo } from 'react'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
 
 import { apiQueryClient } from '@oxide/api'
-import {
-  Cloud16Icon,
-  Divider,
-  Metrics16Icon,
-  Settings16Icon,
-  Storage16Icon,
-} from '@oxide/ui'
+import { Cloud16Icon, Divider, Metrics16Icon, Storage16Icon } from '@oxide/ui'
 
 import { trigger404 } from 'app/components/ErrorBoundary'
 import { DocsLinkItem, NavLinkItem, Sidebar } from 'app/components/Sidebar'
@@ -118,9 +112,6 @@ export default function SystemLayout() {
           <NavLinkItem to={pb.systemNetworking()} disabled>
             <Networking16Icon /> Networking
           </NavLinkItem> */}
-          <NavLinkItem to={pb.systemSettings()} disabled>
-            <Settings16Icon /> Settings
-          </NavLinkItem>
         </Sidebar.Nav>
       </Sidebar>
       <ContentPane />

--- a/app/routes.tsx
+++ b/app/routes.tsx
@@ -171,7 +171,6 @@ export const routes = createRoutesFromElements(
         <Route path="health" element={null} handle={{ crumb: 'Health' }} />
         <Route path="update" element={null} handle={{ crumb: 'Update' }} />
         <Route path="networking" element={null} handle={{ crumb: 'Networking' }} />
-        <Route path="settings" element={null} handle={{ crumb: 'Settings' }} />
       </Route>
 
       <Route index element={<Navigate to={pb.projects()} replace />} />

--- a/app/util/path-builder.spec.ts
+++ b/app/util/path-builder.spec.ts
@@ -73,7 +73,6 @@ test('path builder', () => {
         "systemHealth": "/system/health",
         "systemIssues": "/system/issues",
         "systemNetworking": "/system/networking",
-        "systemSettings": "/system/settings",
         "systemUtilization": "/system/utilization",
         "vpc": "/projects/p/vpcs/v",
         "vpcEdit": "/projects/p/vpcs/v/edit",

--- a/app/util/path-builder.ts
+++ b/app/util/path-builder.ts
@@ -78,7 +78,6 @@ export const pb = {
   systemHealth: () => '/system/health',
 
   systemNetworking: () => '/system/networking',
-  systemSettings: () => '/system/settings',
 
   inventory: () => '/system/inventory',
   rackInventory: () => '/system/inventory/racks',


### PR DESCRIPTION
Per [a chat in Matrix](https://matrix.to/#/!rUuGIIGuojsCiHirYz:oxide.computer/$qLz1FvBO5klIv6aLlawB3f75sh8ZKvsLapYTRY4xpQQ?via=oxide.computer&via=unix.house&via=matrix.org), this removes the disabled `Settings` link from the sidebar nav.

Old:
![image](https://github.com/oxidecomputer/console/assets/22547/9f90a6a5-7734-4fd9-b36d-71f830b80bc5)

New:
![Screenshot 2024-01-22 at 10 55 36 AM](https://github.com/oxidecomputer/console/assets/22547/9ff92909-14ef-445d-a4d3-818b50db97d4)

I also removed from the `path-builder.ts` file since we don't see the use of that page for now. Easy to add back in when we need it.