### PR TITLE
Tweak CSS to remove awkward line wrapping; widen select box

### DIFF
--- a/app/pages/SiloUtilizationPage.tsx
+++ b/app/pages/SiloUtilizationPage.tsx
@@ -82,7 +82,7 @@ export function SiloUtilizationPage() {
       <div className="mb-3 mt-8 flex justify-between gap-3">
         <Listbox
           selected={filterId}
-          className="w-48"
+          className="w-80"
           aria-labelledby="filter-id-label"
           name="filter-id"
           items={projectItems}

--- a/app/pages/SiloUtilizationPage.tsx
+++ b/app/pages/SiloUtilizationPage.tsx
@@ -82,7 +82,7 @@ export function SiloUtilizationPage() {
       <div className="mb-3 mt-8 flex justify-between gap-3">
         <Listbox
           selected={filterId}
-          className="w-80"
+          className="w-64"
           aria-labelledby="filter-id-label"
           name="filter-id"
           items={projectItems}

--- a/app/pages/project/instances/instance/tabs/MetricsTab.tsx
+++ b/app/pages/project/instances/instance/tabs/MetricsTab.tsx
@@ -135,7 +135,7 @@ export function MetricsTab() {
     <>
       <div className="mb-4 flex justify-between">
         <Listbox
-          className="w-48"
+          className="w-80"
           aria-label="Choose disk"
           name="disk-name"
           selected={diskName}

--- a/app/pages/project/instances/instance/tabs/MetricsTab.tsx
+++ b/app/pages/project/instances/instance/tabs/MetricsTab.tsx
@@ -135,7 +135,7 @@ export function MetricsTab() {
     <>
       <div className="mb-4 flex justify-between">
         <Listbox
-          className="w-80"
+          className="w-64"
           aria-label="Choose disk"
           name="disk-name"
           selected={diskName}

--- a/app/pages/system/UtilizationPage.tsx
+++ b/app/pages/system/UtilizationPage.tsx
@@ -108,7 +108,7 @@ const MetricsTab = () => {
       <div className="mb-3 mt-8 flex justify-between gap-3">
         <Listbox
           selected={filterId}
-          className="w-48"
+          className="w-80"
           aria-labelledby="filter-id-label"
           name="filter-id"
           items={siloItems}

--- a/app/pages/system/UtilizationPage.tsx
+++ b/app/pages/system/UtilizationPage.tsx
@@ -108,7 +108,7 @@ const MetricsTab = () => {
       <div className="mb-3 mt-8 flex justify-between gap-3">
         <Listbox
           selected={filterId}
-          className="w-80"
+          className="w-64"
           aria-labelledby="filter-id-label"
           name="filter-id"
           items={siloItems}

--- a/libs/ui/lib/listbox/Listbox.tsx
+++ b/libs/ui/lib/listbox/Listbox.tsx
@@ -126,7 +126,7 @@ export const Listbox = <Value extends string = string>({
               )}
               {...props}
             >
-              <div className="w-full px-3 text-left">
+              <div className="w-full overflow-hidden whitespace-pre px-3 text-left">
                 {selectedItem ? (
                   // labelString is one line, which is what we need when label is a ReactNode
                   selectedItem.labelString || selectedItem.label

--- a/libs/ui/lib/listbox/Listbox.tsx
+++ b/libs/ui/lib/listbox/Listbox.tsx
@@ -126,7 +126,7 @@ export const Listbox = <Value extends string = string>({
               )}
               {...props}
             >
-              <div className="w-full overflow-hidden whitespace-pre px-3 text-left">
+              <div className="w-full overflow-hidden overflow-ellipsis whitespace-pre px-3 text-left">
                 {selectedItem ? (
                   // labelString is one line, which is what we need when label is a ReactNode
                   selectedItem.labelString || selectedItem.label


### PR DESCRIPTION
Fixes #1905 

Currently, we have some awkward line wrapping when the disk or silo name is too long, as seen here:
![image](https://github.com/oxidecomputer/console/assets/22547/4138200a-58e2-4fb2-b92e-a78018e296c9)

This PR adds a few CSS rules to prevent line wrapping for the ListBox select fields.
<img width="615" alt="Screenshot 2024-01-28 at 10 02 49 AM" src="https://github.com/oxidecomputer/console/assets/22547/ec7eb619-5243-44ed-b23b-f80a3797fce5">

The full text of the option is still shown within the dropdown itself
<img width="619" alt="Screenshot 2024-01-28 at 10 02 58 AM" src="https://github.com/oxidecomputer/console/assets/22547/adb4d2fb-5cd5-4214-8b39-eaec8965abe2">

This PR also expands the width of the dropdown from `w-48` to `w-80`, but that change isn't strictly necessary, if there's a reason we want to keep the `w-48` width in place. Or we could compromise with `w-64`. I thought it might be an issue where `w-48` works better for a mobile screen with the other elements of the metrics view, but even at `w-48` there are some collisions and overflow issues, so I don't think it's that. Regardless, if we want to leave the width as-is, fine.
