### PR TITLE
Show project created instead of modified on table

### DIFF
--- a/app/pages/ProjectsPage.tsx
+++ b/app/pages/ProjectsPage.tsx
@@ -115,7 +115,7 @@ export default function ProjectsPage() {
       <Table emptyState={<EmptyState />} makeActions={makeActions}>
         <Column accessor="name" cell={linkCell((project) => pb.instances({ project }))} />
         <Column accessor="description" />
-        <Column accessor="timeModified" header="Last updated" cell={DateCell} />
+        <Column accessor="timeCreated" header="Created" cell={DateCell} />
       </Table>
       <Outlet />
     </>


### PR DESCRIPTION
It just occurred to me how useless and misleading showing the updated time is. The time in question is the last time the project itself was modified, i.e., the name or description changed. That is both a rare occurrence and basically useless information. What you'd really want to know (and what you might think this column means) is when there was last some kind of activity in the project, but we have no way of displaying that. So let's show the created time, which is vaguely useful and unambiguous in meaning.

<img width="913" alt="image" src="https://github.com/oxidecomputer/console/assets/3612203/38c2e03a-33ff-48a8-8264-0c15e54e1d17">
