### PR TITLE
Patch `vite-plugin-html` to stop getting the `[log]` prefix on tests

### DIFF
--- a/patches/vite-plugin-html+3.2.2.patch
+++ b/patches/vite-plugin-html+3.2.2.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/vite-plugin-html/dist/index.mjs b/node_modules/vite-plugin-html/dist/index.mjs
+index 5495ed8..357d10f 100644
+--- a/node_modules/vite-plugin-html/dist/index.mjs
++++ b/node_modules/vite-plugin-html/dist/index.mjs
+@@ -339,7 +339,7 @@ function createMinifyHtmlPlugin({
+   };
+ }
+ 
+-consola.wrapConsole();
++// consola.wrapConsole();
+ function createHtmlPlugin(userOptions = {}) {
+   return [createPlugin(userOptions), createMinifyHtmlPlugin(userOptions)];
+ }


### PR DESCRIPTION
Working around this issue: https://github.com/vbenjs/vite-plugin-html/issues/58

The plugin [calls `consola.wrap`](https://github.com/vbenjs/vite-plugin-html/blob/a21ec7f4971312cc75ef3d7113b6d86e93dbfeac/packages/core/src/index.ts#L7) at top level, which seems to override `console.log` globally. See https://github.com/unjs/consola

### Before

![Screenshot 2024-01-26 at 10 33 35 AM](https://github.com/oxidecomputer/console/assets/3612203/752f3696-8a34-4e51-be71-2a516ef2e1bb)

### After

![Screenshot 2024-01-26 at 10 31 22 AM](https://github.com/oxidecomputer/console/assets/3612203/228f547e-0302-413f-9aef-cb02f1b9677c)

