### PR TITLE
Replace Hannah Arendt as sample user

### DIFF
--- a/app/test/e2e/project-access.e2e.ts
+++ b/app/test/e2e/project-access.e2e.ts
@@ -17,7 +17,7 @@ test('Click through project access page', async ({ page }) => {
   await expectVisible(page, ['role=heading[name*="Access & IAM"]'])
   const table = page.locator('table')
   await expectRowVisible(table, {
-    Name: 'Hannah Arendt',
+    Name: 'Simone Weil',
     'Silo role': 'admin',
     'Project role': '',
   })
@@ -48,7 +48,7 @@ test('Click through project access page', async ({ page }) => {
   // only users not already on the project should be visible
   await expectNotVisible(page, ['role=option[name="Jacob Klein"]'])
   await expectVisible(page, [
-    'role=option[name="Hannah Arendt"]',
+    'role=option[name="Simone Weil"]',
     'role=option[name="Hans Jonas"]',
     'role=option[name="Simone de Beauvoir"]',
   ])
@@ -99,12 +99,12 @@ test('Click through project access page', async ({ page }) => {
   // now add a project role to user 1, who currently only has silo role
   await page.click('role=button[name="Add user or group"]')
   await page.click('role=button[name*="User or group"]')
-  await page.click('role=option[name="Hannah Arendt"]')
+  await page.click('role=option[name="Simone Weil"]')
   await page.click('role=button[name*="Role"]')
   await page.click('role=option[name="Viewer"]')
   await page.click('role=button[name="Assign role"]')
   await expectRowVisible(table, {
-    Name: 'Hannah Arendt',
+    Name: 'Simone Weil',
     'Silo role': 'admin',
     'Project role': 'viewer',
   })

--- a/app/test/e2e/silo-access.e2e.ts
+++ b/app/test/e2e/silo-access.e2e.ts
@@ -24,7 +24,7 @@ test('Click through silo access page', async ({ page }) => {
     'Silo role': 'collaborator',
   })
   await expectRowVisible(table, {
-    Name: 'Hannah Arendt',
+    Name: 'Simone Weil',
     'Silo role': 'admin',
   })
   await expectNotVisible(page, [`role=cell[name="${user4.display_name}"]`])
@@ -35,7 +35,7 @@ test('Click through silo access page', async ({ page }) => {
 
   await page.click('role=button[name*="User or group"]')
   // only users not already on the org should be visible
-  await expectNotVisible(page, ['role=option[name="Hannah Arendt"]'])
+  await expectNotVisible(page, ['role=option[name="Simone Weil"]'])
   await expectVisible(page, [
     'role=option[name="Hans Jonas"]',
     'role=option[name="Jacob Klein"]',

--- a/libs/api-mocks/msw/util.spec.ts
+++ b/libs/api-mocks/msw/util.spec.ts
@@ -76,7 +76,7 @@ describe('userHasRole', () => {
     expect(
       users.map((u) => [u.display_name, userHasRole(u, 'fleet', FLEET_ID, 'viewer')])
     ).toEqual([
-      ['Hannah Arendt', true],
+      ['Simone Weil', true],
       ['Hans Jonas', false],
       ['Jacob Klein', false],
       ['Simone de Beauvoir', false],
@@ -90,7 +90,7 @@ describe('userHasRole', () => {
         userHasRole(u, 'silo', defaultSilo.id, 'collaborator'),
       ])
     ).toEqual([
-      ['Hannah Arendt', true],
+      ['Simone Weil', true],
       ['Hans Jonas', true],
       ['Jacob Klein', false],
       ['Simone de Beauvoir', false],

--- a/libs/api-mocks/user.ts
+++ b/libs/api-mocks/user.ts
@@ -12,7 +12,7 @@ import { defaultSilo } from './silo'
 
 export const user1: Json<User> = {
   id: '2e28576d-43e0-4e9e-9132-838a7b66f602',
-  display_name: 'Hannah Arendt',
+  display_name: 'Simone Weil',
   silo_id: defaultSilo.id,
 }
 


### PR DESCRIPTION
Given Arendt's [history](https://www.normfriesen.info/forgotten/little_rock1.pdf) of [anti-black racism](https://www.jstor.org/stable/10.5325/critphilrace.3.1.0052), this PR is a simple request to replace the sample user with a less problematic 20th century philosopher.