### PR TITLE
Remove Badge component from barrel file

### DIFF
--- a/app/components/AccessNameCell.tsx
+++ b/app/components/AccessNameCell.tsx
@@ -8,7 +8,8 @@
 import type { CellContext } from '@tanstack/react-table'
 
 import type { IdentityType } from '@oxide/api'
-import { Badge } from '@oxide/ui'
+
+import { Badge } from '~/ui/lib/Badge'
 
 /**
  * Display the user or group name. If the row is for a group, add a GROUP badge.

--- a/app/components/RoleBadgeCell.tsx
+++ b/app/components/RoleBadgeCell.tsx
@@ -8,7 +8,8 @@
 import type { CellContext } from '@tanstack/react-table'
 
 import type { RoleKey } from '@oxide/api'
-import { Badge } from '@oxide/ui'
+
+import { Badge } from '~/ui/lib/Badge'
 
 /**
  * Highlight the "effective" role in green, others gray.

--- a/app/components/StatusBadge.tsx
+++ b/app/components/StatusBadge.tsx
@@ -6,7 +6,8 @@
  * Copyright Oxide Computer Company
  */
 import type { DiskState, InstanceState, SnapshotState } from '@oxide/api'
-import { Badge, type BadgeColor, type BadgeProps } from '@oxide/ui'
+
+import { Badge, type BadgeColor, type BadgeProps } from '~/ui/lib/Badge'
 
 const INSTANCE_COLORS: Record<InstanceState, Pick<BadgeProps, 'color' | 'variant'>> = {
   creating: { color: 'purple', variant: 'solid' },

--- a/app/components/form/fields/DisksTableField.tsx
+++ b/app/components/form/fields/DisksTableField.tsx
@@ -9,9 +9,10 @@ import { useState } from 'react'
 import { useController, type Control } from 'react-hook-form'
 
 import type { DiskCreate } from '@oxide/api'
-import { Badge, Button, Error16Icon, FieldLabel, MiniTable } from '@oxide/ui'
+import { Button, Error16Icon, FieldLabel, MiniTable } from '@oxide/ui'
 import { bytesToGiB } from '@oxide/util'
 
+import { Badge } from '~/ui/lib/Badge'
 import AttachDiskSideModalForm from 'app/forms/disk-attach'
 import { CreateDiskSideModalForm } from 'app/forms/disk-create'
 import type { InstanceCreateInput } from 'app/forms/instance-create'

--- a/app/forms/access-util.tsx
+++ b/app/forms/access-util.tsx
@@ -12,8 +12,10 @@ import {
   type Policy,
   type RoleKey,
 } from '@oxide/api'
-import { Badge, type ListboxItem } from '@oxide/ui'
+import { type ListboxItem } from '@oxide/ui'
 import { capitalize } from '@oxide/util'
+
+import { Badge } from '~/ui/lib/Badge'
 
 type AddUserValues = {
   identityId: string

--- a/app/forms/firewall-rules-create.tsx
+++ b/app/forms/firewall-rules-create.tsx
@@ -18,7 +18,7 @@ import {
   type VpcFirewallRuleTarget,
   type VpcFirewallRuleUpdate,
 } from '@oxide/api'
-import { Badge, Button, Error16Icon, FormDivider, MiniTable } from '@oxide/ui'
+import { Button, Error16Icon, FormDivider, MiniTable } from '@oxide/ui'
 
 import { CheckboxField } from '~/components/form/fields/CheckboxField'
 import { DescriptionField } from '~/components/form/fields/DescriptionField'
@@ -28,6 +28,7 @@ import { NumberField } from '~/components/form/fields/NumberField'
 import { RadioField } from '~/components/form/fields/RadioField'
 import { TextField } from '~/components/form/fields/TextField'
 import { SideModalForm } from '~/components/form/SideModalForm'
+import { Badge } from '~/ui/lib/Badge'
 import { useForm, useVpcSelector } from 'app/hooks'
 
 export type FirewallRuleValues = {

--- a/app/forms/floating-ip-create.tsx
+++ b/app/forms/floating-ip-create.tsx
@@ -17,7 +17,7 @@ import {
   type FloatingIpCreate,
   type SiloIpPool,
 } from '@oxide/api'
-import { Badge, Message } from '@oxide/ui'
+import { Message } from '@oxide/ui'
 import { validateIp } from '@oxide/util'
 
 import { DescriptionField } from '~/components/form/fields/DescriptionField'
@@ -25,6 +25,7 @@ import { ListboxField } from '~/components/form/fields/ListboxField'
 import { NameField } from '~/components/form/fields/NameField'
 import { TextField } from '~/components/form/fields/TextField'
 import { SideModalForm } from '~/components/form/SideModalForm'
+import { Badge } from '~/ui/lib/Badge'
 import { AccordionItem } from 'app/components/AccordionItem'
 import { useForm, useProjectSelector, useToast } from 'app/hooks'
 import { pb } from 'app/util/path-builder'

--- a/app/pages/project/instances/instance/SerialConsolePage.tsx
+++ b/app/pages/project/instances/instance/SerialConsolePage.tsx
@@ -9,8 +9,9 @@ import { lazy, Suspense, useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 
 import { api } from '@oxide/api'
-import { Badge, PrevArrow12Icon, Spinner, type BadgeColor } from '@oxide/ui'
+import { PrevArrow12Icon, Spinner } from '@oxide/ui'
 
+import { Badge, type BadgeColor } from '~/ui/lib/Badge'
 import EquivalentCliCommand from 'app/components/EquivalentCliCommand'
 import { useInstanceSelector } from 'app/hooks'
 import { pb } from 'app/util/path-builder'

--- a/app/pages/project/instances/instance/tabs/NetworkingTab.tsx
+++ b/app/pages/project/instances/instance/tabs/NetworkingTab.tsx
@@ -17,12 +17,13 @@ import {
   usePrefetchedApiQuery,
   type InstanceNetworkInterface,
 } from '@oxide/api'
-import { Badge, Button, EmptyMessage, Networking24Icon } from '@oxide/ui'
+import { Button, EmptyMessage, Networking24Icon } from '@oxide/ui'
 
 import { SkeletonCell } from '~/table/cells/EmptyCell'
 import { LinkCell } from '~/table/cells/LinkCell'
 import type { MenuAction } from '~/table/columns/action-col'
 import { useQueryTable } from '~/table/QueryTable'
+import { Badge } from '~/ui/lib/Badge'
 import CreateNetworkInterfaceForm from 'app/forms/network-interface-create'
 import EditNetworkInterfaceForm from 'app/forms/network-interface-edit'
 import {

--- a/app/pages/project/snapshots/SnapshotsPage.tsx
+++ b/app/pages/project/snapshots/SnapshotsPage.tsx
@@ -15,7 +15,6 @@ import {
   type Snapshot,
 } from '@oxide/api'
 import {
-  Badge,
   buttonStyle,
   EmptyMessage,
   PageHeader,
@@ -29,6 +28,7 @@ import { SkeletonCell } from '~/table/cells/EmptyCell'
 import { SizeCell } from '~/table/cells/SizeCell'
 import type { MenuAction } from '~/table/columns/action-col'
 import { useQueryTable } from '~/table/QueryTable'
+import { Badge } from '~/ui/lib/Badge'
 import { SnapshotStatusBadge } from 'app/components/StatusBadge'
 import { getProjectSelector, useProjectSelector } from 'app/hooks'
 import { confirmDelete } from 'app/stores/confirm-delete'

--- a/app/pages/system/networking/IpPoolPage.tsx
+++ b/app/pages/system/networking/IpPoolPage.tsx
@@ -19,7 +19,6 @@ import {
   type IpPoolSiloLink,
 } from '@oxide/api'
 import {
-  Badge,
   Button,
   buttonStyle,
   EmptyMessage,
@@ -38,6 +37,7 @@ import { SkeletonCell } from '~/table/cells/EmptyCell'
 import { LinkCell } from '~/table/cells/LinkCell'
 import type { MenuAction } from '~/table/columns/action-col'
 import { useQueryTable } from '~/table/QueryTable'
+import { Badge } from '~/ui/lib/Badge'
 import { ExternalLink } from 'app/components/ExternalLink'
 import { HL } from 'app/components/HL'
 import { QueryParamTabs } from 'app/components/QueryParamTabs'

--- a/app/pages/system/silos/SiloIdpsTab.tsx
+++ b/app/pages/system/silos/SiloIdpsTab.tsx
@@ -7,13 +7,14 @@
  */
 import { Link, Outlet } from 'react-router-dom'
 
-import { Badge, buttonStyle, Cloud24Icon, EmptyMessage } from '@oxide/ui'
+import { buttonStyle, Cloud24Icon, EmptyMessage } from '@oxide/ui'
 
 import { DateCell } from '~/table/cells/DateCell'
 import { DefaultCell } from '~/table/cells/DefaultCell'
 import { linkCell } from '~/table/cells/LinkCell'
 import { TruncateCell } from '~/table/cells/TruncateCell'
 import { useQueryTable } from '~/table/QueryTable'
+import { Badge } from '~/ui/lib/Badge'
 import { useSiloSelector } from 'app/hooks'
 import { pb } from 'app/util/path-builder'
 

--- a/app/pages/system/silos/SiloIpPoolsTab.tsx
+++ b/app/pages/system/silos/SiloIpPoolsTab.tsx
@@ -10,7 +10,6 @@ import { useMemo, useState } from 'react'
 
 import { useApiMutation, useApiQuery, useApiQueryClient, type SiloIpPool } from '@oxide/api'
 import {
-  Badge,
   Button,
   EmptyMessage,
   Message,
@@ -23,6 +22,7 @@ import { ListboxField } from '~/components/form/fields/ListboxField'
 import { linkCell } from '~/table/cells/LinkCell'
 import type { MenuAction } from '~/table/columns/action-col'
 import { useQueryTable } from '~/table/QueryTable'
+import { Badge } from '~/ui/lib/Badge'
 import { ExternalLink } from 'app/components/ExternalLink'
 import { HL } from 'app/components/HL'
 import { useForm, useSiloSelector } from 'app/hooks'

--- a/app/pages/system/silos/SiloPage.tsx
+++ b/app/pages/system/silos/SiloPage.tsx
@@ -9,7 +9,6 @@ import { type LoaderFunctionArgs } from 'react-router-dom'
 
 import { apiQueryClient, usePrefetchedApiQuery } from '@oxide/api'
 import {
-  Badge,
   Cloud24Icon,
   EmptyMessage,
   NextArrow12Icon,
@@ -22,6 +21,7 @@ import {
 import { formatDateTime } from '@oxide/util'
 
 import { EmptyCell } from '~/table/cells/EmptyCell'
+import { Badge } from '~/ui/lib/Badge'
 import { QueryParamTabs } from 'app/components/QueryParamTabs'
 import { getSiloSelector, useSiloSelector } from 'app/hooks'
 

--- a/app/pages/system/silos/SilosPage.tsx
+++ b/app/pages/system/silos/SilosPage.tsx
@@ -16,7 +16,6 @@ import {
   type Silo,
 } from '@oxide/api'
 import {
-  Badge,
   buttonStyle,
   Cloud24Icon,
   EmptyMessage,
@@ -30,6 +29,7 @@ import { DateCell } from '~/table/cells/DateCell'
 import { linkCell } from '~/table/cells/LinkCell'
 import type { MenuAction } from '~/table/columns/action-col'
 import { useQueryTable } from '~/table/QueryTable'
+import { Badge } from '~/ui/lib/Badge'
 import { useQuickActions } from 'app/hooks/use-quick-actions'
 import { confirmDelete } from 'app/stores/confirm-delete'
 import { pb } from 'app/util/path-builder'

--- a/app/table/cells/EnabledCell.tsx
+++ b/app/table/cells/EnabledCell.tsx
@@ -6,7 +6,9 @@
  * Copyright Oxide Computer Company
  */
 import type { VpcFirewallRuleStatus } from '@oxide/api'
-import { Badge, Success12Icon } from '@oxide/ui'
+import { Success12Icon } from '@oxide/ui'
+
+import { Badge } from '~/ui/lib/Badge'
 
 import type { Cell } from './Cell'
 

--- a/app/table/cells/FirewallFilterCell.tsx
+++ b/app/table/cells/FirewallFilterCell.tsx
@@ -6,7 +6,8 @@
  * Copyright Oxide Computer Company
  */
 import type { VpcFirewallRuleFilter } from '@oxide/api'
-import { Badge } from '@oxide/ui'
+
+import { Badge } from '~/ui/lib/Badge'
 
 import { type Cell } from './Cell'
 import { TypeValueCell } from './TypeValueCell'

--- a/app/table/cells/LabelCell.tsx
+++ b/app/table/cells/LabelCell.tsx
@@ -5,7 +5,7 @@
  *
  * Copyright Oxide Computer Company
  */
-import { Badge } from '@oxide/ui'
+import { Badge } from '~/ui/lib/Badge'
 
 import type { Cell } from './Cell'
 

--- a/app/table/cells/TypeValueCell.tsx
+++ b/app/table/cells/TypeValueCell.tsx
@@ -5,7 +5,8 @@
  *
  * Copyright Oxide Computer Company
  */
-import { Badge } from '@oxide/ui'
+
+import { Badge } from '~/ui/lib/Badge'
 
 import type { Cell } from './Cell'
 

--- a/app/ui/index.ts
+++ b/app/ui/index.ts
@@ -6,7 +6,6 @@
  * Copyright Oxide Computer Company
  */
 
-export * from './lib/Badge'
 export * from './lib/Button'
 export * from './lib/Checkbox'
 export * from './lib/DateRangePicker'

--- a/app/ui/lib/PropertiesTable.tsx
+++ b/app/ui/lib/PropertiesTable.tsx
@@ -10,7 +10,7 @@ import type { ReactNode } from 'react'
 
 import { invariant, isOneOf } from '@oxide/util'
 
-import { Badge } from './Badge'
+import { Badge } from '~/ui/lib/Badge'
 
 import './properties-table.css'
 

--- a/app/ui/lib/Tabs.stories.tsx
+++ b/app/ui/lib/Tabs.stories.tsx
@@ -5,7 +5,7 @@
  *
  * Copyright Oxide Computer Company
  */
-import { Badge } from '@oxide/ui'
+import { Badge } from '~/ui/lib/Badge'
 
 import { Tabs } from './Tabs'
 


### PR DESCRIPTION
Part of #1964 

Wanted to start with a simple migration from the existing Badge component imports over to importing directly from the component file.