### PR TITLE
Better memoization of callbacks in `usePagination`

### DIFF
--- a/app/hooks/use-pagination.ts
+++ b/app/hooks/use-pagination.ts
@@ -5,7 +5,7 @@
  *
  * Copyright Oxide Computer Company
  */
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 
 type PageToken = string | undefined
 
@@ -13,16 +13,19 @@ export function usePagination() {
   const [prevPages, setPrevPages] = useState<PageToken[]>([])
   const [currentPage, setCurrentPage] = useState<PageToken>()
 
-  const goToPrevPage = () => {
+  const goToPrevPage = useCallback(() => {
     const prevPage = prevPages.pop()
     setCurrentPage(prevPage)
     setPrevPages(prevPages)
-  }
+  }, [prevPages])
 
-  const goToNextPage = (nextPageToken: string) => {
-    setPrevPages([...prevPages, currentPage])
-    setCurrentPage(nextPageToken)
-  }
+  const goToNextPage = useCallback(
+    (nextPageToken: string) => {
+      setPrevPages((prevPages) => [...prevPages, currentPage])
+      setCurrentPage(nextPageToken)
+    },
+    [currentPage]
+  )
 
   return {
     currentPage,

--- a/app/pages/project/disks/DisksPage.tsx
+++ b/app/pages/project/disks/DisksPage.tsx
@@ -125,7 +125,7 @@ export function DisksPage() {
         </Link>
       </TableActions>
       <Table emptyState={<EmptyState />} makeActions={makeActions}>
-        <Column accessor="name" header="Disk" />
+        <Column accessor="name" />
         {/* TODO: show info about the instance it's attached to */}
         <Column
           id="attached-to"

--- a/app/table/QueryTable.tsx
+++ b/app/table/QueryTable.tsx
@@ -193,19 +193,6 @@ const makeQueryTable = <Item extends Record<string, unknown>>(
 
     if (debug) console.table((data as { items?: any[] })?.items || data)
 
-    const paginationParams = useMemo(
-      () => ({
-        pageSize,
-        hasNext: tableData.length === pageSize,
-        hasPrev,
-        nextPage: (data as any)?.nextPage,
-        onNext: goToNextPage,
-        onPrev: goToPrevPage,
-      }),
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      [pageSize, tableData.length, (data as any)?.nextPage]
-    )
-
     if (isLoading) return null
 
     const isEmpty = tableData.length === 0 && !hasPrev
@@ -222,7 +209,15 @@ const makeQueryTable = <Item extends Record<string, unknown>>(
           singleSelect={!!onSingleSelect}
           multiSelect={!!onMultiSelect}
         />
-        <Pagination inline={pagination === 'inline'} {...paginationParams} />
+        <Pagination
+          inline={pagination === 'inline'}
+          pageSize={pageSize}
+          hasNext={tableData.length === pageSize}
+          hasPrev={hasPrev}
+          nextPage={(data as any)?.nextPage}
+          onNext={goToNextPage}
+          onPrev={goToPrevPage}
+        />
       </>
     )
   }

--- a/mock-api/disk.ts
+++ b/mock-api/disk.ts
@@ -10,7 +10,7 @@ import { GiB } from '@oxide/util'
 
 import { instance } from './instance'
 import type { Json } from './json-type'
-import { project } from './project'
+import { project, project2 } from './project'
 
 export const disks: Json<Disk>[] = [
   {
@@ -145,4 +145,20 @@ export const disks: Json<Disk>[] = [
     size: 12 * GiB,
     block_size: 2048,
   },
+  // put a ton of disks in project 2 so we can use it to test pagination
+  ...new Array(55).fill(0).map((_, i) => {
+    const numStr = (i + 1).toString().padStart(2, '0')
+    return {
+      id: '9747d936-795d-4d76-8ee0-15561f4cbb' + numStr,
+      name: 'disk-' + numStr,
+      description: '',
+      project_id: project2.id,
+      time_created: new Date().toISOString(),
+      time_modified: new Date().toISOString(),
+      state: { state: 'detached' as const },
+      device_path: '/jkl',
+      size: 12 * GiB,
+      block_size: 2048,
+    }
+  }),
 ]

--- a/test/e2e/disks.e2e.ts
+++ b/test/e2e/disks.e2e.ts
@@ -16,13 +16,13 @@ test('List disks and snapshot', async ({ page }) => {
   // check one attached and one not attached
   await expectRowVisible(table, {
     'Attached To': 'db1',
-    Disk: 'disk-1',
+    name: 'disk-1',
     Size: '2 GiB',
     status: 'attached',
   })
   await expectRowVisible(table, {
     'Attached To': '',
-    Disk: 'disk-3',
+    name: 'disk-3',
     Size: '6 GiB',
     status: 'detached',
   })

--- a/test/e2e/pagination.e2e.ts
+++ b/test/e2e/pagination.e2e.ts
@@ -5,23 +5,37 @@
  *
  * Copyright Oxide Computer Company
  */
-import { expectRowVisible, expectVisible, test } from './utils'
+import { expect, test } from '@playwright/test'
+
+import { expectRowVisible } from './utils'
 
 test('pagination', async ({ page }) => {
-  await page.goto('/projects/mock-project/snapshots')
+  await page.goto('/projects/other-project/disks')
 
-  // Test pagination
-  await page.getByRole('button', { name: 'next' }).click()
-  await expectRowVisible(page.getByRole('table'), {
-    name: 'disk-1-snapshot-25',
-    disk: 'disk-1',
-  })
-  await page.getByRole('button', { name: 'prev', exact: true }).click()
-  await expectVisible(page, [
-    'role=heading[name*="Snapshots"]',
-    'role=cell[name="snapshot-1"]',
-    'role=cell[name="snapshot-2"]',
-    'role=cell[name="delete-500"]',
-    'role=cell[name="snapshot-4"]',
-  ])
+  const table = page.getByRole('table')
+  const rows = page.getByRole('row')
+  const nextButton = page.getByRole('button', { name: 'next' })
+  const prevButton = page.getByRole('button', { name: 'prev', exact: true })
+
+  await expect(rows).toHaveCount(26)
+  await expectRowVisible(table, { name: 'disk-01' })
+  await expectRowVisible(table, { name: 'disk-25' })
+
+  await nextButton.click()
+  await expect(rows).toHaveCount(26)
+  await expectRowVisible(table, { name: 'disk-26' })
+  await expectRowVisible(table, { name: 'disk-50' })
+
+  await prevButton.click()
+  await expect(rows).toHaveCount(26)
+  await expectRowVisible(table, { name: 'disk-01' })
+  await expectRowVisible(table, { name: 'disk-25' })
+
+  await nextButton.click()
+  await nextButton.click()
+  await expect(rows).toHaveCount(6)
+  await expectRowVisible(table, { name: 'disk-51' })
+  await expectRowVisible(table, { name: 'disk-55' })
+
+  await expect(nextButton).toBeDisabled() // no more pages
 })


### PR DESCRIPTION
The `paginationParams` `useMemo` in `QueryTable` was a bit odd. Note especially that we were ignoring the exhaustive-deps lint check. I think memoizing the callbacks inside of `usePagination` makes it strictly more correct as well as simpler.