### PR TITLE
Avoid rest destructuring React Query result

### DIFF
--- a/libs/api/hooks.ts
+++ b/libs/api/hooks.ts
@@ -18,6 +18,7 @@ import {
   type UseMutationOptions,
   type UseQueryOptions,
 } from '@tanstack/react-query'
+import { type SetNonNullable } from 'type-fest'
 
 import { invariant } from '@oxide/util'
 
@@ -138,7 +139,7 @@ export const getUsePrefetchedApiQuery =
     options: UseQueryOtherOptions<Result<A[M]>, ApiError> = {}
   ) => {
     const queryKey = [method, params]
-    const { data, ...rest } = useQuery({
+    const result = useQuery({
       queryKey,
       // no catch, let unexpected errors bubble up
       queryFn: ({ signal }) => api[method](params, { signal }).then(handleResult(method)),
@@ -149,8 +150,13 @@ export const getUsePrefetchedApiQuery =
       throwOnError: (err) => err.statusCode === 404,
       ...options,
     })
-    invariant(data, `Expected query to be prefetched. Key: ${JSON.stringify(queryKey)}`)
-    return { data, ...rest }
+    invariant(
+      result.data,
+      `Expected query to be prefetched. Key: ${JSON.stringify(queryKey)}`
+    )
+    // TS infers non-nullable on a freestanding variable, but doesn't like to do
+    // it on a property. So we give it a hint
+    return result as SetNonNullable<typeof result, 'data'>
   }
 
 const ERRORS_ALLOWED = 'errors-allowed'


### PR DESCRIPTION
The RQ docs are quite clear that you're not supposed to use rest destructuring on results. They even publish a [lint rule](https://tanstack.com/query/v5/docs/eslint/no-rest-destructuring) to catch it. The irony in our case is that we don't even need the destructure — we're putting the object right back together again and doing a totally unnecessary object copy. The only reason we're doing it is to get TypeScript to recognize that `data` must be non-null after we call `invariant` on it. It will do that narrowing on a freestanding variable, but it doesn't like to do it on an object property. So we have to tell it.