### PR TITLE
pass preloaded data to edit modals

### DIFF
--- a/app/pages/project/vpcs/VpcsPage.tsx
+++ b/app/pages/project/vpcs/VpcsPage.tsx
@@ -66,6 +66,11 @@ export function VpcsPage() {
     {
       label: 'Edit',
       onActivate() {
+        apiQueryClient.setQueryData(
+          'vpcView',
+          { path: { vpc: vpc.name }, query: projectSelector },
+          vpc
+        )
         navigate(pb.vpcEdit({ ...projectSelector, vpc: vpc.name }), { state: vpc })
       },
     },


### PR DESCRIPTION
Fixes #2034 

Turns out we only had one location where we … 1) navigate to a new screen for editing (as opposed to loading a form without changing the URL) and 2) didn't already have `apiQueryClient.setQueryData` in place.

With this change, the `Edit VPC` modal loads instantly.