### PR TITLE
Fixes tooltip submitting forms on click

### DIFF
--- a/libs/ui/lib/field-label/FieldLabel.tsx
+++ b/libs/ui/lib/field-label/FieldLabel.tsx
@@ -43,7 +43,7 @@ export const FieldLabel = ({
       </Component>
       {tip && (
         <Tooltip content={tip} placement="top">
-          <button className="svg:pointer-events-none">
+          <button className="svg:pointer-events-none" type="button">
             <Question12Icon className="text-quinary" />
           </button>
         </Tooltip>


### PR DESCRIPTION
Silly silly silly...why is the default browser setting `type="submit"`.

Fixes #1902 