### PR TITLE
Dynamically render units on metrics tab

### DIFF
--- a/app/pages/project/instances/instance/tabs/MetricsTab.tsx
+++ b/app/pages/project/instances/instance/tabs/MetricsTab.tsx
@@ -85,10 +85,12 @@ function DiskMetric({
     }
   }
 
+  const divisor = divisorBase ^ cycleCount
+
   const data = (metrics?.items || []).map(({ datum, timestamp }) => ({
     timestamp: timestamp.getTime(),
     // all of these metrics are cumulative ints
-    value: (datum.datum as Cumulativeint64).value / (divisorBase ^ cycleCount),
+    value: (datum.datum as Cumulativeint64).value / divisor,
   }))
 
   return (


### PR DESCRIPTION
Fixes #1866.

We're pulling in data for the instance page's metrics tab, showing read / write counts and size, and the number of flushes. Currently, we aren't adjusting the numbers, and are just showing the raw count / bytes.

This PR updates how we render the data. Because the data is cumulative, we can use the largest data value to determine the unit of measurement for the set of data. We then divide the given datapoint by the appropriate divisor and pass that data along to the chart.

I'm open to suggestions for better ways to label the overall chart.

While it's fine on datapoints using Byte counts …
<img width="609" alt="Screenshot 2024-01-26 at 3 36 21 PM" src="https://github.com/oxidecomputer/console/assets/22547/fcbe06ee-5fcc-4bfe-8030-4b9718e7684c">

… it's a little meh on Count charts …
<img width="605" alt="Screenshot 2024-01-26 at 4 27 08 PM" src="https://github.com/oxidecomputer/console/assets/22547/f975bc8d-8e1f-409e-990e-ebe0c6734718">
(The thing you're supposed to be looking at is at the very top of the chart, currently showing "count x K".)

@benjaminleonard if you have any thoughts, I'm all ears.
