### PR TITLE
Abstract confirm-delete into more general confirm-action

### DIFF
--- a/app/components/ConfirmActionModal.tsx
+++ b/app/components/ConfirmActionModal.tsx
@@ -8,16 +8,13 @@
 import { useState } from 'react'
 
 import { type ApiError } from '@oxide/api'
-import { Message, Modal } from '@oxide/ui'
-import { classed } from '@oxide/util'
+import { Modal } from '@oxide/ui'
 
-import { clearConfirmDelete, useConfirmDelete } from 'app/stores/confirm-delete'
+import { clearConfirmAction, useConfirmAction } from 'app/stores/confirm-action'
 import { addToast } from 'app/stores/toast'
 
-export const HL = classed.span`text-sans-semi-md text-default`
-
-export function ConfirmDeleteModal() {
-  const deleteConfig = useConfirmDelete((state) => state.deleteConfig)
+export function ConfirmActionModal() {
+  const actionConfig = useConfirmAction((state) => state.actionConfig)
 
   // this is a bit sad -- ideally we would be able to use the loading state
   // from the mutation directly, but that would require a lot of line changes
@@ -25,28 +22,23 @@ export function ConfirmDeleteModal() {
   // loading state changes
   const [loading, setLoading] = useState(false)
 
-  if (!deleteConfig) return null
+  if (!actionConfig) return null
 
-  const { doDelete, warning, label } = deleteConfig
-
-  const displayLabel = typeof label === 'string' ? <HL>{label}</HL> : label
+  const { doAction, modalContent, errorTitle, modalTitle } = actionConfig
 
   return (
-    <Modal isOpen onDismiss={clearConfirmDelete} title="Confirm delete">
-      <Modal.Section>
-        <p>Are you sure you want to delete {displayLabel}?</p>
-        {warning && <Message variant="error" content={warning} />}
-      </Modal.Section>
+    <Modal isOpen onDismiss={clearConfirmAction} title={modalTitle}>
+      <Modal.Section>{modalContent}</Modal.Section>
       <Modal.Footer
-        onDismiss={clearConfirmDelete}
+        onDismiss={clearConfirmAction}
         onAction={async () => {
           setLoading(true)
           try {
-            await doDelete()
+            await doAction()
           } catch (error) {
             addToast({
               variant: 'error',
-              title: 'Could not delete resource',
+              title: errorTitle,
               content: (error as ApiError).message,
             })
           }
@@ -54,7 +46,7 @@ export function ConfirmDeleteModal() {
           setLoading(false) // do this regardless of success or error
 
           // TODO: generic success toast?
-          clearConfirmDelete()
+          clearConfirmAction()
         }}
         cancelText="Cancel"
         actionText="Confirm"

--- a/app/main.tsx
+++ b/app/main.tsx
@@ -14,7 +14,7 @@ import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 import { queryClient } from '@oxide/api'
 import { SkipLink } from '@oxide/ui'
 
-import { ConfirmDeleteModal } from './components/ConfirmDeleteModal'
+import { ConfirmActionModal } from './components/ConfirmActionModal'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { ReduceMotion } from './hooks'
 // stripped out by rollup in production
@@ -45,7 +45,7 @@ function render() {
     <StrictMode>
       <QueryClientProvider client={queryClient}>
         <ErrorBoundary>
-          <ConfirmDeleteModal />
+          <ConfirmActionModal />
           <SkipLink id="skip-nav" />
           <ReduceMotion />
           <RouterProvider router={router} />

--- a/app/pages/SiloAccessPage.tsx
+++ b/app/pages/SiloAccessPage.tsx
@@ -32,13 +32,12 @@ import {
 import { groupBy, isTruthy } from '@oxide/util'
 
 import { AccessNameCell } from 'app/components/AccessNameCell'
-import { HL } from 'app/components/ConfirmDeleteModal'
 import { RoleBadgeCell } from 'app/components/RoleBadgeCell'
 import {
   SiloAccessAddUserSideModal,
   SiloAccessEditUserSideModal,
 } from 'app/forms/silo-access'
-import { confirmDelete } from 'app/stores/confirm-delete'
+import { confirmDelete, HL } from 'app/stores/confirm-delete'
 
 const EmptyState = ({ onClick }: { onClick: () => void }) => (
   <TableEmptyBox>

--- a/app/pages/project/access/ProjectAccessPage.tsx
+++ b/app/pages/project/access/ProjectAccessPage.tsx
@@ -35,14 +35,13 @@ import {
 import { groupBy, isTruthy } from '@oxide/util'
 
 import { AccessNameCell } from 'app/components/AccessNameCell'
-import { HL } from 'app/components/ConfirmDeleteModal'
 import { RoleBadgeCell } from 'app/components/RoleBadgeCell'
 import {
   ProjectAccessAddUserSideModal,
   ProjectAccessEditUserSideModal,
 } from 'app/forms/project-access'
 import { getProjectSelector, useProjectSelector } from 'app/hooks'
-import { confirmDelete } from 'app/stores/confirm-delete'
+import { confirmDelete, HL } from 'app/stores/confirm-delete'
 
 const EmptyState = ({ onClick }: { onClick: () => void }) => (
   <TableEmptyBox>

--- a/app/pages/project/instances/actions.tsx
+++ b/app/pages/project/instances/actions.tsx
@@ -111,12 +111,6 @@ export const useMakeInstanceActions = (
                   options.onDelete?.()
                   addToast({ title: `Deleting instance '${instance.name}'` })
                 },
-                onError: (error) =>
-                  addToast({
-                    variant: 'error',
-                    title: `Error deleting instance '${instance.name}'`,
-                    content: error.message,
-                  }),
               }),
             label: instance.name,
           }),

--- a/app/stores/confirm-action.ts
+++ b/app/stores/confirm-action.ts
@@ -8,25 +8,22 @@
 import type { ReactNode } from 'react'
 import { create } from 'zustand'
 
-type DeleteConfig = {
+type ActionConfig = {
   /** Must be `mutateAsync`, otherwise we can't catch the error generically */
-  doDelete: () => Promise<unknown>
-  warning?: string
-  /**
-   * Label identifying the resource. Could be a name or something more elaborate
-   * "the Admin role for user Harry Styles". If a string, the modal will
-   * automatically give it a highlighted style. Otherwise it will be rendered
-   * directly.
-   */
-  label: ReactNode
+  doAction: () => Promise<unknown>
+  /** e.g., Confirm delete, Confirm unlink */
+  modalTitle: string
+  modalContent: ReactNode
+  /** Title of error toast */
+  errorTitle: string
 }
 
-type ConfirmDeleteStore = {
-  deleteConfig: DeleteConfig | null
+type ConfirmActionStore = {
+  actionConfig: ActionConfig | null
 }
 
-export const useConfirmDelete = create<ConfirmDeleteStore>(() => ({
-  deleteConfig: null,
+export const useConfirmAction = create<ConfirmActionStore>(() => ({
+  actionConfig: null,
 }))
 
 // zustand docs say this pattern is equivalent to putting the actions on the
@@ -39,10 +36,10 @@ export const useConfirmDelete = create<ConfirmDeleteStore>(() => ({
 /**
  * Note that this returns a function so we can save a line in the calling code.
  */
-export const confirmDelete = (deleteConfig: DeleteConfig) => () => {
-  useConfirmDelete.setState({ deleteConfig })
+export const confirmAction = (actionConfig: ActionConfig) => () => {
+  useConfirmAction.setState({ actionConfig })
 }
 
-export function clearConfirmDelete() {
-  useConfirmDelete.setState({ deleteConfig: null })
+export function clearConfirmAction() {
+  useConfirmAction.setState({ actionConfig: null })
 }

--- a/app/stores/confirm-delete.tsx
+++ b/app/stores/confirm-delete.tsx
@@ -1,0 +1,42 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
+ */
+
+import { classed } from '@oxide/util'
+
+import { useConfirmAction } from './confirm-action'
+
+// confirmAction was originally abstracted from confirmDelete. this preserves
+// the existing confirmDelete API by constructing a confirmAction from it
+
+type DeleteConfig = {
+  /** Must be `mutateAsync`, otherwise we can't catch the error generically */
+  doDelete: () => Promise<unknown>
+  /**
+   * Label identifying the resource. Could be a name or something more elaborate
+   * "the Admin role for user Harry Styles". If a string, the modal will
+   * automatically give it a highlighted style. Otherwise it will be rendered
+   * directly.
+   */
+  label: React.ReactNode
+}
+
+export const HL = classed.span`text-sans-semi-md text-default`
+
+export const confirmDelete =
+  ({ doDelete, label }: DeleteConfig) =>
+  () => {
+    const displayLabel = typeof label === 'string' ? <HL>{label}</HL> : label
+    useConfirmAction.setState({
+      actionConfig: {
+        doAction: doDelete,
+        modalContent: <p>Are you sure you want to delete {displayLabel}?</p>,
+        errorTitle: 'Could not delete resource',
+        modalTitle: 'Confirm delete',
+      },
+    })
+  }


### PR DESCRIPTION
Needed to confirm IP pool link/unlink/make default in #1910. We have a really nice way of confirming deletes, but what if we want to confirm an action that's not a delete? Turns out there were only a couple of bits specific to deleting, and I was able to wrap them up in a helper that keeps the API the same.

Existing delete confirmations look and work exactly as they do now:

<img width="473" alt="image" src="https://github.com/oxidecomputer/console/assets/3612203/b15d9993-0537-4b4c-ae31-3631b4f15c22">
