### PR TITLE
Use proper capitalization in instance metric chart label

### DIFF
--- a/app/pages/project/instances/instance/tabs/MetricsTab.tsx
+++ b/app/pages/project/instances/instance/tabs/MetricsTab.tsx
@@ -86,7 +86,7 @@ function DiskMetric({
   let unitForSet = ''
   let label = '(COUNT)'
   if (isBytesChart) {
-    const byteUnits = ['Bytes', 'KiB', 'MiB', 'GiB', 'TiB']
+    const byteUnits = ['BYTES', 'KiB', 'MiB', 'GiB', 'TiB']
     unitForSet = byteUnits[cycleCount]
     label = `(${unitForSet})`
   }


### PR DESCRIPTION
Fixes #1989 

`Bytes` should be `BYTES`, to match `COUNT`

<img width="795" alt="Screenshot 2024-03-05 at 3 10 55 PM" src="https://github.com/oxidecomputer/console/assets/22547/72b64ded-4114-4d7d-b528-ed68dbc7ff1d">
