### PR TITLE
Display API message on not found errors

### DIFF
--- a/app/test/e2e/instance-create.e2e.ts
+++ b/app/test/e2e/instance-create.e2e.ts
@@ -217,3 +217,11 @@ test('add ssh key from instance create form', async ({ page }) => {
   await page.getByRole('link', { name: 'SSH Keys' }).click()
   await expectRowVisible(page.getByRole('table'), { Name: newKey, Description: 'hi' })
 })
+
+test('shows object not found error on no default pool', async ({ page }) => {
+  await page.goto('/projects/mock-project/instances-new')
+  await page.getByRole('textbox', { name: 'Name', exact: true }).fill('no-default-pool')
+  await page.getByRole('button', { name: 'Create instance' }).click()
+
+  await expect(page.getByText('Not found: default IP pool')).toBeVisible()
+})

--- a/libs/api-mocks/msw/db.ts
+++ b/libs/api-mocks/msw/db.ts
@@ -19,14 +19,10 @@ import { internalError, json } from './util'
 
 const notFoundBody = { error_code: 'ObjectNotFound' } as const
 export type NotFound = typeof notFoundBody
-export const notFoundErr = (message?: string) =>
-  json(
-    {
-      error_code: 'ObjectNotFound',
-      message: message ? `not found: ${message}` : undefined,
-    } as const,
-    { status: 404 }
-  )
+export const notFoundErr = (msg?: string) => {
+  const message = msg ? `not found: ${msg}` : 'not found'
+  return json({ error_code: 'ObjectNotFound', message } as const, { status: 404 })
+}
 
 export const lookupById = <T extends { id: string }>(table: T[], id: string) => {
   const item = table.find((i) => i.id === id)

--- a/libs/api-mocks/msw/db.ts
+++ b/libs/api-mocks/msw/db.ts
@@ -19,8 +19,14 @@ import { internalError, json } from './util'
 
 const notFoundBody = { error_code: 'ObjectNotFound' } as const
 export type NotFound = typeof notFoundBody
-export const notFoundErr = () =>
-  json({ error_code: 'ObjectNotFound' } as const, { status: 404 })
+export const notFoundErr = (message?: string) =>
+  json(
+    {
+      error_code: 'ObjectNotFound',
+      message: message ? `not found: ${message}` : undefined,
+    } as const,
+    { status: 404 }
+  )
 
 export const lookupById = <T extends { id: string }>(table: T[], id: string) => {
   const item = table.find((i) => i.id === id)

--- a/libs/api-mocks/msw/handlers.ts
+++ b/libs/api-mocks/msw/handlers.ts
@@ -292,6 +292,10 @@ export const handlers = makeHandlers({
   instanceCreate({ body, query }) {
     const project = lookup.project(query)
 
+    if (body.name === 'no-default-pool') {
+      throw notFoundErr('default IP pool for current silo')
+    }
+
     errIfExists(db.instances, { name: body.name, project_id: project.id }, 'instance')
 
     const instanceId = uuid()

--- a/libs/api/__tests__/errors.spec.ts
+++ b/libs/api/__tests__/errors.spec.ts
@@ -83,6 +83,21 @@ describe('processServerError', () => {
     })
   })
 
+  describe('ObjectNotFound', () => {
+    it('passes through the API error', () => {
+      const error = makeError({
+        errorCode: 'ObjectNotFound',
+        message: 'not found: whatever',
+        statusCode: 404,
+      })
+      expect(processServerError('fakeThingCreate', error)).toEqual({
+        errorCode: 'ObjectNotFound',
+        message: 'Not found: whatever',
+        statusCode: 404,
+      })
+    })
+  })
+
   it('falls back to server error message if code not found', () => {
     const error = makeError({ errorCode: 'WeirdError', message: 'whatever' })
     expect(processServerError('womp', error)).toEqual({
@@ -100,6 +115,6 @@ it.each([
   ['instanceNetworkInterfaceCreate', '', 'interface'],
   ['instanceNetworkInterfaceCreate', 'already exists: something else', 'something else'],
   ['doesNotContainC-reate', '', null],
-])('getResourceName', (method, message, resource) => {
+])('getResourceName: %s', (method, message, resource) => {
   expect(getResourceName(method, message)).toEqual(resource)
 })

--- a/libs/api/__tests__/hooks.spec.tsx
+++ b/libs/api/__tests__/hooks.spec.tsx
@@ -130,7 +130,7 @@ describe('useApiQuery', () => {
         const error = onError.mock.lastCall?.[0]
         expect(error).toEqual({
           errorCode: 'ObjectNotFound',
-          message: 'Object not found',
+          message: 'Not found',
           statusCode: 404,
         })
       })
@@ -208,7 +208,7 @@ describe('useApiMutation', () => {
 
       expect(result.current.error).toEqual({
         errorCode: 'ObjectNotFound',
-        message: 'Object not found',
+        message: 'Not found',
         statusCode: 404,
       })
     })

--- a/libs/api/errors.ts
+++ b/libs/api/errors.ts
@@ -56,7 +56,7 @@ export function processServerError(method: string, resp: ErrorResult): ApiError 
   if (code === 'Forbidden') {
     message = 'Action not authorized'
   } else if (code === 'ObjectNotFound') {
-    message = resp.data.message ? capitalize(resp.data.message) : 'Object not found'
+    message = capitalize(resp.data.message)
   } else if (code === 'ObjectAlreadyExists') {
     const resource = getResourceName(method, resp.data.message)
     if (resource) {

--- a/libs/api/errors.ts
+++ b/libs/api/errors.ts
@@ -7,7 +7,7 @@
  */
 import { camelCaseToWords, capitalize } from '@oxide/util'
 
-import type { ErrorResult } from '.'
+import type { ErrorResult } from './__generated__/Api'
 
 /**
  * Processed API error ready for display in the console. Note that it's possible
@@ -56,7 +56,7 @@ export function processServerError(method: string, resp: ErrorResult): ApiError 
   if (code === 'Forbidden') {
     message = 'Action not authorized'
   } else if (code === 'ObjectNotFound') {
-    message = 'Object not found'
+    message = resp.data.message ? capitalize(resp.data.message) : 'Object not found'
   } else if (code === 'ObjectAlreadyExists') {
     const resource = getResourceName(method, resp.data.message)
     if (resource) {


### PR DESCRIPTION
We have had multiple people raise the issue that when they tried to create an instance without a default IP pool in their silo, it was almost impossible to figure out what the problem was.

https://github.com/oxidecomputer/omicron/issues/4864
https://github.com/oxidecomputer/omicron/issues/4954

I improved the API error message in https://github.com/oxidecomputer/omicron/pull/4880, but this morning I figured out that in both cases, they were using the web console, and it did not matter what the API error was because we only show `OBJECT NOT FOUND` on instance create when we get a 404 back.

https://github.com/oxidecomputer/console/blob/2aa720d297dd758e83a356a60af6396cacf45b7b/libs/api/errors.ts#L58-L59

So this PR changes that behavior so that the client-side error object we pass around contains the error message from the API. As I mentioned [here](https://docs.google.com/document/d/1MfbRgxfYGRk2uQhGzZu3LpdAV5xO3fuKeqazBR14V_w/edit), it might be nice to change the error code from 404 to something else, but I really think this PR gets us 80% of the way there.

My only concern here is that there might be some spots where "Object not found" was nicer than the API error and made sense in context, but now we will be displaying the API error. But hopefully that can't be _too_ bad, since the API messages are all designed to be human readable and helpful.

### Before

![image](https://github.com/oxidecomputer/console/assets/3612203/43bb4dee-0341-4540-ba1e-bf9fd811feb7)

### After

<img width="1188" alt="image" src="https://github.com/oxidecomputer/console/assets/3612203/8f25226f-bed0-4977-875e-e6bae9da2ae6">
