### PR TITLE
Don't prefetch IP pools for floating IP create

### DIFF
--- a/app/forms/floating-ip-create.tsx
+++ b/app/forms/floating-ip-create.tsx
@@ -11,10 +11,9 @@ import { useNavigate } from 'react-router-dom'
 import type { SetRequired } from 'type-fest'
 
 import {
-  apiQueryClient,
   useApiMutation,
+  useApiQuery,
   useApiQueryClient,
-  usePrefetchedApiQuery,
   type FloatingIpCreate,
   type SiloIpPool,
 } from '@oxide/api'
@@ -31,13 +30,6 @@ import {
 } from 'app/components/form'
 import { useForm, useProjectSelector, useToast } from 'app/hooks'
 import { pb } from 'app/util/path-builder'
-
-CreateFloatingIpSideModalForm.loader = async () => {
-  await apiQueryClient.prefetchQuery('projectIpPoolList', {
-    query: { limit: 1000 },
-  })
-  return null
-}
 
 const toListboxItem = (p: SiloIpPool) => {
   if (!p.isDefault) {
@@ -66,8 +58,9 @@ const defaultValues: SetRequired<FloatingIpCreate, 'address'> = {
 }
 
 export function CreateFloatingIpSideModalForm() {
-  // Fetch 1000 to we can be sure to get them all.
-  const { data: allPools } = usePrefetchedApiQuery('projectIpPoolList', {
+  // Fetch 1000 to we can be sure to get them all. Don't bother prefetching
+  // because the list is hidden under the Advanced accordion.
+  const { data: allPools } = useApiQuery('projectIpPoolList', {
     query: { limit: 1000 },
   })
 
@@ -126,7 +119,7 @@ export function CreateFloatingIpSideModalForm() {
 
           <ListboxField
             name="pool"
-            items={allPools.items.map((p) => toListboxItem(p))}
+            items={(allPools?.items || []).map((p) => toListboxItem(p))}
             label="IP pool"
             control={form.control}
             placeholder="Select pool"

--- a/app/routes.tsx
+++ b/app/routes.tsx
@@ -356,7 +356,6 @@ export const routes = createRoutesFromElements(
           <Route path="floating-ips" handle={{ crumb: 'Floating IPs' }} element={null} />
           <Route
             path="floating-ips-new"
-            loader={CreateFloatingIpSideModalForm.loader}
             element={<CreateFloatingIpSideModalForm />}
             handle={{ crumb: 'New Floating IP' }}
           />


### PR DESCRIPTION
Didn't occur to me after we put the pool picker under the accordion, but we don't need to prefetch the list of IP pools since the list is hidden. Getting rid of the loader makes the create side modal pop up instantly.