### PR TITLE
More thorough IP address regex tests

### DIFF
--- a/libs/util/str.spec.ts
+++ b/libs/util/str.spec.ts
@@ -86,7 +86,7 @@ describe('titleCase', () => {
 })
 
 // Rust playground showing the results of these test cases match the results of std::net::{Ipv4Addr, Ipv6Addr}
-// https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=babc49cd34bf19669137e22b9202d2eb
+// https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=3c7514e2ac6838f8ea971a9027586747
 
 test.each(['123.4.56.7', '1.2.3.4'])('ipv4Regex passes: %s', (s) => {
   expect(IPV4_REGEX.test(s)).toBe(true)
@@ -99,6 +99,11 @@ test.each([
   'a.b.c.d',
   // some implementations (I think incorrectly) allow leading zeros but nexus does not
   '01.102.103.104',
+  '::ffff:192.0.2.128',
+  '127.0.0',
+  '127.0.0.1.',
+  '127.0.0.1 ',
+  ' 127.0.0.1',
 ])('ipv4Regex fails: %s', (s) => {
   expect(IPV4_REGEX.test(s)).toBe(false)
 })
@@ -111,10 +116,18 @@ test.each([
   '::1234:5678',
   '2001:db8::1234:5678',
   '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+  '::ffff:192.0.2.128',
 ])('ipv6Regex passes: %s', (s) => {
   expect(IPV6_REGEX.test(s)).toBe(true)
 })
 
-test.each(['', '1', 'abc', '123.4.56.7'])('ipv6Regex fails: %s', (s) => {
+test.each([
+  '',
+  '1',
+  'abc',
+  '123.4.56.7',
+  ' 2001:db8:3333:4444:5555:6666:7777:8888',
+  '::1234:5678 ',
+])('ipv6Regex fails: %s', (s) => {
   expect(IPV6_REGEX.test(s)).toBe(false)
 })

--- a/libs/util/str.spec.ts
+++ b/libs/util/str.spec.ts
@@ -85,8 +85,8 @@ describe('titleCase', () => {
   })
 })
 
-// Rust playground showing the results of these test cases match the results of std::net::{Ipv4Addr, Ipv6Addr}
-// https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=3c7514e2ac6838f8ea971a9027586747
+// Rust playground comparing results with std::net::{Ipv4Addr, Ipv6Addr}
+// https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=493b3345b9f6c0b1c8ee91834e99ef7b
 
 test.each(['123.4.56.7', '1.2.3.4'])('ipv4Regex passes: %s', (s) => {
   expect(IPV4_REGEX.test(s)).toBe(true)
@@ -104,6 +104,10 @@ test.each([
   '127.0.0.1.',
   '127.0.0.1 ',
   ' 127.0.0.1',
+  '10002.3.4',
+  '1.2.3.4.5',
+  '256.0.0.0',
+  '260.0.0.0',
 ])('ipv4Regex fails: %s', (s) => {
   expect(IPV4_REGEX.test(s)).toBe(false)
 })
@@ -117,6 +121,14 @@ test.each([
   '2001:db8::1234:5678',
   '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
   '::ffff:192.0.2.128',
+  '1:2:3:4:5:6:7:8',
+  '::ffff:10.0.0.1',
+  '::ffff:1.2.3.4',
+  '::ffff:0.0.0.0',
+  '1:2:3:4:5:6:77:88',
+  '::ffff:255.255.255.255',
+  'fe08::7:8',
+  'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
 ])('ipv6Regex passes: %s', (s) => {
   expect(IPV6_REGEX.test(s)).toBe(true)
 })
@@ -126,8 +138,19 @@ test.each([
   '1',
   'abc',
   '123.4.56.7',
-  ' 2001:db8:3333:4444:5555:6666:7777:8888',
-  '::1234:5678 ',
+  '2001:0db8:85a3:0000:0000:8a2e:0370:7334 ',
+  ' 2001:db8::',
+  '1:2:3:4:5:6:7:8:9',
+  '1:2:3:4:5:6::7:8',
+  ':1:2:3:4:5:6:7:8',
+  '1:2:3:4:5:6:7:8:',
+  '::1:2:3:4:5:6:7:8',
+  '1:2:3:4:5:6:7:8::',
+  '1:2:3:4:5:6:7:88888',
+  '2001:db8:3:4:5::192.0.2.33', // std::new::Ipv6Net allows this one
+  'fe08::7:8%',
+  'fe08::7:8i',
+  'fe08::7:8interface',
 ])('ipv6Regex fails: %s', (s) => {
   expect(IPV6_REGEX.test(s)).toBe(false)
 })

--- a/libs/util/str.spec.ts
+++ b/libs/util/str.spec.ts
@@ -88,31 +88,33 @@ describe('titleCase', () => {
 // Rust playground showing the results of these test cases match the results of std::net::{Ipv4Addr, Ipv6Addr}
 // https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=babc49cd34bf19669137e22b9202d2eb
 
-test.each([
-  ['', false],
-  ['1', false],
-  ['abc', false],
-  ['a.b.c.d', false],
-  // some implementations (I think incorrectly) allow leading zeros but nexus does not
-  ['01.102.103.104', false],
-  ['123.4.56.7', true],
-  ['1.2.3.4', true],
-])('ipv4Regex %s', (s, result) => {
-  expect(IPV4_REGEX.test(s)).toBe(result)
+test.each(['123.4.56.7', '1.2.3.4'])('ipv4Regex passes: %s', (s) => {
+  expect(IPV4_REGEX.test(s)).toBe(true)
 })
 
 test.each([
-  ['', false],
-  ['1', false],
-  ['abc', false],
-  ['123.4.56.7', false],
-  ['2001:db8:3333:4444:5555:6666:7777:8888', true],
-  ['2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF', true],
-  ['::', true],
-  ['2001:db8::', true],
-  ['::1234:5678', true],
-  ['2001:db8::1234:5678', true],
-  ['2001:0db8:85a3:0000:0000:8a2e:0370:7334', true],
-])('ipv6Regex %s', (s, result) => {
-  expect(IPV6_REGEX.test(s)).toBe(result)
+  '',
+  '1',
+  'abc',
+  'a.b.c.d',
+  // some implementations (I think incorrectly) allow leading zeros but nexus does not
+  '01.102.103.104',
+])('ipv4Regex fails: %s', (s) => {
+  expect(IPV4_REGEX.test(s)).toBe(false)
+})
+
+test.each([
+  '2001:db8:3333:4444:5555:6666:7777:8888',
+  '2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF',
+  '::',
+  '2001:db8::',
+  '::1234:5678',
+  '2001:db8::1234:5678',
+  '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+])('ipv6Regex passes: %s', (s) => {
+  expect(IPV6_REGEX.test(s)).toBe(true)
+})
+
+test.each(['', '1', 'abc', '123.4.56.7'])('ipv6Regex fails: %s', (s) => {
+  expect(IPV6_REGEX.test(s)).toBe(false)
 })


### PR DESCRIPTION
No code changes, so this doesn't need to go into omicron in a hurry. I just wanted to validate the regexes with more kinds of IP addresses.