### PR TITLE
Use NumberFields in more places; enhance NumberField component

### DIFF
--- a/app/components/form/fields/DiskSizeField.tsx
+++ b/app/components/form/fields/DiskSizeField.tsx
@@ -38,7 +38,6 @@ export function DiskSizeField<
   return (
     <NumberField
       units="GiB"
-      type="number"
       required={required}
       name={name}
       min={minSize}

--- a/app/components/form/fields/NumberField.tsx
+++ b/app/components/form/fields/NumberField.tsx
@@ -69,6 +69,8 @@ export const NumberFieldInner = <
   required,
   id: idProp,
   disabled,
+  max,
+  min,
 }: TextFieldProps<TFieldValues, TName>) => {
   const generatedId = useId()
   const id = idProp || generatedId
@@ -89,6 +91,8 @@ export const NumberFieldInner = <
               })}
               aria-describedby={tooltipText ? `${id}-label-tip` : undefined}
               isDisabled={disabled}
+              maxValue={max ? Number(max) : undefined}
+              minValue={min !== undefined ? Number(min) : undefined}
               {...field}
               formatOptions={{
                 useGrouping: false,

--- a/app/components/form/fields/NumberField.tsx
+++ b/app/components/form/fields/NumberField.tsx
@@ -70,7 +70,7 @@ export const NumberFieldInner = <
   id: idProp,
   disabled,
   max,
-  min,
+  min = 0,
 }: TextFieldProps<TFieldValues, TName>) => {
   const generatedId = useId()
   const id = idProp || generatedId

--- a/app/components/form/fields/NumberField.tsx
+++ b/app/components/form/fields/NumberField.tsx
@@ -52,9 +52,9 @@ export function NumberField<
  * Primarily exists for `NumberField`, but we occasionally also need a plain field
  * without a label on it.
  *
- * Note that `id` is an allowed prop, unlike in `TextField`, where it is always
+ * Note that `id` is an allowed prop, unlike in `NumberField`, where it is always
  * generated from `name`. This is because we need to pass the generated ID in
- * from there to here. For the case where `TextFieldInner` is used
+ * from there to here. For the case where `NumberFieldInner` is used
  * independently, we also generate an ID for use only if none is passed in.
  */
 export const NumberFieldInner = <

--- a/app/components/form/fields/TextField.tsx
+++ b/app/components/form/fields/TextField.tsx
@@ -30,8 +30,10 @@ import { ErrorMessage } from './ErrorMessage'
 export interface TextFieldProps<
   TFieldValues extends FieldValues,
   TName extends FieldPath<TFieldValues>,
-> extends Omit<UITextFieldProps, 'type'> {
+> extends UITextFieldProps {
   name: TName
+  /** HTML type attribute, defaults to text */
+  type?: 'text' | 'password'
   /** Will default to name if not provided */
   label?: string
   /**
@@ -104,6 +106,7 @@ export const TextFieldInner = <
   TName extends FieldPath<TFieldValues>,
 >({
   name,
+  type = 'text',
   label = capitalize(name),
   validate,
   control,
@@ -126,6 +129,7 @@ export const TextFieldInner = <
             <UITextField
               id={id}
               title={label}
+              type={type}
               error={!!error}
               aria-labelledby={cn(`${id}-label`, {
                 [`${id}-help-text`]: !!tooltipText,

--- a/app/components/form/fields/TextField.tsx
+++ b/app/components/form/fields/TextField.tsx
@@ -30,10 +30,8 @@ import { ErrorMessage } from './ErrorMessage'
 export interface TextFieldProps<
   TFieldValues extends FieldValues,
   TName extends FieldPath<TFieldValues>,
-> extends UITextFieldProps {
+> extends Omit<UITextFieldProps, 'type'> {
   name: TName
-  /** HTML type attribute, defaults to text */
-  type?: string
   /** Will default to name if not provided */
   label?: string
   /**
@@ -92,17 +90,9 @@ export function TextField<
   )
 }
 
-function numberToInputValue(value: number) {
-  // could add `|| value === 0`, but that means when the value is 0, we always
-  // show an empty string, which is weird, and doubly bad because then the
-  // browser apparently fails to validate it against minimum (if one is
-  // provided). I found it let me submit instance create with 0 CPUs.
-  return isNaN(value) ? '' : value.toString()
-}
-
 /**
  * Primarily exists for `TextField`, but we occasionally also need a plain field
- * without a label on it. Note special handling of `type="number"`.
+ * without a label on it.
  *
  * Note that `id` is an allowed prop, unlike in `TextField`, where it is always
  * generated from `name`. This is because we need to pass the generated ID in
@@ -114,7 +104,6 @@ export const TextFieldInner = <
   TName extends FieldPath<TFieldValues>,
 >({
   name,
-  type = 'text',
   label = capitalize(name),
   validate,
   control,
@@ -131,44 +120,20 @@ export const TextFieldInner = <
       name={name}
       control={control}
       rules={{ required, validate }}
-      render={({ field: { onChange, value, ...fieldRest }, fieldState: { error } }) => {
+      render={({ field: { onChange, ...fieldRest }, fieldState: { error } }) => {
         return (
           <>
             <UITextField
               id={id}
               title={label}
-              type={type}
               error={!!error}
               aria-labelledby={cn(`${id}-label`, {
                 [`${id}-help-text`]: !!tooltipText,
               })}
               aria-describedby={tooltipText ? `${id}-label-tip` : undefined}
-              // note special handling for number fields, which produce a number
-              // for the calling code despite the actual input value necessarily
-              // being a string.
               onChange={(e) => {
-                if (transform) {
-                  onChange(transform(e.target.value))
-                  return
-                }
-                if (type === 'number') {
-                  if (e.target.value.trim() === '') {
-                    onChange(0)
-                  } else if (!isNaN(e.target.valueAsNumber)) {
-                    onChange(e.target.valueAsNumber)
-                  }
-                  // otherwise ignore the input. this means, for example, typing
-                  // letters does nothing. If we instead said take anything
-                  // that's NaN and fall back to 0, typing a letter would reset
-                  // the field to 0, which is silly. Browsers are supposed to
-                  // ignore non-numeric input for you anyway, but Firefox does
-                  // not.
-                  return
-                }
-
-                onChange(e.target.value)
+                onChange(transform ? transform(e.target.value) : e.target.value)
               }}
-              value={type === 'number' ? numberToInputValue(value) : value}
               {...fieldRest}
               {...props}
             />

--- a/app/forms/instance-create.tsx
+++ b/app/forms/instance-create.tsx
@@ -50,6 +50,7 @@ import {
   ImageSelectField,
   NameField,
   NetworkInterfaceField,
+  NumberField,
   RadioFieldDyn,
   TextField,
   type DiskTableItem,
@@ -284,8 +285,7 @@ export function CreateInstanceForm() {
         </Tabs.Content>
 
         <Tabs.Content value="custom">
-          <TextField
-            type="number"
+          <NumberField
             required
             label="CPUs"
             name="ncpus"
@@ -302,9 +302,8 @@ export function CreateInstanceForm() {
             }}
             disabled={isSubmitting}
           />
-          <TextField
+          <NumberField
             units="GiB"
-            type="number"
             required
             label="Memory"
             name="memory"

--- a/app/forms/silo-create.tsx
+++ b/app/forms/silo-create.tsx
@@ -109,7 +109,6 @@ export function CreateSiloSideModalForm() {
         name="quotas.cpus"
         required
         units="nCPUs"
-        min={0}
         validate={validateQuota}
       />
       <NumberField
@@ -118,7 +117,6 @@ export function CreateSiloSideModalForm() {
         name="quotas.memory"
         required
         units="GiB"
-        min={0}
         validate={validateQuota}
       />
       <NumberField
@@ -127,7 +125,6 @@ export function CreateSiloSideModalForm() {
         name="quotas.storage"
         required
         units="GiB"
-        min={0}
         validate={validateQuota}
       />
       <FormDivider />

--- a/app/forms/silo-create.tsx
+++ b/app/forms/silo-create.tsx
@@ -108,8 +108,8 @@ export function CreateSiloSideModalForm() {
         label="CPU quota"
         name="quotas.cpus"
         required
-        type="number"
         units="nCPUs"
+        min={0}
         validate={validateQuota}
       />
       <NumberField
@@ -117,8 +117,8 @@ export function CreateSiloSideModalForm() {
         label="Memory quota"
         name="quotas.memory"
         required
-        type="number"
         units="GiB"
+        min={0}
         validate={validateQuota}
       />
       <NumberField
@@ -126,8 +126,8 @@ export function CreateSiloSideModalForm() {
         label="Storage quota"
         name="quotas.storage"
         required
-        type="number"
         units="GiB"
+        min={0}
         validate={validateQuota}
       />
       <FormDivider />

--- a/app/test/e2e/instance-create.e2e.ts
+++ b/app/test/e2e/instance-create.e2e.ts
@@ -109,8 +109,8 @@ test('can create an instance with custom hardware', async ({ page }) => {
 
   // Fill in custom specs
   await page.getByRole('tab', { name: 'Custom' }).click()
-  await page.fill('input[name=ncpus]', '29')
-  await page.fill('input[name=memory]', '53')
+  await page.getByRole('textbox', { name: 'cpus' }).fill('29')
+  await page.getByRole('textbox', { name: 'memory' }).fill('53')
 
   await page.getByRole('textbox', { name: 'Disk name' }).fill('my-boot-disk')
   const diskSizeInput = page.getByRole('textbox', { name: 'Disk size (GiB)' })

--- a/app/test/e2e/instance-create.e2e.ts
+++ b/app/test/e2e/instance-create.e2e.ts
@@ -109,8 +109,8 @@ test('can create an instance with custom hardware', async ({ page }) => {
 
   // Fill in custom specs
   await page.getByRole('tab', { name: 'Custom' }).click()
-  await page.getByRole('textbox', { name: 'cpus' }).fill('29')
-  await page.getByRole('textbox', { name: 'memory' }).fill('53')
+  await page.getByRole('textbox', { name: 'CPUs' }).fill('29')
+  await page.getByRole('textbox', { name: 'Memory (GiB)' }).fill('53')
 
   await page.getByRole('textbox', { name: 'Disk name' }).fill('my-boot-disk')
   const diskSizeInput = page.getByRole('textbox', { name: 'Disk size (GiB)' })


### PR DESCRIPTION
We currently have a few places in the UI where we have TextInputs with `type="number"`. This renders like this:
<img width="575" alt="Screenshot 2024-01-30 at 8 08 18 PM" src="https://github.com/oxidecomputer/console/assets/22547/ec980466-b34b-4edf-898f-16a1d5b6d100">

We have a NumberField component that we're currently using in a few places, but could use in the other places where we currently have `type="number"` … this PR converts those over:
<img width="542" alt="Screenshot 2024-01-30 at 8 01 30 PM" src="https://github.com/oxidecomputer/console/assets/22547/7deb98f6-4a7f-44a8-b244-60ff5f075921">

This PR also adds a small bit of logic to translate the `min` and `max` value that we pass in as props to NumberField, converting those to the `minValue` and `maxValue` props that the NumberInput component is expecting. The benefit from that is that we now automatically disable the up/down arrow button in the NumberField component when the input's value is at the boundary number. If the user tries typing in a number beyond the boundary, it gets pulled back to the min/max automatically.