### PR TITLE
Make `VpcNameFromId` more linkCell-like

### DIFF
--- a/app/pages/project/instances/instance/tabs/NetworkingTab.tsx
+++ b/app/pages/project/instances/instance/tabs/NetworkingTab.tsx
@@ -43,7 +43,13 @@ import { fancifyStates } from './common'
 
 export const Skeleton = classed.div`h-4 w-12 rounded bg-tertiary motion-safe:animate-pulse`
 
-export const VpcNameFromId = ({ value }: { value: string }) => {
+export const VpcNameFromId = ({
+  value,
+  isLinkCell = false,
+}: {
+  value: string
+  isLinkCell?: boolean
+}) => {
   const projectSelector = useProjectSelector()
   const { data: vpc, isError } = useApiQuery(
     'vpcView',
@@ -58,10 +64,12 @@ export const VpcNameFromId = ({ value }: { value: string }) => {
   if (!vpc) return <Skeleton />
   return (
     <Link
-      className="link-with-underline text-sans-semi-md"
+      className="link-with-underline group text-sans-semi-md"
       to={pb.vpc({ ...projectSelector, vpc: vpc.name })}
     >
-      {vpc.name}
+      {/* Pushes out the link area to the entire cell for improved clickability™ */}
+      {isLinkCell && <div className="absolute inset-0 right-px group-hover:bg-raise" />}
+      <div className="relative">{vpc.name}</div>
     </Link>
   )
 }
@@ -196,7 +204,11 @@ export function NetworkingTab() {
         <Column accessor="name" />
         <Column accessor="description" />
         <Column accessor="ip" />
-        <Column header="vpc" accessor="vpcId" cell={VpcNameFromId} />
+        <Column
+          header="vpc"
+          accessor="vpcId"
+          cell={(props) => <VpcNameFromId {...props} isLinkCell />}
+        />
         <Column header="subnet" accessor="subnetId" cell={SubnetNameFromId} />
         <Column
           accessor="primary"

--- a/app/pages/project/instances/instance/tabs/NetworkingTab.tsx
+++ b/app/pages/project/instances/instance/tabs/NetworkingTab.tsx
@@ -43,13 +43,7 @@ import { fancifyStates } from './common'
 
 export const Skeleton = classed.div`h-4 w-12 rounded bg-tertiary motion-safe:animate-pulse`
 
-export const VpcNameFromId = ({
-  value,
-  isLinkCell = false,
-}: {
-  value: string
-  isLinkCell?: boolean
-}) => {
+const VpcNameFromId = ({ value }: { value: string }) => {
   const projectSelector = useProjectSelector()
   const { data: vpc, isError } = useApiQuery(
     'vpcView',
@@ -68,7 +62,7 @@ export const VpcNameFromId = ({
       to={pb.vpc({ ...projectSelector, vpc: vpc.name })}
     >
       {/* Pushes out the link area to the entire cell for improved clickability™ */}
-      {isLinkCell && <div className="absolute inset-0 right-px group-hover:bg-raise" />}
+      <div className="absolute inset-0 right-px group-hover:bg-raise" />
       <div className="relative">{vpc.name}</div>
     </Link>
   )
@@ -204,11 +198,7 @@ export function NetworkingTab() {
         <Column accessor="name" />
         <Column accessor="description" />
         <Column accessor="ip" />
-        <Column
-          header="vpc"
-          accessor="vpcId"
-          cell={(props) => <VpcNameFromId {...props} isLinkCell />}
-        />
+        <Column header="vpc" accessor="vpcId" cell={VpcNameFromId} />
         <Column header="subnet" accessor="subnetId" cell={SubnetNameFromId} />
         <Column
           accessor="primary"


### PR DESCRIPTION
This was the only one I found like that. Eventually we might want a component that's a bit more flexible? The challenge here is that we're using this component inside both tables and the properties table and they appear a little differently.