### PR TITLE
Update layout and spacing of badges in firewall rules table

### DIFF
--- a/libs/api-mocks/vpc.ts
+++ b/libs/api-mocks/vpc.ts
@@ -55,12 +55,20 @@ export const defaultFirewallRules: Json<VpcFirewallRule[]> = [
     name: 'allow-internal-inbound',
     status: 'enabled',
     direction: 'inbound',
-    targets: [{ type: 'vpc', value: 'default' }],
+    targets: [
+      { type: 'vpc', value: 'default' },
+      { type: 'subnet', value: 'default' },
+    ],
     action: 'allow',
     description:
       'allow inbound traffic to all instances within the VPC if originated within the VPC',
     filters: {
-      hosts: [{ type: 'vpc', value: 'default' }],
+      hosts: [
+        { type: 'vpc', value: 'default' },
+        { type: 'subnet', value: 'default' },
+      ],
+      ports: ['0-65535', '1234', '5678', '8080'],
+      protocols: ['TCP'],
     },
     priority: 65534,
     time_created,

--- a/libs/table/cells/FirewallFilterCell.tsx
+++ b/libs/table/cells/FirewallFilterCell.tsx
@@ -8,19 +8,22 @@
 import type { VpcFirewallRuleFilter } from '@oxide/api'
 import { Badge } from '@oxide/ui'
 
-import { TypeValueCell, type Cell } from '.'
+import { type Cell } from '.'
 
 export const FirewallFilterCell = ({
   value: { hosts, ports, protocols },
 }: Cell<VpcFirewallRuleFilter>) => (
-  <div className="space-x-1">
-    {hosts && hosts.map((tv, i) => <TypeValueCell key={`${tv}-${i}`} value={tv} />)}
-    {protocols &&
-      protocols.map((p, i) => (
-        <Badge key={`${p}-${i}`} variant="default">
-          {p}
-        </Badge>
+  <div className="flex flex-col gap-1">
+    {hosts &&
+      hosts.map(({ type, value }) => (
+        <div key={`${type}-${value}`} className="flex gap-0.5">
+          <Badge>{type}</Badge>
+          <Badge>{value}</Badge>
+        </div>
       ))}
-    {ports && ports.map((p, i) => <Badge key={`${p}-${i}`}>{p}</Badge>)}
+    <div className="flex gap-0.5">
+      {protocols && protocols.map((p, i) => <Badge key={`${p}-${i}`}>{p}</Badge>)}
+      {ports && ports.map((p, i) => <Badge key={`${p}-${i}`}>{p}</Badge>)}
+    </div>
   </div>
 )

--- a/libs/table/cells/TypeValueCell.tsx
+++ b/libs/table/cells/TypeValueCell.tsx
@@ -15,7 +15,7 @@ export type TypeValue = {
 }
 
 export const TypeValueCell = ({ value: { type, value } }: Cell<TypeValue>) => (
-  <div className="space-x-1">
+  <div className="flex gap-0.5">
     <Badge>{type}</Badge>
     <Badge>{value}</Badge>
   </div>

--- a/libs/table/cells/TypeValueListCell.tsx
+++ b/libs/table/cells/TypeValueListCell.tsx
@@ -8,7 +8,7 @@
 import { TypeValueCell, type Cell, type TypeValue } from '.'
 
 export const TypeValueListCell = ({ value }: Cell<TypeValue[]>) => (
-  <div>
+  <div className="flex flex-col gap-1">
     {value.map((v, i) => (
       <TypeValueCell key={i} value={v} />
     ))}


### PR DESCRIPTION
In #1932 we have a report of the badges having funky alignments:
![image](https://github.com/oxidecomputer/console/assets/22547/3581e990-f764-4048-9db6-b72bcb02d159)

There's a bit more we can do to improve these tables, but this PR at least addresses the layout. It pulls everything to the left-hand side of the column. It also slightly tightens the horizontal spacing between the badges (to 0.5), to create a bit more of a visual connection between them.
![Screenshot 2024-02-01 at 5 02 18 PM](https://github.com/oxidecomputer/console/assets/22547/89a2f459-70f0-4e9c-b378-74cd4868e384)

This PR also makes some changes to the mock api call, to have a bit more data showing on the firewall rules table by default.

I'll note that Justin and I were looking at this and think there could be improvements that (visually) more tightly link the filter type and the value, perhaps a split badge or something? Types with multiple filters (e.g. ports) would need consideration. All that's outside the scope of this PR, though, which is just intended to fix some of the spacing issues.