### PR TITLE
Add CLI command button to settings group

### DIFF
--- a/app/components/EquivalentCliCommand.tsx
+++ b/app/components/EquivalentCliCommand.tsx
@@ -15,12 +15,35 @@ import useTimeout from '~/ui/lib/use-timeout'
 
 export default function EquivalentCliCommand({ command }: { command: string }) {
   const [isOpen, setIsOpen] = useState(false)
-  const [hasCopied, setHasCopied] = useState(false)
 
   function handleDismiss() {
     setIsOpen(false)
   }
 
+  return (
+    <>
+      <Button variant="ghost" size="sm" className="ml-2" onClick={() => setIsOpen(true)}>
+        Equivalent CLI Command
+      </Button>
+      <EquivalentCliCommandModal
+        isOpen={isOpen}
+        handleDismiss={handleDismiss}
+        command={command}
+      />
+    </>
+  )
+}
+
+export const EquivalentCliCommandModal = ({
+  command,
+  isOpen,
+  handleDismiss,
+}: {
+  command: string
+  isOpen: boolean
+  handleDismiss: () => void
+}) => {
+  const [hasCopied, setHasCopied] = useState(false)
   useTimeout(() => setHasCopied(false), hasCopied ? 2000 : null)
 
   const handleCopy = () => {
@@ -30,36 +53,31 @@ export default function EquivalentCliCommand({ command }: { command: string }) {
   }
 
   return (
-    <>
-      <Button variant="ghost" size="sm" className="ml-2" onClick={() => setIsOpen(true)}>
-        Equivalent CLI Command
-      </Button>
-      <Modal isOpen={isOpen} onDismiss={handleDismiss} title="CLI command">
-        <Modal.Section>
-          <pre className="flex w-full rounded border px-4 py-3 !normal-case !tracking-normal text-mono-md bg-default border-secondary">
-            <div className="mr-2 select-none text-quaternary">$</div>
-            {command}
-          </pre>
-        </Modal.Section>
-        <Modal.Footer
-          onDismiss={handleDismiss}
-          onAction={handleCopy}
-          actionText={
-            <>
-              {/* use of invisible keeps button the same size in both states */}
-              <span className={hasCopied ? 'invisible' : ''}>Copy command</span>
-              <span
-                className={`absolute left-1/2 top-1/2 flex -translate-x-1/2 -translate-y-1/2 items-center ${
-                  hasCopied ? '' : 'invisible'
-                }`}
-              >
-                <Success12Icon className="mr-2 text-accent" />
-                Copied
-              </span>
-            </>
-          }
-        />
-      </Modal>
-    </>
+    <Modal isOpen={isOpen} onDismiss={handleDismiss} title="CLI command">
+      <Modal.Section>
+        <pre className="flex w-full rounded border px-4 py-3 !normal-case !tracking-normal text-mono-md bg-default border-secondary">
+          <div className="mr-2 select-none text-quaternary">$</div>
+          {command}
+        </pre>
+      </Modal.Section>
+      <Modal.Footer
+        onDismiss={handleDismiss}
+        onAction={handleCopy}
+        actionText={
+          <>
+            {/* use of invisible keeps button the same size in both states */}
+            <span className={hasCopied ? 'invisible' : ''}>Copy command</span>
+            <span
+              className={`absolute left-1/2 top-1/2 flex -translate-x-1/2 -translate-y-1/2 items-center ${
+                hasCopied ? '' : 'invisible'
+              }`}
+            >
+              <Success12Icon className="mr-2 text-accent" />
+              Copied
+            </span>
+          </>
+        }
+      />
+    </Modal>
   )
 }

--- a/app/components/EquivalentCliCommand.tsx
+++ b/app/components/EquivalentCliCommand.tsx
@@ -13,37 +13,14 @@ import { Button } from '~/ui/lib/Button'
 import { Modal } from '~/ui/lib/Modal'
 import useTimeout from '~/ui/lib/use-timeout'
 
-export default function EquivalentCliCommand({ command }: { command: string }) {
+export function EquivalentCliCommand({ command }: { command: string }) {
   const [isOpen, setIsOpen] = useState(false)
+  const [hasCopied, setHasCopied] = useState(false)
 
   function handleDismiss() {
     setIsOpen(false)
   }
 
-  return (
-    <>
-      <Button variant="ghost" size="sm" className="ml-2" onClick={() => setIsOpen(true)}>
-        Equivalent CLI Command
-      </Button>
-      <EquivalentCliCommandModal
-        isOpen={isOpen}
-        handleDismiss={handleDismiss}
-        command={command}
-      />
-    </>
-  )
-}
-
-export const EquivalentCliCommandModal = ({
-  command,
-  isOpen,
-  handleDismiss,
-}: {
-  command: string
-  isOpen: boolean
-  handleDismiss: () => void
-}) => {
-  const [hasCopied, setHasCopied] = useState(false)
   useTimeout(() => setHasCopied(false), hasCopied ? 2000 : null)
 
   const handleCopy = () => {
@@ -53,31 +30,36 @@ export const EquivalentCliCommandModal = ({
   }
 
   return (
-    <Modal isOpen={isOpen} onDismiss={handleDismiss} title="CLI command">
-      <Modal.Section>
-        <pre className="flex w-full rounded border px-4 py-3 !normal-case !tracking-normal text-mono-md bg-default border-secondary">
-          <div className="mr-2 select-none text-quaternary">$</div>
-          {command}
-        </pre>
-      </Modal.Section>
-      <Modal.Footer
-        onDismiss={handleDismiss}
-        onAction={handleCopy}
-        actionText={
-          <>
-            {/* use of invisible keeps button the same size in both states */}
-            <span className={hasCopied ? 'invisible' : ''}>Copy command</span>
-            <span
-              className={`absolute left-1/2 top-1/2 flex -translate-x-1/2 -translate-y-1/2 items-center ${
-                hasCopied ? '' : 'invisible'
-              }`}
-            >
-              <Success12Icon className="mr-2 text-accent" />
-              Copied
-            </span>
-          </>
-        }
-      />
-    </Modal>
+    <>
+      <Button variant="ghost" size="sm" className="ml-2" onClick={() => setIsOpen(true)}>
+        Equivalent CLI Command
+      </Button>
+      <Modal isOpen={isOpen} onDismiss={handleDismiss} title="CLI command">
+        <Modal.Section>
+          <pre className="flex w-full rounded border px-4 py-3 !normal-case !tracking-normal text-mono-md bg-default border-secondary">
+            <div className="mr-2 select-none text-quaternary">$</div>
+            {command}
+          </pre>
+        </Modal.Section>
+        <Modal.Footer
+          onDismiss={handleDismiss}
+          onAction={handleCopy}
+          actionText={
+            <>
+              {/* use of invisible keeps button the same size in both states */}
+              <span className={hasCopied ? 'invisible' : ''}>Copy command</span>
+              <span
+                className={`absolute left-1/2 top-1/2 flex -translate-x-1/2 -translate-y-1/2 items-center ${
+                  hasCopied ? '' : 'invisible'
+                }`}
+              >
+                <Success12Icon className="mr-2 text-accent" />
+                Copied
+              </span>
+            </>
+          }
+        />
+      </Modal>
+    </>
   )
 }

--- a/app/pages/project/instances/instance/SerialConsolePage.tsx
+++ b/app/pages/project/instances/instance/SerialConsolePage.tsx
@@ -95,10 +95,6 @@ export function SerialConsolePage() {
     }
   }, [])
 
-  const command = `oxide instance serial console
-  --project ${project}
-  --instance ${instance}`
-
   return (
     <div className="!mx-0 flex h-full max-h-[calc(100vh-60px)] !w-full flex-col">
       <Link
@@ -118,7 +114,7 @@ export function SerialConsolePage() {
       <div className="flex-shrink-0 justify-between overflow-hidden border-t bg-default border-secondary empty:border-t-0">
         <div className="gutter flex h-20 items-center justify-between">
           <div>
-            <EquivalentCliCommand command={command} />
+            <EquivalentCliCommand command={serialConsoleCliCommand(project, instance)} />
           </div>
 
           <Badge color={statusColor[connectionStatus]}>
@@ -129,6 +125,13 @@ export function SerialConsolePage() {
     </div>
   )
 }
+
+export const serialConsoleCliCommand = (
+  project: string,
+  instance: string
+) => `oxide instance serial console
+--project ${project}
+--instance ${instance}`
 
 function SerialSkeleton() {
   const instanceSelector = useInstanceSelector()

--- a/app/pages/project/instances/instance/SerialConsolePage.tsx
+++ b/app/pages/project/instances/instance/SerialConsolePage.tsx
@@ -11,10 +11,11 @@ import { Link } from 'react-router-dom'
 import { api } from '@oxide/api'
 import { PrevArrow12Icon } from '@oxide/design-system/icons/react'
 
-import EquivalentCliCommand from '~/components/EquivalentCliCommand'
+import { EquivalentCliCommand } from '~/components/EquivalentCliCommand'
 import { useInstanceSelector } from '~/hooks'
 import { Badge, type BadgeColor } from '~/ui/lib/Badge'
 import { Spinner } from '~/ui/lib/Spinner'
+import { cliCmd } from '~/util/cli-cmd'
 import { pb } from '~/util/path-builder'
 
 const Terminal = lazy(() => import('~/components/Terminal'))
@@ -114,7 +115,7 @@ export function SerialConsolePage() {
       <div className="flex-shrink-0 justify-between overflow-hidden border-t bg-default border-secondary empty:border-t-0">
         <div className="gutter flex h-20 items-center justify-between">
           <div>
-            <EquivalentCliCommand command={serialConsoleCliCommand(project, instance)} />
+            <EquivalentCliCommand command={cliCmd.serialConsole({ project, instance })} />
           </div>
 
           <Badge color={statusColor[connectionStatus]}>
@@ -125,13 +126,6 @@ export function SerialConsolePage() {
     </div>
   )
 }
-
-export const serialConsoleCliCommand = (
-  project: string,
-  instance: string
-) => `oxide instance serial console
---project ${project}
---instance ${instance}`
 
 function SerialSkeleton() {
   const instanceSelector = useInstanceSelector()

--- a/app/pages/project/instances/instance/tabs/ConnectTab.tsx
+++ b/app/pages/project/instances/instance/tabs/ConnectTab.tsx
@@ -6,36 +6,33 @@
  * Copyright Oxide Computer Company
  */
 
-import { useState } from 'react'
+import { Link } from 'react-router-dom'
 
-import { EquivalentCliCommandModal } from '~/components/EquivalentCliCommand'
+import { EquivalentCliCommand } from '~/components/EquivalentCliCommand'
 import { useInstanceSelector } from '~/hooks'
+import { buttonStyle } from '~/ui/lib/Button'
 import { SettingsGroup } from '~/ui/lib/SettingsGroup'
+import { cliCmd } from '~/util/cli-cmd'
 import { pb } from '~/util/path-builder'
-
-import { serialConsoleCliCommand } from '../SerialConsolePage'
 
 export function ConnectTab() {
   const { project, instance } = useInstanceSelector()
 
-  const [cliModalOpen, setCliModalOpen] = useState(false)
-
   return (
-    <>
-      <EquivalentCliCommandModal
-        isOpen={cliModalOpen}
-        handleDismiss={() => setCliModalOpen(false)}
-        command={serialConsoleCliCommand(project, instance)}
-      />
-      <SettingsGroup
-        title="Serial Console"
-        cta={pb.serialConsole({ project, instance })}
-        ctaText="Connect"
-        secondaryCta={() => setCliModalOpen(true)}
-        secondaryCtaText="Equivalent CLI Command"
-      >
+    <SettingsGroup.Container>
+      <SettingsGroup.Body>
+        <SettingsGroup.Title>Serial console</SettingsGroup.Title>
         Connect to your instance&rsquo;s serial console
-      </SettingsGroup>
-    </>
+      </SettingsGroup.Body>
+      <SettingsGroup.Footer>
+        <EquivalentCliCommand command={cliCmd.serialConsole({ project, instance })} />
+        <Link
+          to={pb.serialConsole({ project, instance })}
+          className={buttonStyle({ size: 'sm' })}
+        >
+          Connect
+        </Link>
+      </SettingsGroup.Footer>
+    </SettingsGroup.Container>
   )
 }

--- a/app/pages/project/instances/instance/tabs/ConnectTab.tsx
+++ b/app/pages/project/instances/instance/tabs/ConnectTab.tsx
@@ -6,20 +6,36 @@
  * Copyright Oxide Computer Company
  */
 
+import { useState } from 'react'
+
+import { EquivalentCliCommandModal } from '~/components/EquivalentCliCommand'
 import { useInstanceSelector } from '~/hooks'
 import { SettingsGroup } from '~/ui/lib/SettingsGroup'
 import { pb } from '~/util/path-builder'
 
+import { serialConsoleCliCommand } from '../SerialConsolePage'
+
 export function ConnectTab() {
   const { project, instance } = useInstanceSelector()
 
+  const [cliModalOpen, setCliModalOpen] = useState(false)
+
   return (
-    <SettingsGroup
-      title="Serial Console"
-      cta={pb.serialConsole({ project, instance })}
-      ctaText="Connect"
-    >
-      Connect to your instance&rsquo;s serial console
-    </SettingsGroup>
+    <>
+      <EquivalentCliCommandModal
+        isOpen={cliModalOpen}
+        handleDismiss={() => setCliModalOpen(false)}
+        command={serialConsoleCliCommand(project, instance)}
+      />
+      <SettingsGroup
+        title="Serial Console"
+        cta={pb.serialConsole({ project, instance })}
+        ctaText="Connect"
+        secondaryCta={() => setCliModalOpen(true)}
+        secondaryCtaText="Equivalent CLI Command"
+      >
+        Connect to your instance&rsquo;s serial console
+      </SettingsGroup>
+    </>
   )
 }

--- a/app/ui/lib/SettingsGroup.stories.tsx
+++ b/app/ui/lib/SettingsGroup.stories.tsx
@@ -19,7 +19,13 @@ export const Default = () => (
 )
 
 export const WithoutDocs = () => (
-  <SettingsGroup title="Serial Console" cta="/" ctaText="Connect">
+  <SettingsGroup
+    title="Serial Console"
+    cta="/"
+    ctaText="Connect"
+    secondaryCta={() => {}}
+    secondaryCtaText="Secondary"
+  >
     Connect to your instance&rsquo;s serial console
   </SettingsGroup>
 )

--- a/app/ui/lib/SettingsGroup.stories.tsx
+++ b/app/ui/lib/SettingsGroup.stories.tsx
@@ -5,33 +5,40 @@
  *
  * Copyright Oxide Computer Company
  */
+import { Link } from 'react-router-dom'
+
+import { Button, buttonStyle } from './Button'
 import { SettingsGroup } from './SettingsGroup'
 
 export const Default = () => (
-  <SettingsGroup
-    title="Serial Console"
-    docs={{ text: 'Serial Console', link: '/' }}
-    cta="/"
-    ctaText="Connect"
-  >
-    Connect to your instance&rsquo;s serial console
-  </SettingsGroup>
+  <SettingsGroup.Container>
+    <SettingsGroup.Body>
+      <SettingsGroup.Title>Serial console</SettingsGroup.Title>
+      Connect to your instance&rsquo;s serial console
+    </SettingsGroup.Body>
+    <SettingsGroup.Footer
+      docsLink={{ text: 'math', href: 'https://en.wikipedia.org/wiki/Mathematics' }}
+    >
+      <Link to="/" className={buttonStyle({ size: 'sm' })}>
+        Connect
+      </Link>
+    </SettingsGroup.Footer>
+  </SettingsGroup.Container>
 )
 
 export const WithoutDocs = () => (
-  <SettingsGroup
-    title="Serial Console"
-    cta="/"
-    ctaText="Connect"
-    secondaryCta={() => {}}
-    secondaryCtaText="Secondary"
-  >
-    Connect to your instance&rsquo;s serial console
-  </SettingsGroup>
-)
-
-export const FunctionAction = () => (
-  <SettingsGroup title="Serial Console" cta={() => alert('hi')} ctaText="Connect">
-    Connect to your instance&rsquo;s serial console
-  </SettingsGroup>
+  <SettingsGroup.Container>
+    <SettingsGroup.Body>
+      <SettingsGroup.Title>Serial console</SettingsGroup.Title>
+      Connect to your instance&rsquo;s serial console
+    </SettingsGroup.Body>
+    <SettingsGroup.Footer>
+      <Link to="/" className={buttonStyle({ size: 'sm' })}>
+        Connect
+      </Link>
+      <Button size="sm" variant="secondary" onClick={() => {}}>
+        Secondary
+      </Button>
+    </SettingsGroup.Footer>
+  </SettingsGroup.Container>
 )

--- a/app/ui/lib/SettingsGroup.tsx
+++ b/app/ui/lib/SettingsGroup.tsx
@@ -5,82 +5,44 @@
  *
  * Copyright Oxide Computer Company
  */
-import { Link } from 'react-router-dom'
 
 import { OpenLink12Icon } from '@oxide/design-system/icons/react'
 
-import { Button, buttonStyle } from '~/ui/lib/Button'
+import { classed } from '~/util/classed'
 
-type Props = {
-  title: string
-  docs?: {
-    text: string
-    link: string
-  }
+type LearnMoreProps = {
+  href: string
+  /** Link text */
+  text: React.ReactNode
+}
+
+type FooterProps = {
+  /** Link text */
   children: React.ReactNode
-  /** String action is a link */
-  cta: string | (() => void)
-  ctaText: string
-} & (
-  | { secondaryCta: string | (() => void); secondaryCtaText: string }
-  | { secondaryCta?: undefined; secondaryCtaText?: undefined }
-)
+  docsLink?: { text: string; href: string }
+}
 
-export const SettingsGroup = ({
-  title,
-  docs,
-  children,
-  cta,
-  ctaText,
-  secondaryCta,
-  secondaryCtaText,
-}: Props) => {
-  return (
-    <div className="w-full max-w-[660px] rounded-lg border text-sans-md text-secondary border-default">
-      <div className="p-6">
-        <div className="mb-1 text-sans-lg text-default">{title}</div>
-        {children}
-      </div>
-      <div className="flex items-center justify-between border-t px-6 py-3 border-default">
-        {/* div always present to keep the button right-aligned */}
-        <div className="text-tertiary">
-          {docs && (
-            <>
-              Learn more about{' '}
-              <a href={docs.link} className="text-accent-secondary hover:text-accent">
-                {docs.text}
-                <OpenLink12Icon className="ml-1 align-middle" />
-              </a>
-            </>
-          )}
-        </div>
-
-        <div className="flex gap-3">
-          {secondaryCta &&
-            (typeof secondaryCta === 'string' ? (
-              <Link
-                to={secondaryCta}
-                className={buttonStyle({ size: 'sm', variant: 'secondary' })}
-              >
-                {secondaryCtaText}
-              </Link>
-            ) : (
-              <Button size="sm" variant="secondary" onClick={secondaryCta}>
-                {secondaryCtaText}
-              </Button>
-            ))}
-
-          {typeof cta === 'string' ? (
-            <Link to={cta} className={buttonStyle({ size: 'sm' })}>
-              {ctaText}
-            </Link>
-          ) : (
-            <Button size="sm" onClick={cta}>
-              {ctaText}
-            </Button>
-          )}
-        </div>
-      </div>
+/** Use size=sm on buttons and links! */
+export const SettingsGroup = {
+  Container: classed.div`w-full max-w-[660px] rounded-lg border text-sans-md text-secondary border-default`,
+  LearnMore: ({ href, text }: LearnMoreProps) => (
+    <div>
+      Learn more about{' '}
+      <a href={href} className="text-accent-secondary hover:text-accent">
+        {text}
+        <OpenLink12Icon className="ml-1 align-middle" />
+      </a>
     </div>
-  )
+  ),
+  Body: classed.div`p-6`,
+  Title: classed.div`mb-1 text-sans-lg text-default`,
+  Footer: ({ children, docsLink }: FooterProps) => (
+    <div className="flex items-center justify-between border-t px-6 py-3 border-default">
+      {/* div always present to keep the buttons right-aligned */}
+      <div className="text-tertiary">
+        {docsLink && <SettingsGroup.LearnMore {...docsLink} />}
+      </div>
+      <div className="flex gap-3">{children}</div>
+    </div>
+  ),
 }

--- a/app/ui/lib/SettingsGroup.tsx
+++ b/app/ui/lib/SettingsGroup.tsx
@@ -10,11 +10,15 @@ import { OpenLink12Icon } from '@oxide/design-system/icons/react'
 
 import { classed } from '~/util/classed'
 
-type LearnMoreProps = {
-  href: string
-  /** Link text */
-  text: React.ReactNode
-}
+const LearnMore = ({ href, text }: { href: string; text: React.ReactNode }) => (
+  <>
+    Learn more about{' '}
+    <a href={href} className="text-accent-secondary hover:text-accent">
+      {text}
+      <OpenLink12Icon className="ml-1 align-middle" />
+    </a>
+  </>
+)
 
 type FooterProps = {
   /** Link text */
@@ -25,23 +29,12 @@ type FooterProps = {
 /** Use size=sm on buttons and links! */
 export const SettingsGroup = {
   Container: classed.div`w-full max-w-[660px] rounded-lg border text-sans-md text-secondary border-default`,
-  LearnMore: ({ href, text }: LearnMoreProps) => (
-    <div>
-      Learn more about{' '}
-      <a href={href} className="text-accent-secondary hover:text-accent">
-        {text}
-        <OpenLink12Icon className="ml-1 align-middle" />
-      </a>
-    </div>
-  ),
   Body: classed.div`p-6`,
   Title: classed.div`mb-1 text-sans-lg text-default`,
   Footer: ({ children, docsLink }: FooterProps) => (
     <div className="flex items-center justify-between border-t px-6 py-3 border-default">
       {/* div always present to keep the buttons right-aligned */}
-      <div className="text-tertiary">
-        {docsLink && <SettingsGroup.LearnMore {...docsLink} />}
-      </div>
+      <div className="text-tertiary">{docsLink && <LearnMore {...docsLink} />}</div>
       <div className="flex gap-3">{children}</div>
     </div>
   ),

--- a/app/ui/lib/SettingsGroup.tsx
+++ b/app/ui/lib/SettingsGroup.tsx
@@ -21,9 +21,20 @@ type Props = {
   /** String action is a link */
   cta: string | (() => void)
   ctaText: string
-}
+} & (
+  | { secondaryCta: string | (() => void); secondaryCtaText: string }
+  | { secondaryCta?: undefined; secondaryCtaText?: undefined }
+)
 
-export const SettingsGroup = ({ title, docs, children, cta, ctaText }: Props) => {
+export const SettingsGroup = ({
+  title,
+  docs,
+  children,
+  cta,
+  ctaText,
+  secondaryCta,
+  secondaryCtaText,
+}: Props) => {
   return (
     <div className="w-full max-w-[660px] rounded-lg border text-sans-md text-secondary border-default">
       <div className="p-6">
@@ -44,15 +55,31 @@ export const SettingsGroup = ({ title, docs, children, cta, ctaText }: Props) =>
           )}
         </div>
 
-        {typeof cta === 'string' ? (
-          <Link to={cta} className={buttonStyle({ size: 'sm' })}>
-            {ctaText}
-          </Link>
-        ) : (
-          <Button size="sm" onClick={cta}>
-            {ctaText}
-          </Button>
-        )}
+        <div className="flex gap-3">
+          {secondaryCta &&
+            (typeof secondaryCta === 'string' ? (
+              <Link
+                to={secondaryCta}
+                className={buttonStyle({ size: 'sm', variant: 'secondary' })}
+              >
+                {secondaryCtaText}
+              </Link>
+            ) : (
+              <Button size="sm" variant="secondary" onClick={secondaryCta}>
+                {secondaryCtaText}
+              </Button>
+            ))}
+
+          {typeof cta === 'string' ? (
+            <Link to={cta} className={buttonStyle({ size: 'sm' })}>
+              {ctaText}
+            </Link>
+          ) : (
+            <Button size="sm" onClick={cta}>
+              {ctaText}
+            </Button>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/app/util/cli-cmd.ts
+++ b/app/util/cli-cmd.ts
@@ -1,0 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
+ */
+
+export const cliCmd = {
+  serialConsole: ({ project, instance }: { project: string; instance: string }) =>
+    `oxide instance serial console\n--project ${project}\n--instance ${instance}`,
+}


### PR DESCRIPTION
Fixes #1991 

I initially tried changing `cta` to take a react component, that way I could just pass the `<EquivalentCliCommand />` component together with the "Connect" button. But I think the issue with that approach is it's very easy to pass the wrong button style or size.

Instead I broke the modal into its own compound that way I could pass a `secondaryCta` prop and just call it directly from that.

![CleanShot 2024-03-07 at 12 38 55](https://github.com/oxidecomputer/console/assets/4020798/0b9419a8-32ff-4c14-91a4-da3490620f51)