### PR TITLE
delete `.appearance-textfield` utility

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -84,11 +84,6 @@ module.exports = {
       )
       addUtilities(textUtilities)
       addUtilities(colorUtilities)
-      addUtilities({
-        '.appearance-textfield': {
-          appearance: 'textfield',
-        },
-      })
       addUtilities(elevationUtilities)
     }),
   ],


### PR DESCRIPTION
It was added [here](https://github.com/oxidecomputer/console/pull/630/files#r801994295) to hide +/- on a number field when we wanted to do that.