### PR TITLE
Return floating IPs from mock instance external IPs endpoint

### DIFF
--- a/libs/api-mocks/external-ip.ts
+++ b/libs/api-mocks/external-ip.ts
@@ -10,14 +10,24 @@ import type { ExternalIp } from '@oxide/api'
 import { instances } from './instance'
 import type { Json } from './json-type'
 
+/**
+ * This is a case where we need extra structure beyond the API response. The API
+ * response for an ephemeral IP does not indicate the instance it's attached to
+ * (maybe it should, but that's a separate problem), but we need the instance ID
+ * on each one in order to look up the IPs for a given instance. The floating IP
+ * arm of the union does have an instance_id field, so that's a point in favor
+ * of adding it to the ephemeral IP arm.
+ */
 type DbExternalIp = {
   instance_id: string
   external_ip: Json<ExternalIp>
 }
 
-// TODO: this type represents the API response, but we need to mock more
-// structure in order to be able to look up IPs for a particular instance
-export const externalIps: DbExternalIp[] = [
+// Note that ExternalIp is a union of types representing ephemeral and floating
+// IPs, but we only put the ephemeral ones here. We have a separate table for
+// floating IPs analogous to the floating_ip view in Nexus.
+
+export const ephemeralIps: DbExternalIp[] = [
   {
     instance_id: instances[0].id,
     external_ip: {

--- a/libs/api-mocks/msw/db.ts
+++ b/libs/api-mocks/msw/db.ts
@@ -263,7 +263,7 @@ const initDb = {
   /** Join table for `users` and `userGroups` */
   groupMemberships: [...mock.groupMemberships],
   images: [...mock.images],
-  externalIps: [...mock.externalIps],
+  ephemeralIps: [...mock.ephemeralIps],
   instances: [...mock.instances],
   ipPools: [...mock.ipPools],
   ipPoolSilos: [...mock.ipPoolSilos],

--- a/libs/api-mocks/msw/handlers.ts
+++ b/libs/api-mocks/msw/handlers.ts
@@ -496,11 +496,18 @@ export const handlers = makeHandlers({
   },
   instanceExternalIpList({ path, query }) {
     const instance = lookup.instance({ ...path, ...query })
-    const externalIps = db.externalIps
+
+    const ephemeralIps = db.ephemeralIps
       .filter((eip) => eip.instance_id === instance.id)
       .map((eip) => eip.external_ip)
+
+    // floating IPs are missing their `kind` field in the DB so we add it
+    const floatingIps = db.floatingIps
+      .filter((f) => f.instance_id === instance.id)
+      .map((f) => ({ kind: 'floating' as const, ...f }))
+
     // endpoint is not paginated. or rather, it's fake paginated
-    return { items: externalIps }
+    return { items: [...ephemeralIps, ...floatingIps] }
   },
   instanceNetworkInterfaceList({ query }) {
     const instance = lookup.instance(query)


### PR DESCRIPTION
Closes #1966

I considered storing floating and ephemeral IPs in a single `externalIps` table, but it was a bit annoying because the response for the floating IPs list is slightly different from the `ExternalIp` type — it doesn't have a `kind` field because there is only one kind. For some reason it felt better to add the kind in the `instanceExternalIpList` handler than to remove the kind for the `floatingIp` endpoint and friends. We can revisit this in the future if more complex mock functionality makes the two tables feel overcomplicated. Right now nothing ever writes to the ephemeral IPs table, though it probably should — when you create an instance it should add an ephemeral IP.