### PR TITLE
Make SideModal submit button copy consistent

### DIFF
--- a/app/components/form/SideModalForm.tsx
+++ b/app/components/form/SideModalForm.tsx
@@ -23,9 +23,11 @@ type ResourceName =
   | 'IP range'
   | 'network interface'
   | 'project'
+  | 'project image'
   | 'role'
   | 'rule'
   | 'silo'
+  | 'silo image'
   | 'snapshot'
   | 'SSH key'
   | 'subnet'
@@ -34,11 +36,13 @@ type ResourceName =
 type CreateFormProps = {
   formType: 'create'
   submitLabel?: string
+  title?: string
 }
 
 type EditFormProps = {
   formType: 'edit'
   submitLabel?: never
+  title?: never
 }
 
 type SideModalFormProps<TFieldValues extends FieldValues> = {
@@ -59,7 +63,6 @@ type SideModalFormProps<TFieldValues extends FieldValues> = {
   /** Error from the API call */
   submitError: ApiError | null
   loading?: boolean
-  title: string
   subtitle?: ReactNode
   onSubmit?: (values: TFieldValues) => void
 } & (CreateFormProps | EditFormProps)
@@ -98,7 +101,7 @@ export function SideModalForm<TFieldValues extends FieldValues>({
     }
   }, [submitError, form])
   const defaultTitle = formType === 'edit' ? `Edit ${resourceName}` : title
-  const defaultLabel = formType === 'edit' ? `Update ${resourceName}` : submitLabel || title
+  const label = formType === 'edit' ? `Update ${resourceName}` : submitLabel || title
 
   return (
     <SideModal
@@ -141,7 +144,7 @@ export function SideModalForm<TFieldValues extends FieldValues>({
             loading={loading || isSubmitting}
             form={id}
           >
-            {submitLabel || defaultLabel}
+            {label}
           </Button>
         )}
       </SideModal.Footer>

--- a/app/components/form/SideModalForm.tsx
+++ b/app/components/form/SideModalForm.tsx
@@ -14,6 +14,23 @@ import type { ApiError } from '@oxide/api'
 import { Button } from '~/ui/lib/Button'
 import { SideModal } from '~/ui/lib/SideModal'
 
+type ResourceName =
+  | 'disk'
+  | 'floating IP'
+  | 'identity provider'
+  | 'image'
+  | 'IP pool'
+  | 'IP range'
+  | 'network interface'
+  | 'project'
+  | 'role'
+  | 'rule'
+  | 'silo'
+  | 'snapshot'
+  | 'SSH key'
+  | 'subnet'
+  | 'VPC'
+
 type SideModalFormProps<TFieldValues extends FieldValues> = {
   form: UseFormReturn<TFieldValues>
   formType: 'create' | 'edit'
@@ -27,6 +44,7 @@ type SideModalFormProps<TFieldValues extends FieldValues> = {
    */
   children: ReactNode
   onDismiss: () => void
+  resourceName: ResourceName
   /** Must be provided with a reason describing why it's disabled */
   submitDisabled?: string
   /** Error from the API call */
@@ -53,6 +71,7 @@ export function SideModalForm<TFieldValues extends FieldValues>({
   formType,
   children,
   onDismiss,
+  resourceName,
   submitDisabled,
   submitError,
   title,
@@ -70,13 +89,14 @@ export function SideModalForm<TFieldValues extends FieldValues>({
       form.setError('name', { message: 'Name already exists' })
     }
   }, [submitError, form])
-  const defaultLabel = formType === 'edit' ? 'Save changes' : title
+  const defaultTitle = formType === 'edit' ? `Edit ${resourceName}` : title
+  const defaultLabel = formType === 'edit' ? `Update ${resourceName}` : submitLabel || title
 
   return (
     <SideModal
       onDismiss={onDismiss}
       isOpen
-      title={title}
+      title={defaultTitle}
       animate={useShouldAnimateModal()}
       subtitle={subtitle}
       errors={submitError ? [submitError.message] : []}

--- a/app/components/form/SideModalForm.tsx
+++ b/app/components/form/SideModalForm.tsx
@@ -108,7 +108,7 @@ export function SideModalForm<TFieldValues extends FieldValues>({
           <Button
             type="submit"
             size="sm"
-            disabled={!form.formState.isDirty || !!submitDisabled}
+            disabled={!!submitDisabled}
             disabledReason={submitDisabled}
             loading={loading || isSubmitting}
             form={id}

--- a/app/components/form/SideModalForm.tsx
+++ b/app/components/form/SideModalForm.tsx
@@ -80,15 +80,12 @@ export function SideModalForm<TFieldValues extends FieldValues>({
       form.setError('name', { message: 'Name already exists' })
     }
   }, [submitError, form])
-  const defaultTitle = title || `${formType === 'edit' ? 'Edit' : 'Create'} ${resourceName}`
-  const label =
-    submitLabel || title || `${formType === 'edit' ? 'Update' : 'Create'} ${resourceName}`
 
   return (
     <SideModal
       onDismiss={onDismiss}
       isOpen
-      title={defaultTitle}
+      title={title || `${formType === 'edit' ? 'Edit' : 'Create'} ${resourceName}`}
       animate={useShouldAnimateModal()}
       subtitle={subtitle}
       errors={submitError ? [submitError.message] : []}
@@ -125,7 +122,9 @@ export function SideModalForm<TFieldValues extends FieldValues>({
             loading={loading || isSubmitting}
             form={id}
           >
-            {label}
+            {submitLabel ||
+              title ||
+              `${formType === 'edit' ? 'Update' : 'Create'} ${resourceName}`}
           </Button>
         )}
       </SideModal.Footer>

--- a/app/components/form/SideModalForm.tsx
+++ b/app/components/form/SideModalForm.tsx
@@ -14,35 +14,14 @@ import type { ApiError } from '@oxide/api'
 import { Button } from '~/ui/lib/Button'
 import { SideModal } from '~/ui/lib/SideModal'
 
-type ResourceName =
-  | 'disk'
-  | 'floating IP'
-  | 'identity provider'
-  | 'image'
-  | 'IP pool'
-  | 'IP range'
-  | 'network interface'
-  | 'project'
-  | 'project image'
-  | 'role'
-  | 'rule'
-  | 'silo'
-  | 'silo image'
-  | 'snapshot'
-  | 'SSH key'
-  | 'subnet'
-  | 'VPC'
-
 type CreateFormProps = {
   formType: 'create'
   submitLabel?: string
-  title?: string
 }
 
 type EditFormProps = {
   formType: 'edit'
   submitLabel?: never
-  title?: never
 }
 
 type SideModalFormProps<TFieldValues extends FieldValues> = {
@@ -57,12 +36,13 @@ type SideModalFormProps<TFieldValues extends FieldValues> = {
    */
   children: ReactNode
   onDismiss: () => void
-  resourceName: ResourceName
+  resourceName: string
   /** Must be provided with a reason describing why it's disabled */
   submitDisabled?: string
   /** Error from the API call */
   submitError: ApiError | null
   loading?: boolean
+  title?: string
   subtitle?: ReactNode
   onSubmit?: (values: TFieldValues) => void
 } & (CreateFormProps | EditFormProps)
@@ -100,8 +80,9 @@ export function SideModalForm<TFieldValues extends FieldValues>({
       form.setError('name', { message: 'Name already exists' })
     }
   }, [submitError, form])
-  const defaultTitle = formType === 'edit' ? `Edit ${resourceName}` : title
-  const label = formType === 'edit' ? `Update ${resourceName}` : submitLabel || title
+  const defaultTitle = title || `${formType === 'edit' ? 'Edit' : 'Create'} ${resourceName}`
+  const label =
+    submitLabel || title || `${formType === 'edit' ? 'Update' : 'Create'} ${resourceName}`
 
   return (
     <SideModal

--- a/app/components/form/SideModalForm.tsx
+++ b/app/components/form/SideModalForm.tsx
@@ -84,6 +84,11 @@ export function SideModalForm<TFieldValues extends FieldValues>({
     }
   }, [submitError, form])
 
+  const label =
+    formType === 'edit'
+      ? `Update ${resourceName}`
+      : submitLabel || title || `Create ${resourceName}`
+
   return (
     <SideModal
       onDismiss={onDismiss}
@@ -125,9 +130,7 @@ export function SideModalForm<TFieldValues extends FieldValues>({
             loading={loading || isSubmitting}
             form={id}
           >
-            {submitLabel ||
-              title ||
-              `${formType === 'edit' ? 'Update' : 'Create'} ${resourceName}`}
+            {label}
           </Button>
         )}
       </SideModal.Footer>

--- a/app/components/form/SideModalForm.tsx
+++ b/app/components/form/SideModalForm.tsx
@@ -16,11 +16,13 @@ import { SideModal } from '~/ui/lib/SideModal'
 
 type CreateFormProps = {
   formType: 'create'
+  /** Only needed if you need to override the default button text (`Create ${resourceName}`) */
   submitLabel?: string
 }
 
 type EditFormProps = {
   formType: 'edit'
+  /** Not permitted, as all edit form buttons should read `Update ${resourceName}` */
   submitLabel?: never
 }
 
@@ -42,6 +44,7 @@ type SideModalFormProps<TFieldValues extends FieldValues> = {
   /** Error from the API call */
   submitError: ApiError | null
   loading?: boolean
+  /** Only needed if you need to override the default title (Create/Edit ${resourceName}) */
   title?: string
   subtitle?: ReactNode
   onSubmit?: (values: TFieldValues) => void

--- a/app/components/form/SideModalForm.tsx
+++ b/app/components/form/SideModalForm.tsx
@@ -5,7 +5,7 @@
  *
  * Copyright Oxide Computer Company
  */
-import { useEffect, type ReactNode } from 'react'
+import { useEffect, useId, type ReactNode } from 'react'
 import type { FieldValues, UseFormReturn } from 'react-hook-form'
 import { useNavigationType } from 'react-router-dom'
 
@@ -15,8 +15,8 @@ import { Button } from '~/ui/lib/Button'
 import { SideModal } from '~/ui/lib/SideModal'
 
 type SideModalFormProps<TFieldValues extends FieldValues> = {
-  id: string
   form: UseFormReturn<TFieldValues>
+  formType: 'create' | 'edit'
   /**
    * A function that returns the fields.
    *
@@ -49,8 +49,8 @@ export function useShouldAnimateModal() {
 }
 
 export function SideModalForm<TFieldValues extends FieldValues>({
-  id,
   form,
+  formType,
   children,
   onDismiss,
   submitDisabled,
@@ -61,6 +61,7 @@ export function SideModalForm<TFieldValues extends FieldValues>({
   loading,
   subtitle,
 }: SideModalFormProps<TFieldValues>) {
+  const id = useId()
   const { isSubmitting } = form.formState
 
   useEffect(() => {
@@ -69,6 +70,7 @@ export function SideModalForm<TFieldValues extends FieldValues>({
       form.setError('name', { message: 'Name already exists' })
     }
   }, [submitError, form])
+  const defaultLabel = formType === 'edit' ? 'Save changes' : title
 
   return (
     <SideModal
@@ -106,12 +108,12 @@ export function SideModalForm<TFieldValues extends FieldValues>({
           <Button
             type="submit"
             size="sm"
-            disabled={!!submitDisabled}
+            disabled={!form.formState.isDirty || !!submitDisabled}
             disabledReason={submitDisabled}
             loading={loading || isSubmitting}
             form={id}
           >
-            {submitLabel || title}
+            {submitLabel || defaultLabel}
           </Button>
         )}
       </SideModal.Footer>

--- a/app/components/form/SideModalForm.tsx
+++ b/app/components/form/SideModalForm.tsx
@@ -31,9 +31,18 @@ type ResourceName =
   | 'subnet'
   | 'VPC'
 
+type CreateFormProps = {
+  formType: 'create'
+  submitLabel?: string
+}
+
+type EditFormProps = {
+  formType: 'edit'
+  submitLabel?: never
+}
+
 type SideModalFormProps<TFieldValues extends FieldValues> = {
   form: UseFormReturn<TFieldValues>
-  formType: 'create' | 'edit'
   /**
    * A function that returns the fields.
    *
@@ -53,8 +62,7 @@ type SideModalFormProps<TFieldValues extends FieldValues> = {
   title: string
   subtitle?: ReactNode
   onSubmit?: (values: TFieldValues) => void
-  submitLabel?: string
-}
+} & (CreateFormProps | EditFormProps)
 
 /**
  * Only animate the modal in when we're navigating by a client-side click.

--- a/app/forms/access-util.tsx
+++ b/app/forms/access-util.tsx
@@ -50,6 +50,7 @@ export type AddRoleModalProps = {
 }
 
 export type EditRoleModalProps = AddRoleModalProps & {
+  name?: string
   identityId: string
   identityType: IdentityType
   defaultValues: { roleName: RoleKey }

--- a/app/forms/disk-attach.tsx
+++ b/app/forms/disk-attach.tsx
@@ -46,10 +46,10 @@ export function AttachDiskSideModalForm({
 
   return (
     <SideModalForm
-      title="Attach Disk"
-      resourceName="disk"
       form={form}
       formType="create"
+      resourceName="disk"
+      title="Attach Disk"
       onSubmit={onSubmit}
       loading={loading}
       submitError={submitError}

--- a/app/forms/disk-attach.tsx
+++ b/app/forms/disk-attach.tsx
@@ -46,9 +46,9 @@ export function AttachDiskSideModalForm({
 
   return (
     <SideModalForm
-      id="form-disk-attach"
       title="Attach Disk"
       form={form}
+      formType="create"
       onSubmit={onSubmit}
       loading={loading}
       submitError={submitError}

--- a/app/forms/disk-attach.tsx
+++ b/app/forms/disk-attach.tsx
@@ -47,6 +47,7 @@ export function AttachDiskSideModalForm({
   return (
     <SideModalForm
       title="Attach Disk"
+      resourceName="disk"
       form={form}
       formType="create"
       onSubmit={onSubmit}

--- a/app/forms/disk-create.tsx
+++ b/app/forms/disk-create.tsx
@@ -100,7 +100,6 @@ export function CreateDiskSideModalForm({
 
   return (
     <SideModalForm
-      title="Create Disk"
       resourceName="disk"
       form={form}
       formType="create"

--- a/app/forms/disk-create.tsx
+++ b/app/forms/disk-create.tsx
@@ -100,9 +100,9 @@ export function CreateDiskSideModalForm({
 
   return (
     <SideModalForm
-      id="create-disk-form"
       title="Create Disk"
       form={form}
+      formType="create"
       onDismiss={() => onDismiss(navigate)}
       onSubmit={({ size, ...rest }) => {
         const body = { size: size * GiB, ...rest }

--- a/app/forms/disk-create.tsx
+++ b/app/forms/disk-create.tsx
@@ -101,6 +101,7 @@ export function CreateDiskSideModalForm({
   return (
     <SideModalForm
       title="Create Disk"
+      resourceName="disk"
       form={form}
       formType="create"
       onDismiss={() => onDismiss(navigate)}

--- a/app/forms/disk-create.tsx
+++ b/app/forms/disk-create.tsx
@@ -100,9 +100,9 @@ export function CreateDiskSideModalForm({
 
   return (
     <SideModalForm
-      resourceName="disk"
       form={form}
       formType="create"
+      resourceName="disk"
       onDismiss={() => onDismiss(navigate)}
       onSubmit={({ size, ...rest }) => {
         const body = { size: size * GiB, ...rest }

--- a/app/forms/firewall-rules-create.tsx
+++ b/app/forms/firewall-rules-create.tsx
@@ -505,6 +505,7 @@ export function CreateFirewallRuleForm({
   return (
     <SideModalForm
       title="Add firewall rule"
+      resourceName="rule"
       form={form}
       formType="create"
       onDismiss={onDismiss}

--- a/app/forms/firewall-rules-create.tsx
+++ b/app/forms/firewall-rules-create.tsx
@@ -504,9 +504,9 @@ export function CreateFirewallRuleForm({
 
   return (
     <SideModalForm
-      id="create-firewall-rule-form"
       title="Add firewall rule"
       form={form}
+      formType="create"
       onDismiss={onDismiss}
       onSubmit={(values) => {
         // TODO: this silently overwrites existing rules with the current name.

--- a/app/forms/firewall-rules-create.tsx
+++ b/app/forms/firewall-rules-create.tsx
@@ -504,10 +504,10 @@ export function CreateFirewallRuleForm({
 
   return (
     <SideModalForm
-      title="Add firewall rule"
-      resourceName="rule"
       form={form}
       formType="create"
+      resourceName="rule"
+      title="Add firewall rule"
       onDismiss={onDismiss}
       onSubmit={(values) => {
         // TODO: this silently overwrites existing rules with the current name.

--- a/app/forms/firewall-rules-edit.tsx
+++ b/app/forms/firewall-rules-edit.tsx
@@ -66,6 +66,7 @@ export function EditFirewallRuleForm({
   return (
     <SideModalForm
       title="Edit rule"
+      resourceName="rule"
       form={form}
       formType="edit"
       onDismiss={onDismiss}

--- a/app/forms/firewall-rules-edit.tsx
+++ b/app/forms/firewall-rules-edit.tsx
@@ -65,9 +65,9 @@ export function EditFirewallRuleForm({
 
   return (
     <SideModalForm
-      id="create-firewall-rule-form"
       title="Edit rule"
       form={form}
+      formType="edit"
       onDismiss={onDismiss}
       onSubmit={(values) => {
         // note different filter logic from create: filter out the rule with the
@@ -86,7 +86,6 @@ export function EditFirewallRuleForm({
       // validateOnBlur
       loading={updateRules.isPending}
       submitError={updateRules.error}
-      submitLabel="Update rule"
     >
       <CommonFields error={updateRules.error} control={form.control} />
     </SideModalForm>

--- a/app/forms/firewall-rules-edit.tsx
+++ b/app/forms/firewall-rules-edit.tsx
@@ -65,7 +65,6 @@ export function EditFirewallRuleForm({
 
   return (
     <SideModalForm
-      title="Edit rule"
       resourceName="rule"
       form={form}
       formType="edit"

--- a/app/forms/firewall-rules-edit.tsx
+++ b/app/forms/firewall-rules-edit.tsx
@@ -65,9 +65,9 @@ export function EditFirewallRuleForm({
 
   return (
     <SideModalForm
-      resourceName="rule"
       form={form}
       formType="edit"
+      resourceName="rule"
       onDismiss={onDismiss}
       onSubmit={(values) => {
         // note different filter logic from create: filter out the rule with the

--- a/app/forms/floating-ip-create.tsx
+++ b/app/forms/floating-ip-create.tsx
@@ -84,6 +84,7 @@ export function CreateFloatingIpSideModalForm() {
   return (
     <SideModalForm
       title="Create Floating IP"
+      resourceName="floating IP"
       form={form}
       formType="create"
       onDismiss={() => navigate(pb.floatingIps(projectSelector))}

--- a/app/forms/floating-ip-create.tsx
+++ b/app/forms/floating-ip-create.tsx
@@ -83,9 +83,9 @@ export function CreateFloatingIpSideModalForm() {
 
   return (
     <SideModalForm
-      id="create-floating-ip-form"
       title="Create Floating IP"
       form={form}
+      formType="create"
       onDismiss={() => navigate(pb.floatingIps(projectSelector))}
       onSubmit={({ ip, ...rest }) => {
         createFloatingIp.mutate({

--- a/app/forms/floating-ip-create.tsx
+++ b/app/forms/floating-ip-create.tsx
@@ -83,9 +83,9 @@ export function CreateFloatingIpSideModalForm() {
 
   return (
     <SideModalForm
-      resourceName="floating IP"
       form={form}
       formType="create"
+      resourceName="floating IP"
       onDismiss={() => navigate(pb.floatingIps(projectSelector))}
       onSubmit={({ ip, ...rest }) => {
         createFloatingIp.mutate({

--- a/app/forms/floating-ip-create.tsx
+++ b/app/forms/floating-ip-create.tsx
@@ -83,7 +83,6 @@ export function CreateFloatingIpSideModalForm() {
 
   return (
     <SideModalForm
-      title="Create Floating IP"
       resourceName="floating IP"
       form={form}
       formType="create"

--- a/app/forms/floating-ip-edit.tsx
+++ b/app/forms/floating-ip-edit.tsx
@@ -55,8 +55,8 @@ export function EditFloatingIpSideModalForm() {
 
   return (
     <SideModalForm
-      id="edit-floating-ip-form"
       form={form}
+      formType="edit"
       title="Edit floating IP"
       onDismiss={onDismiss}
       onSubmit={({ name, description }) => {
@@ -68,7 +68,6 @@ export function EditFloatingIpSideModalForm() {
       }}
       loading={editFloatingIp.isPending}
       submitError={editFloatingIp.error}
-      submitLabel="Save changes"
     >
       <NameField name="name" control={form.control} />
       <DescriptionField name="description" control={form.control} />

--- a/app/forms/floating-ip-edit.tsx
+++ b/app/forms/floating-ip-edit.tsx
@@ -58,7 +58,6 @@ export function EditFloatingIpSideModalForm() {
       form={form}
       resourceName="floating IP"
       formType="edit"
-      title="Edit floating IP"
       onDismiss={onDismiss}
       onSubmit={({ name, description }) => {
         editFloatingIp.mutate({

--- a/app/forms/floating-ip-edit.tsx
+++ b/app/forms/floating-ip-edit.tsx
@@ -56,6 +56,7 @@ export function EditFloatingIpSideModalForm() {
   return (
     <SideModalForm
       form={form}
+      resourceName="floating IP"
       formType="edit"
       title="Edit floating IP"
       onDismiss={onDismiss}

--- a/app/forms/floating-ip-edit.tsx
+++ b/app/forms/floating-ip-edit.tsx
@@ -56,8 +56,8 @@ export function EditFloatingIpSideModalForm() {
   return (
     <SideModalForm
       form={form}
-      resourceName="floating IP"
       formType="edit"
+      resourceName="floating IP"
       onDismiss={onDismiss}
       onSubmit={({ name, description }) => {
         editFloatingIp.mutate({

--- a/app/forms/idp/create.tsx
+++ b/app/forms/idp/create.tsx
@@ -64,7 +64,6 @@ export function CreateIdpSideModalForm() {
       form={form}
       resourceName="identity provider"
       formType="create"
-      title="Create identity provider"
       onDismiss={onDismiss}
       onSubmit={async ({
         signingKeypair,

--- a/app/forms/idp/create.tsx
+++ b/app/forms/idp/create.tsx
@@ -62,6 +62,7 @@ export function CreateIdpSideModalForm() {
   return (
     <SideModalForm
       form={form}
+      resourceName="identity provider"
       formType="create"
       title="Create identity provider"
       onDismiss={onDismiss}

--- a/app/forms/idp/create.tsx
+++ b/app/forms/idp/create.tsx
@@ -61,8 +61,8 @@ export function CreateIdpSideModalForm() {
 
   return (
     <SideModalForm
-      id="create-idp-form"
       form={form}
+      formType="create"
       title="Create identity provider"
       onDismiss={onDismiss}
       onSubmit={async ({

--- a/app/forms/idp/create.tsx
+++ b/app/forms/idp/create.tsx
@@ -62,8 +62,8 @@ export function CreateIdpSideModalForm() {
   return (
     <SideModalForm
       form={form}
-      resourceName="identity provider"
       formType="create"
+      resourceName="identity provider"
       onDismiss={onDismiss}
       onSubmit={async ({
         signingKeypair,

--- a/app/forms/idp/edit.tsx
+++ b/app/forms/idp/edit.tsx
@@ -45,9 +45,9 @@ export function EditIdpSideModalForm() {
   return (
     <SideModalForm
       form={form}
+      formType="edit"
       resourceName="identity provider"
       title="Identity provider"
-      formType="edit"
       onDismiss={onDismiss}
       subtitle={
         <ResourceLabel>

--- a/app/forms/idp/edit.tsx
+++ b/app/forms/idp/edit.tsx
@@ -44,8 +44,8 @@ export function EditIdpSideModalForm() {
 
   return (
     <SideModalForm
-      id="edit-idp-form"
       form={form}
+      formType="edit"
       title="Identity provider"
       onDismiss={onDismiss}
       subtitle={

--- a/app/forms/idp/edit.tsx
+++ b/app/forms/idp/edit.tsx
@@ -46,6 +46,7 @@ export function EditIdpSideModalForm() {
     <SideModalForm
       form={form}
       resourceName="identity provider"
+      title="Identity provider"
       formType="edit"
       onDismiss={onDismiss}
       subtitle={

--- a/app/forms/idp/edit.tsx
+++ b/app/forms/idp/edit.tsx
@@ -45,6 +45,7 @@ export function EditIdpSideModalForm() {
   return (
     <SideModalForm
       form={form}
+      resourceName="identity provider"
       formType="edit"
       title="Identity provider"
       onDismiss={onDismiss}

--- a/app/forms/idp/edit.tsx
+++ b/app/forms/idp/edit.tsx
@@ -47,7 +47,6 @@ export function EditIdpSideModalForm() {
       form={form}
       resourceName="identity provider"
       formType="edit"
-      title="Identity provider"
       onDismiss={onDismiss}
       subtitle={
         <ResourceLabel>

--- a/app/forms/image-edit.tsx
+++ b/app/forms/image-edit.tsx
@@ -73,9 +73,8 @@ export function EditImageSideModalForm({
   return (
     <SideModalForm
       form={form}
-      resourceName="image"
+      resourceName={type === 'Project' ? 'project image' : 'silo image'}
       formType="edit"
-      title={`${type} image`}
       onDismiss={() => navigate(dismissLink)}
       subtitle={
         <ResourceLabel>

--- a/app/forms/image-edit.tsx
+++ b/app/forms/image-edit.tsx
@@ -72,8 +72,8 @@ export function EditImageSideModalForm({
 
   return (
     <SideModalForm
-      id="edit-project-image-form"
       form={form}
+      formType="edit"
       title={`${type} image`}
       onDismiss={() => navigate(dismissLink)}
       subtitle={

--- a/app/forms/image-edit.tsx
+++ b/app/forms/image-edit.tsx
@@ -73,8 +73,8 @@ export function EditImageSideModalForm({
   return (
     <SideModalForm
       form={form}
-      resourceName={type === 'Project' ? 'project image' : 'silo image'}
       formType="edit"
+      resourceName={type === 'Project' ? 'project image' : 'silo image'}
       onDismiss={() => navigate(dismissLink)}
       subtitle={
         <ResourceLabel>

--- a/app/forms/image-edit.tsx
+++ b/app/forms/image-edit.tsx
@@ -73,6 +73,7 @@ export function EditImageSideModalForm({
   return (
     <SideModalForm
       form={form}
+      resourceName="image"
       formType="edit"
       title={`${type} image`}
       onDismiss={() => navigate(dismissLink)}

--- a/app/forms/image-from-snapshot.tsx
+++ b/app/forms/image-from-snapshot.tsx
@@ -72,7 +72,7 @@ export function CreateImageFromSnapshotSideModalForm() {
       form={form}
       resourceName="image"
       formType="create"
-      title={`Create image from snapshot`}
+      title="Create image from snapshot"
       submitLabel="Create image"
       onDismiss={onDismiss}
       onSubmit={(body) =>

--- a/app/forms/image-from-snapshot.tsx
+++ b/app/forms/image-from-snapshot.tsx
@@ -70,6 +70,7 @@ export function CreateImageFromSnapshotSideModalForm() {
   return (
     <SideModalForm
       form={form}
+      resourceName="image"
       formType="create"
       title={`Create image from snapshot`}
       submitLabel="Create image"

--- a/app/forms/image-from-snapshot.tsx
+++ b/app/forms/image-from-snapshot.tsx
@@ -69,8 +69,8 @@ export function CreateImageFromSnapshotSideModalForm() {
 
   return (
     <SideModalForm
-      id="create-image-from-snapshot-form"
       form={form}
+      formType="create"
       title={`Create image from snapshot`}
       submitLabel="Create image"
       onDismiss={onDismiss}

--- a/app/forms/image-from-snapshot.tsx
+++ b/app/forms/image-from-snapshot.tsx
@@ -70,8 +70,8 @@ export function CreateImageFromSnapshotSideModalForm() {
   return (
     <SideModalForm
       form={form}
-      resourceName="image"
       formType="create"
+      resourceName="image"
       title="Create image from snapshot"
       submitLabel="Create image"
       onDismiss={onDismiss}

--- a/app/forms/image-upload.tsx
+++ b/app/forms/image-upload.tsx
@@ -472,8 +472,8 @@ export function CreateImageSideModalForm() {
   return (
     <SideModalForm
       form={form}
-      resourceName="image"
       formType="create"
+      resourceName="image"
       title="Upload image"
       onDismiss={backToImages}
       onSubmit={async (values) => {

--- a/app/forms/image-upload.tsx
+++ b/app/forms/image-upload.tsx
@@ -472,6 +472,7 @@ export function CreateImageSideModalForm() {
   return (
     <SideModalForm
       form={form}
+      resourceName="image"
       formType="create"
       title="Upload image"
       onDismiss={backToImages}

--- a/app/forms/image-upload.tsx
+++ b/app/forms/image-upload.tsx
@@ -471,8 +471,8 @@ export function CreateImageSideModalForm() {
 
   return (
     <SideModalForm
-      id="upload-image-form"
       form={form}
+      formType="create"
       title="Upload image"
       onDismiss={backToImages}
       onSubmit={async (values) => {

--- a/app/forms/ip-pool-create.tsx
+++ b/app/forms/ip-pool-create.tsx
@@ -40,6 +40,7 @@ export function CreateIpPoolSideModalForm() {
   return (
     <SideModalForm
       form={form}
+      resourceName="IP pool"
       formType="create"
       title="Create IP pool"
       onDismiss={onDismiss}

--- a/app/forms/ip-pool-create.tsx
+++ b/app/forms/ip-pool-create.tsx
@@ -42,7 +42,6 @@ export function CreateIpPoolSideModalForm() {
       form={form}
       resourceName="IP pool"
       formType="create"
-      title="Create IP pool"
       onDismiss={onDismiss}
       onSubmit={({ name, description }) => {
         createPool.mutate({ body: { name, description } })

--- a/app/forms/ip-pool-create.tsx
+++ b/app/forms/ip-pool-create.tsx
@@ -39,8 +39,8 @@ export function CreateIpPoolSideModalForm() {
 
   return (
     <SideModalForm
-      id="create-pool-form"
       form={form}
+      formType="create"
       title="Create IP pool"
       onDismiss={onDismiss}
       onSubmit={({ name, description }) => {

--- a/app/forms/ip-pool-create.tsx
+++ b/app/forms/ip-pool-create.tsx
@@ -40,8 +40,8 @@ export function CreateIpPoolSideModalForm() {
   return (
     <SideModalForm
       form={form}
-      resourceName="IP pool"
       formType="create"
+      resourceName="IP pool"
       onDismiss={onDismiss}
       onSubmit={({ name, description }) => {
         createPool.mutate({ body: { name, description } })

--- a/app/forms/ip-pool-edit.tsx
+++ b/app/forms/ip-pool-edit.tsx
@@ -52,7 +52,6 @@ export function EditIpPoolSideModalForm() {
       form={form}
       resourceName="IP pool"
       formType="edit"
-      title="Edit IP pool"
       onDismiss={onDismiss}
       onSubmit={({ name, description }) => {
         editPool.mutate({ path: poolSelector, body: { name, description } })

--- a/app/forms/ip-pool-edit.tsx
+++ b/app/forms/ip-pool-edit.tsx
@@ -50,6 +50,7 @@ export function EditIpPoolSideModalForm() {
   return (
     <SideModalForm
       form={form}
+      resourceName="IP pool"
       formType="edit"
       title="Edit IP pool"
       onDismiss={onDismiss}

--- a/app/forms/ip-pool-edit.tsx
+++ b/app/forms/ip-pool-edit.tsx
@@ -49,8 +49,8 @@ export function EditIpPoolSideModalForm() {
 
   return (
     <SideModalForm
-      id="edit-pool-form"
       form={form}
+      formType="edit"
       title="Edit IP pool"
       onDismiss={onDismiss}
       onSubmit={({ name, description }) => {
@@ -58,7 +58,6 @@ export function EditIpPoolSideModalForm() {
       }}
       loading={editPool.isPending}
       submitError={editPool.error}
-      submitLabel="Save changes"
     >
       <NameField name="name" control={form.control} />
       <DescriptionField name="description" control={form.control} />

--- a/app/forms/ip-pool-edit.tsx
+++ b/app/forms/ip-pool-edit.tsx
@@ -50,8 +50,8 @@ export function EditIpPoolSideModalForm() {
   return (
     <SideModalForm
       form={form}
-      resourceName="IP pool"
       formType="edit"
+      resourceName="IP pool"
       onDismiss={onDismiss}
       onSubmit={({ name, description }) => {
         editPool.mutate({ path: poolSelector, body: { name, description } })

--- a/app/forms/ip-pool-range-add.tsx
+++ b/app/forms/ip-pool-range-add.tsx
@@ -78,8 +78,8 @@ export function IpPoolAddRangeSideModalForm() {
   return (
     <SideModalForm
       form={form}
-      resourceName="IP range"
       formType="create"
+      resourceName="IP range"
       title="Add IP range"
       onDismiss={onDismiss}
       onSubmit={(body) => addRange.mutate({ path: { pool }, body })}

--- a/app/forms/ip-pool-range-add.tsx
+++ b/app/forms/ip-pool-range-add.tsx
@@ -78,6 +78,7 @@ export function IpPoolAddRangeSideModalForm() {
   return (
     <SideModalForm
       form={form}
+      resourceName="IP range"
       formType="create"
       title="Add IP range"
       onDismiss={onDismiss}

--- a/app/forms/ip-pool-range-add.tsx
+++ b/app/forms/ip-pool-range-add.tsx
@@ -77,8 +77,8 @@ export function IpPoolAddRangeSideModalForm() {
 
   return (
     <SideModalForm
-      id="add-ip-range-form"
       form={form}
+      formType="create"
       title="Add IP range"
       onDismiss={onDismiss}
       onSubmit={(body) => addRange.mutate({ path: { pool }, body })}

--- a/app/forms/network-interface-create.tsx
+++ b/app/forms/network-interface-create.tsx
@@ -53,6 +53,7 @@ export default function CreateNetworkInterfaceForm({
   return (
     <SideModalForm
       title="Add network interface"
+      resourceName="network interface"
       form={form}
       formType="create"
       onDismiss={onDismiss}

--- a/app/forms/network-interface-create.tsx
+++ b/app/forms/network-interface-create.tsx
@@ -52,9 +52,9 @@ export default function CreateNetworkInterfaceForm({
 
   return (
     <SideModalForm
-      id="create-network-interface-form"
       title="Add network interface"
       form={form}
+      formType="create"
       onDismiss={onDismiss}
       onSubmit={onSubmit}
       loading={loading}

--- a/app/forms/network-interface-create.tsx
+++ b/app/forms/network-interface-create.tsx
@@ -52,10 +52,10 @@ export default function CreateNetworkInterfaceForm({
 
   return (
     <SideModalForm
-      title="Add network interface"
-      resourceName="network interface"
       form={form}
       formType="create"
+      resourceName="network interface"
+      title="Add network interface"
       onDismiss={onDismiss}
       onSubmit={onSubmit}
       loading={loading}

--- a/app/forms/network-interface-edit.tsx
+++ b/app/forms/network-interface-edit.tsx
@@ -42,7 +42,6 @@ export default function EditNetworkInterfaceForm({
 
   return (
     <SideModalForm
-      title="Edit network interface"
       resourceName="network interface"
       form={form}
       formType="edit"

--- a/app/forms/network-interface-edit.tsx
+++ b/app/forms/network-interface-edit.tsx
@@ -43,6 +43,7 @@ export default function EditNetworkInterfaceForm({
   return (
     <SideModalForm
       title="Edit network interface"
+      resourceName="network interface"
       form={form}
       formType="edit"
       onDismiss={onDismiss}

--- a/app/forms/network-interface-edit.tsx
+++ b/app/forms/network-interface-edit.tsx
@@ -42,9 +42,9 @@ export default function EditNetworkInterfaceForm({
 
   return (
     <SideModalForm
-      id="edit-network-interface-form"
       title="Edit network interface"
       form={form}
+      formType="edit"
       onDismiss={onDismiss}
       onSubmit={(body) => {
         const interfaceName = defaultValues.name
@@ -56,7 +56,6 @@ export default function EditNetworkInterfaceForm({
       }}
       loading={editNetworkInterface.isPending}
       submitError={editNetworkInterface.error}
-      submitLabel="Save changes"
     >
       <NameField name="name" control={form.control} />
       <DescriptionField name="description" control={form.control} />

--- a/app/forms/network-interface-edit.tsx
+++ b/app/forms/network-interface-edit.tsx
@@ -42,9 +42,9 @@ export default function EditNetworkInterfaceForm({
 
   return (
     <SideModalForm
-      resourceName="network interface"
       form={form}
       formType="edit"
+      resourceName="network interface"
       onDismiss={onDismiss}
       onSubmit={(body) => {
         const interfaceName = defaultValues.name

--- a/app/forms/project-access.tsx
+++ b/app/forms/project-access.tsx
@@ -103,7 +103,6 @@ export function ProjectAccessEditUserSideModal({
   return (
     <SideModalForm
       // TODO: show user name in header or SOMEWHERE
-      title="Change user role"
       resourceName="role"
       form={form}
       formType="edit"

--- a/app/forms/project-access.tsx
+++ b/app/forms/project-access.tsx
@@ -42,8 +42,8 @@ export function ProjectAccessAddUserSideModal({ onDismiss, policy }: AddRoleModa
   return (
     <SideModalForm
       title="Add user or group"
-      id="project-access-add-user"
       form={form}
+      formType="create"
       onSubmit={({ identityId, roleName }) => {
         // can't happen because roleName is validated not to be '', but TS
         // wants to be sure
@@ -103,8 +103,8 @@ export function ProjectAccessEditUserSideModal({
     <SideModalForm
       // TODO: show user name in header or SOMEWHERE
       title="Change user role"
-      id="project-access-edit-user"
       form={form}
+      formType="edit"
       onSubmit={({ roleName }) => {
         updatePolicy.mutate({
           path: { project },
@@ -113,7 +113,6 @@ export function ProjectAccessEditUserSideModal({
       }}
       loading={updatePolicy.isPending}
       submitError={updatePolicy.error}
-      submitLabel="Update role"
       onDismiss={onDismiss}
     >
       <ListboxField

--- a/app/forms/project-access.tsx
+++ b/app/forms/project-access.tsx
@@ -103,9 +103,9 @@ export function ProjectAccessEditUserSideModal({
   return (
     <SideModalForm
       // TODO: show user name in header or SOMEWHERE
-      resourceName="role"
       form={form}
       formType="edit"
+      resourceName="role"
       onSubmit={({ roleName }) => {
         updatePolicy.mutate({
           path: { project },

--- a/app/forms/project-access.tsx
+++ b/app/forms/project-access.tsx
@@ -83,6 +83,7 @@ export function ProjectAccessAddUserSideModal({ onDismiss, policy }: AddRoleModa
 
 export function ProjectAccessEditUserSideModal({
   onDismiss,
+  name,
   identityId,
   identityType,
   policy,
@@ -106,6 +107,7 @@ export function ProjectAccessEditUserSideModal({
       form={form}
       formType="edit"
       resourceName="role"
+      title={`Change role for ${name}`}
       onSubmit={({ roleName }) => {
         updatePolicy.mutate({
           path: { project },

--- a/app/forms/project-access.tsx
+++ b/app/forms/project-access.tsx
@@ -42,6 +42,7 @@ export function ProjectAccessAddUserSideModal({ onDismiss, policy }: AddRoleModa
   return (
     <SideModalForm
       title="Add user or group"
+      resourceName="role"
       form={form}
       formType="create"
       onSubmit={({ identityId, roleName }) => {
@@ -103,6 +104,7 @@ export function ProjectAccessEditUserSideModal({
     <SideModalForm
       // TODO: show user name in header or SOMEWHERE
       title="Change user role"
+      resourceName="role"
       form={form}
       formType="edit"
       onSubmit={({ roleName }) => {

--- a/app/forms/project-create.tsx
+++ b/app/forms/project-create.tsx
@@ -45,7 +45,6 @@ export function CreateProjectSideModalForm() {
       form={form}
       resourceName="project"
       formType="create"
-      title="Create project"
       onDismiss={onDismiss}
       onSubmit={({ name, description }) => {
         createProject.mutate({ body: { name, description } })

--- a/app/forms/project-create.tsx
+++ b/app/forms/project-create.tsx
@@ -42,8 +42,8 @@ export function CreateProjectSideModalForm() {
 
   return (
     <SideModalForm
-      id="create-project-form"
       form={form}
+      formType="create"
       title="Create project"
       onDismiss={onDismiss}
       onSubmit={({ name, description }) => {

--- a/app/forms/project-create.tsx
+++ b/app/forms/project-create.tsx
@@ -43,8 +43,8 @@ export function CreateProjectSideModalForm() {
   return (
     <SideModalForm
       form={form}
-      resourceName="project"
       formType="create"
+      resourceName="project"
       onDismiss={onDismiss}
       onSubmit={({ name, description }) => {
         createProject.mutate({ body: { name, description } })

--- a/app/forms/project-create.tsx
+++ b/app/forms/project-create.tsx
@@ -43,6 +43,7 @@ export function CreateProjectSideModalForm() {
   return (
     <SideModalForm
       form={form}
+      resourceName="project"
       formType="create"
       title="Create project"
       onDismiss={onDismiss}

--- a/app/forms/project-edit.tsx
+++ b/app/forms/project-edit.tsx
@@ -55,8 +55,8 @@ export function EditProjectSideModalForm() {
 
   return (
     <SideModalForm
-      id="edit-project-form"
       form={form}
+      formType="edit"
       title="Edit project"
       onDismiss={onDismiss}
       onSubmit={({ name, description }) => {
@@ -64,7 +64,6 @@ export function EditProjectSideModalForm() {
       }}
       loading={editProject.isPending}
       submitError={editProject.error}
-      submitLabel="Save changes"
     >
       <NameField name="name" control={form.control} />
       <DescriptionField name="description" control={form.control} />

--- a/app/forms/project-edit.tsx
+++ b/app/forms/project-edit.tsx
@@ -55,7 +55,6 @@ export function EditProjectSideModalForm() {
 
   return (
     <SideModalForm
-      title="Edit project"
       resourceName="project"
       form={form}
       formType="edit"

--- a/app/forms/project-edit.tsx
+++ b/app/forms/project-edit.tsx
@@ -55,9 +55,10 @@ export function EditProjectSideModalForm() {
 
   return (
     <SideModalForm
+      title="Edit project"
+      resourceName="project"
       form={form}
       formType="edit"
-      title="Edit project"
       onDismiss={onDismiss}
       onSubmit={({ name, description }) => {
         editProject.mutate({ path: projectSelector, body: { name, description } })

--- a/app/forms/project-edit.tsx
+++ b/app/forms/project-edit.tsx
@@ -55,9 +55,9 @@ export function EditProjectSideModalForm() {
 
   return (
     <SideModalForm
-      resourceName="project"
       form={form}
       formType="edit"
+      resourceName="project"
       onDismiss={onDismiss}
       onSubmit={({ name, description }) => {
         editProject.mutate({ path: projectSelector, body: { name, description } })

--- a/app/forms/silo-access.tsx
+++ b/app/forms/silo-access.tsx
@@ -81,6 +81,7 @@ export function SiloAccessAddUserSideModal({ onDismiss, policy }: AddRoleModalPr
 
 export function SiloAccessEditUserSideModal({
   onDismiss,
+  name,
   identityId,
   identityType,
   policy,
@@ -101,6 +102,7 @@ export function SiloAccessEditUserSideModal({
       form={form}
       formType="edit"
       resourceName="role"
+      title={`Change role for ${name}`}
       onSubmit={({ roleName }) => {
         updatePolicy.mutate({
           body: updateRole({ identityId, identityType, roleName }, policy),

--- a/app/forms/silo-access.tsx
+++ b/app/forms/silo-access.tsx
@@ -39,6 +39,7 @@ export function SiloAccessAddUserSideModal({ onDismiss, policy }: AddRoleModalPr
 
   return (
     <SideModalForm
+      resourceName="role"
       onDismiss={onDismiss}
       title="Add user or group"
       form={form}
@@ -98,6 +99,7 @@ export function SiloAccessEditUserSideModal({
     <SideModalForm
       // TODO: show user name in header or SOMEWHERE
       title="Change user role"
+      resourceName="role"
       form={form}
       formType="edit"
       onSubmit={({ roleName }) => {

--- a/app/forms/silo-access.tsx
+++ b/app/forms/silo-access.tsx
@@ -98,7 +98,6 @@ export function SiloAccessEditUserSideModal({
   return (
     <SideModalForm
       // TODO: show user name in header or SOMEWHERE
-      title="Change user role"
       resourceName="role"
       form={form}
       formType="edit"

--- a/app/forms/silo-access.tsx
+++ b/app/forms/silo-access.tsx
@@ -39,11 +39,11 @@ export function SiloAccessAddUserSideModal({ onDismiss, policy }: AddRoleModalPr
 
   return (
     <SideModalForm
-      resourceName="role"
-      onDismiss={onDismiss}
-      title="Add user or group"
       form={form}
       formType="create"
+      resourceName="role"
+      title="Add user or group"
+      onDismiss={onDismiss}
       onSubmit={({ identityId, roleName }) => {
         // can't happen because roleName is validated not to be '', but TS
         // wants to be sure
@@ -98,9 +98,9 @@ export function SiloAccessEditUserSideModal({
   return (
     <SideModalForm
       // TODO: show user name in header or SOMEWHERE
-      resourceName="role"
       form={form}
       formType="edit"
+      resourceName="role"
       onSubmit={({ roleName }) => {
         updatePolicy.mutate({
           body: updateRole({ identityId, identityType, roleName }, policy),

--- a/app/forms/silo-access.tsx
+++ b/app/forms/silo-access.tsx
@@ -41,8 +41,8 @@ export function SiloAccessAddUserSideModal({ onDismiss, policy }: AddRoleModalPr
     <SideModalForm
       onDismiss={onDismiss}
       title="Add user or group"
-      id="silo-access-add-user"
       form={form}
+      formType="create"
       onSubmit={({ identityId, roleName }) => {
         // can't happen because roleName is validated not to be '', but TS
         // wants to be sure
@@ -98,8 +98,8 @@ export function SiloAccessEditUserSideModal({
     <SideModalForm
       // TODO: show user name in header or SOMEWHERE
       title="Change user role"
-      id="silo-access-edit-user"
       form={form}
+      formType="edit"
       onSubmit={({ roleName }) => {
         updatePolicy.mutate({
           body: updateRole({ identityId, identityType, roleName }, policy),
@@ -107,7 +107,6 @@ export function SiloAccessEditUserSideModal({
       }}
       loading={updatePolicy.isPending}
       submitError={updatePolicy.error}
-      submitLabel="Update role"
       onDismiss={onDismiss}
     >
       <ListboxField

--- a/app/forms/silo-create.tsx
+++ b/app/forms/silo-create.tsx
@@ -66,9 +66,9 @@ export function CreateSiloSideModalForm() {
 
   return (
     <SideModalForm
-      id="create-silo-form"
       title="Create silo"
       form={form}
+      formType="create"
       onDismiss={onDismiss}
       onSubmit={({
         adminGroupName,

--- a/app/forms/silo-create.tsx
+++ b/app/forms/silo-create.tsx
@@ -66,7 +66,6 @@ export function CreateSiloSideModalForm() {
 
   return (
     <SideModalForm
-      title="Create silo"
       resourceName="silo"
       form={form}
       formType="create"

--- a/app/forms/silo-create.tsx
+++ b/app/forms/silo-create.tsx
@@ -67,6 +67,7 @@ export function CreateSiloSideModalForm() {
   return (
     <SideModalForm
       title="Create silo"
+      resourceName="silo"
       form={form}
       formType="create"
       onDismiss={onDismiss}

--- a/app/forms/silo-create.tsx
+++ b/app/forms/silo-create.tsx
@@ -66,9 +66,9 @@ export function CreateSiloSideModalForm() {
 
   return (
     <SideModalForm
-      resourceName="silo"
       form={form}
       formType="create"
+      resourceName="silo"
       onDismiss={onDismiss}
       onSubmit={({
         adminGroupName,

--- a/app/forms/snapshot-create.tsx
+++ b/app/forms/snapshot-create.tsx
@@ -62,9 +62,9 @@ export function CreateSnapshotSideModalForm() {
 
   return (
     <SideModalForm
-      id="create-snapshot-form"
       title="Create Snapshot"
       form={form}
+      formType="create"
       onDismiss={onDismiss}
       onSubmit={(values) => {
         createSnapshot.mutate({ query: projectSelector, body: values })

--- a/app/forms/snapshot-create.tsx
+++ b/app/forms/snapshot-create.tsx
@@ -62,9 +62,9 @@ export function CreateSnapshotSideModalForm() {
 
   return (
     <SideModalForm
-      resourceName="snapshot"
       form={form}
       formType="create"
+      resourceName="snapshot"
       onDismiss={onDismiss}
       onSubmit={(values) => {
         createSnapshot.mutate({ query: projectSelector, body: values })

--- a/app/forms/snapshot-create.tsx
+++ b/app/forms/snapshot-create.tsx
@@ -62,7 +62,6 @@ export function CreateSnapshotSideModalForm() {
 
   return (
     <SideModalForm
-      title="Create Snapshot"
       resourceName="snapshot"
       form={form}
       formType="create"

--- a/app/forms/snapshot-create.tsx
+++ b/app/forms/snapshot-create.tsx
@@ -63,6 +63,7 @@ export function CreateSnapshotSideModalForm() {
   return (
     <SideModalForm
       title="Create Snapshot"
+      resourceName="snapshot"
       form={form}
       formType="create"
       onDismiss={onDismiss}

--- a/app/forms/ssh-key-create.tsx
+++ b/app/forms/ssh-key-create.tsx
@@ -44,10 +44,10 @@ export function CreateSSHKeySideModalForm({
 
   return (
     <SideModalForm
-      title="Add SSH key"
-      resourceName="SSH key"
       form={form}
       formType="create"
+      resourceName="SSH key"
+      title="Add SSH key"
       onDismiss={handleDismiss}
       onSubmit={(body) => createSshKey.mutate({ body })}
       loading={createSshKey.isPending}

--- a/app/forms/ssh-key-create.tsx
+++ b/app/forms/ssh-key-create.tsx
@@ -44,9 +44,9 @@ export function CreateSSHKeySideModalForm({
 
   return (
     <SideModalForm
-      id="create-ssh-key-form"
       title="Add SSH key"
       form={form}
+      formType="create"
       onDismiss={handleDismiss}
       onSubmit={(body) => createSshKey.mutate({ body })}
       loading={createSshKey.isPending}

--- a/app/forms/ssh-key-create.tsx
+++ b/app/forms/ssh-key-create.tsx
@@ -45,6 +45,7 @@ export function CreateSSHKeySideModalForm({
   return (
     <SideModalForm
       title="Add SSH key"
+      resourceName="SSH key"
       form={form}
       formType="create"
       onDismiss={handleDismiss}

--- a/app/forms/subnet-create.tsx
+++ b/app/forms/subnet-create.tsx
@@ -39,7 +39,6 @@ export function CreateSubnetForm({ onDismiss }: CreateSubnetFormProps) {
 
   return (
     <SideModalForm
-      title="Create subnet"
       resourceName="subnet"
       form={form}
       formType="create"

--- a/app/forms/subnet-create.tsx
+++ b/app/forms/subnet-create.tsx
@@ -39,9 +39,9 @@ export function CreateSubnetForm({ onDismiss }: CreateSubnetFormProps) {
 
   return (
     <SideModalForm
-      id="create-subnet-form"
       title="Create subnet"
       form={form}
+      formType="create"
       onDismiss={onDismiss}
       onSubmit={(body) => createSubnet.mutate({ query: vpcSelector, body })}
       loading={createSubnet.isPending}

--- a/app/forms/subnet-create.tsx
+++ b/app/forms/subnet-create.tsx
@@ -39,9 +39,9 @@ export function CreateSubnetForm({ onDismiss }: CreateSubnetFormProps) {
 
   return (
     <SideModalForm
-      resourceName="subnet"
       form={form}
       formType="create"
+      resourceName="subnet"
       onDismiss={onDismiss}
       onSubmit={(body) => createSubnet.mutate({ query: vpcSelector, body })}
       loading={createSubnet.isPending}

--- a/app/forms/subnet-create.tsx
+++ b/app/forms/subnet-create.tsx
@@ -40,6 +40,7 @@ export function CreateSubnetForm({ onDismiss }: CreateSubnetFormProps) {
   return (
     <SideModalForm
       title="Create subnet"
+      resourceName="subnet"
       form={form}
       formType="create"
       onDismiss={onDismiss}

--- a/app/forms/subnet-edit.tsx
+++ b/app/forms/subnet-edit.tsx
@@ -35,10 +35,10 @@ export function EditSubnetForm({ onDismiss, editing }: EditSubnetFormProps) {
 
   return (
     <SideModalForm
-      resourceName="subnet"
-      onDismiss={onDismiss}
       form={form}
       formType="edit"
+      resourceName="subnet"
+      onDismiss={onDismiss}
       onSubmit={(body) => {
         updateSubnet.mutate({
           path: { subnet: editing.name },

--- a/app/forms/subnet-edit.tsx
+++ b/app/forms/subnet-edit.tsx
@@ -49,7 +49,6 @@ export function EditSubnetForm({ onDismiss, editing }: EditSubnetFormProps) {
       }}
       loading={updateSubnet.isPending}
       submitError={updateSubnet.error}
-      submitLabel="Update subnet"
     >
       <NameField name="name" control={form.control} />
       <DescriptionField name="description" control={form.control} />

--- a/app/forms/subnet-edit.tsx
+++ b/app/forms/subnet-edit.tsx
@@ -36,6 +36,7 @@ export function EditSubnetForm({ onDismiss, editing }: EditSubnetFormProps) {
   return (
     <SideModalForm
       title="Edit subnet"
+      resourceName="subnet"
       onDismiss={onDismiss}
       form={form}
       formType="edit"

--- a/app/forms/subnet-edit.tsx
+++ b/app/forms/subnet-edit.tsx
@@ -35,10 +35,10 @@ export function EditSubnetForm({ onDismiss, editing }: EditSubnetFormProps) {
 
   return (
     <SideModalForm
-      id="edit-subnet-form"
       title="Edit subnet"
       onDismiss={onDismiss}
       form={form}
+      formType="edit"
       onSubmit={(body) => {
         updateSubnet.mutate({
           path: { subnet: editing.name },

--- a/app/forms/subnet-edit.tsx
+++ b/app/forms/subnet-edit.tsx
@@ -35,7 +35,6 @@ export function EditSubnetForm({ onDismiss, editing }: EditSubnetFormProps) {
 
   return (
     <SideModalForm
-      title="Edit subnet"
       resourceName="subnet"
       onDismiss={onDismiss}
       form={form}

--- a/app/forms/vpc-create.tsx
+++ b/app/forms/vpc-create.tsx
@@ -49,7 +49,6 @@ export function CreateVpcSideModalForm() {
       form={form}
       resourceName="VPC"
       formType="create"
-      title="Create VPC"
       onSubmit={(values) => createVpc.mutate({ query: projectSelector, body: values })}
       onDismiss={() => navigate(pb.vpcs(projectSelector))}
       loading={createVpc.isPending}

--- a/app/forms/vpc-create.tsx
+++ b/app/forms/vpc-create.tsx
@@ -47,6 +47,7 @@ export function CreateVpcSideModalForm() {
   return (
     <SideModalForm
       form={form}
+      resourceName="VPC"
       formType="create"
       title="Create VPC"
       onSubmit={(values) => createVpc.mutate({ query: projectSelector, body: values })}

--- a/app/forms/vpc-create.tsx
+++ b/app/forms/vpc-create.tsx
@@ -47,7 +47,7 @@ export function CreateVpcSideModalForm() {
   return (
     <SideModalForm
       form={form}
-      id="create-vpc-form"
+      formType="create"
       title="Create VPC"
       onSubmit={(values) => createVpc.mutate({ query: projectSelector, body: values })}
       onDismiss={() => navigate(pb.vpcs(projectSelector))}

--- a/app/forms/vpc-create.tsx
+++ b/app/forms/vpc-create.tsx
@@ -47,8 +47,8 @@ export function CreateVpcSideModalForm() {
   return (
     <SideModalForm
       form={form}
-      resourceName="VPC"
       formType="create"
+      resourceName="VPC"
       onSubmit={(values) => createVpc.mutate({ query: projectSelector, body: values })}
       onDismiss={() => navigate(pb.vpcs(projectSelector))}
       loading={createVpc.isPending}

--- a/app/forms/vpc-edit.tsx
+++ b/app/forms/vpc-edit.tsx
@@ -56,9 +56,9 @@ export function EditVpcSideModalForm() {
 
   return (
     <SideModalForm
-      resourceName="VPC"
       form={form}
       formType="edit"
+      resourceName="VPC"
       onDismiss={onDismiss}
       onSubmit={({ name, description, dnsName }) => {
         editVpc.mutate({

--- a/app/forms/vpc-edit.tsx
+++ b/app/forms/vpc-edit.tsx
@@ -56,7 +56,6 @@ export function EditVpcSideModalForm() {
 
   return (
     <SideModalForm
-      title="Edit VPC"
       resourceName="VPC"
       form={form}
       formType="edit"

--- a/app/forms/vpc-edit.tsx
+++ b/app/forms/vpc-edit.tsx
@@ -57,6 +57,7 @@ export function EditVpcSideModalForm() {
   return (
     <SideModalForm
       title="Edit VPC"
+      resourceName="VPC"
       form={form}
       formType="edit"
       onDismiss={onDismiss}

--- a/app/forms/vpc-edit.tsx
+++ b/app/forms/vpc-edit.tsx
@@ -56,9 +56,9 @@ export function EditVpcSideModalForm() {
 
   return (
     <SideModalForm
-      id="edit-vpc-form"
       title="Edit VPC"
       form={form}
+      formType="edit"
       onDismiss={onDismiss}
       onSubmit={({ name, description, dnsName }) => {
         editVpc.mutate({
@@ -68,7 +68,6 @@ export function EditVpcSideModalForm() {
         })
       }}
       loading={editVpc.isPending}
-      submitLabel="Save changes"
       submitError={editVpc.error}
     >
       <NameField name="name" control={form.control} />

--- a/app/pages/SiloAccessPage.tsx
+++ b/app/pages/SiloAccessPage.tsx
@@ -172,6 +172,7 @@ export function SiloAccessPage() {
         <SiloAccessEditUserSideModal
           onDismiss={() => setEditingUserRow(null)}
           policy={siloPolicy}
+          name={editingUserRow.name}
           identityId={editingUserRow.id}
           identityType={editingUserRow.identityType}
           defaultValues={{ roleName: editingUserRow.siloRole }}

--- a/app/pages/project/access/ProjectAccessPage.tsx
+++ b/app/pages/project/access/ProjectAccessPage.tsx
@@ -199,6 +199,7 @@ export function ProjectAccessPage() {
         <ProjectAccessEditUserSideModal
           onDismiss={() => setEditingUserRow(null)}
           policy={projectPolicy}
+          name={editingUserRow.name}
           identityId={editingUserRow.id}
           identityType={editingUserRow.identityType}
           defaultValues={{ roleName: editingUserRow.projectRole }}

--- a/app/ui/lib/SideModal.tsx
+++ b/app/ui/lib/SideModal.tsx
@@ -143,7 +143,7 @@ SideModal.Title = ({
 }) => (
   <div className="items-top mb-4 mt-8">
     <h2
-      className="flex w-full items-center justify-between break-all pr-8 text-sans-2xl"
+      className="flex w-full items-center justify-between break-words pr-8 text-sans-2xl"
       id={id}
     >
       {title}

--- a/app/ui/lib/SideModal.tsx
+++ b/app/ui/lib/SideModal.tsx
@@ -142,7 +142,10 @@ SideModal.Title = ({
   subtitle?: ReactNode
 }) => (
   <div className="items-top mb-4 mt-8">
-    <h2 className="flex w-full items-center justify-between pr-8 text-sans-2xl" id={id}>
+    <h2
+      className="flex w-full items-center justify-between break-all pr-8 text-sans-2xl"
+      id={id}
+    >
       {title}
     </h2>
     {subtitle}

--- a/test/e2e/click-everything.e2e.ts
+++ b/test/e2e/click-everything.e2e.ts
@@ -48,12 +48,12 @@ test('Click through disks page', async ({ page }) => {
   // Create disk form
   await page.click('role=link[name="New Disk"]')
   await expectVisible(page, [
-    'role=heading[name*="Create Disk"]',
+    'role=heading[name*="Create disk"]',
     'role=textbox[name="Name"]',
     'role=textbox[name="Description"]',
     'role=radiogroup[name="Block size (Bytes)"]',
     'role=textbox[name="Size (GiB)"]',
-    'role=button[name="Create Disk"]',
+    'role=button[name="Create disk"]',
   ])
   await page.goBack()
 })

--- a/test/e2e/firewall-rules.e2e.ts
+++ b/test/e2e/firewall-rules.e2e.ts
@@ -238,7 +238,7 @@ test('can update firewall rule', async ({ page }) => {
   await expect(page.locator('role=cell >> text="edit-filter-subnet"')).toBeVisible()
 
   // submit the form
-  await page.locator('text="Update rule"').click()
+  await page.locator('text="Save changes"').click()
 
   // modal closes again
   await expect(modal).toBeHidden()

--- a/test/e2e/firewall-rules.e2e.ts
+++ b/test/e2e/firewall-rules.e2e.ts
@@ -238,7 +238,7 @@ test('can update firewall rule', async ({ page }) => {
   await expect(page.locator('role=cell >> text="edit-filter-subnet"')).toBeVisible()
 
   // submit the form
-  await page.locator('text="Save changes"').click()
+  await page.locator('text="Update rule"').click()
 
   // modal closes again
   await expect(modal).toBeHidden()

--- a/test/e2e/floating-ip-create.e2e.ts
+++ b/test/e2e/floating-ip-create.e2e.ts
@@ -22,11 +22,11 @@ test('can create a floating IP', async ({ page }) => {
   await page.locator('text="New Floating IP"').click()
 
   await expectVisible(page, [
-    'role=heading[name*="Create Floating IP"]',
+    'role=heading[name*="Create floating IP"]',
     'role=textbox[name="Name"]',
     'role=textbox[name="Description"]',
     'role=button[name="Advanced"]',
-    'role=button[name="Create Floating IP"]',
+    'role=button[name="Create floating IP"]',
   ])
 
   const floatingIpName = 'my-floating-ip'
@@ -51,14 +51,14 @@ test('can create a floating IP', async ({ page }) => {
   await poolListbox.click()
   await page.getByRole('option', { name: 'ip-pool-1' }).click()
   await ipTextbox.fill('256.256.256.256')
-  await page.getByRole('button', { name: 'Create Floating IP' }).click()
+  await page.getByRole('button', { name: 'Create floating IP' }).click()
   await expect(page.getByText('Not a valid IP address').first()).toBeVisible()
 
   // correct IP and submit
   await ipTextbox.clear()
   await ipTextbox.fill('12.34.56.78')
 
-  await page.getByRole('button', { name: 'Create Floating IP' }).click()
+  await page.getByRole('button', { name: 'Create floating IP' }).click()
 
   await expect(page).toHaveURL(floatingIpsPage)
 

--- a/test/e2e/floating-ip-update.e2e.ts
+++ b/test/e2e/floating-ip-update.e2e.ts
@@ -16,7 +16,7 @@ const expectedFormElements = [
   'role=heading[name*="Edit floating IP"]',
   'role=textbox[name="Name"]',
   'role=textbox[name="Description"]',
-  'role=button[name="Save changes"]',
+  'role=button[name="Update floating IP"]',
 ]
 
 test('can update a floating IP', async ({ page }) => {
@@ -26,7 +26,7 @@ test('can update a floating IP', async ({ page }) => {
 
   await page.fill('input[name=name]', updatedName)
   await page.getByRole('textbox', { name: 'Description' }).fill(updatedDescription)
-  await page.getByRole('button', { name: 'Save changes' }).click()
+  await page.getByRole('button', { name: 'Update floating IP' }).click()
   await expect(page).toHaveURL(floatingIpsPage)
   await expectRowVisible(page.getByRole('table'), {
     name: updatedName,
@@ -41,7 +41,7 @@ test('can update *just* the floating IP description', async ({ page }) => {
   await expectVisible(page, expectedFormElements)
 
   await page.getByRole('textbox', { name: 'Description' }).fill(updatedDescription)
-  await page.getByRole('button', { name: 'Save changes' }).click()
+  await page.getByRole('button', { name: 'Update floating IP' }).click()
   await expect(page).toHaveURL(floatingIpsPage)
   await expectRowVisible(page.getByRole('table'), {
     name: originalName,

--- a/test/e2e/instance/disks.e2e.ts
+++ b/test/e2e/instance/disks.e2e.ts
@@ -46,7 +46,7 @@ test('Attach disk', async ({ page }) => {
     'role=textbox[name="Description"]',
     'role=radiogroup[name="Block size (Bytes)"]',
     'role=textbox[name="Size (GiB)"]',
-    'role=button[name="Create Disk"]',
+    'role=button[name="Create disk"]',
   ])
   await page.click('role=button[name="Cancel"]')
 

--- a/test/e2e/instance/networking.e2e.ts
+++ b/test/e2e/instance/networking.e2e.ts
@@ -66,7 +66,7 @@ test('Instance networking tab', async ({ page }) => {
   // Make an edit to the network interface
   await clickRowAction(page, 'nic-2', 'Edit')
   await page.fill('role=textbox[name="Name"]', 'nic-3')
-  await page.click('role=button[name="Save changes"]')
+  await page.click('role=button[name="Update network interface"]')
   await expectNotVisible(page, ['role=cell[name="nic-2"]'])
   const nic3 = page.getByRole('cell', { name: 'nic-3' })
   await expect(nic3).toBeVisible()

--- a/test/e2e/networking.e2e.ts
+++ b/test/e2e/networking.e2e.ts
@@ -40,10 +40,10 @@ test('Create and edit VPC', async ({ page }) => {
     'role=textbox[name="Name"]',
     'role=textbox[name="Description"]',
     'role=textbox[name="DNS name"]',
-    'role=button[name="Save changes"]',
+    'role=button[name="Update VPC"]',
   ])
   await page.fill('role=textbox[name="Name"]', 'new-vpc')
-  await page.click('role=button[name="Save changes"]')
+  await page.click('role=button[name="Update VPC"]')
 
   // Close toast, it holds up the test for some reason
   await page.click('role=button[name="Dismiss notification"]')

--- a/test/e2e/project-access.e2e.ts
+++ b/test/e2e/project-access.e2e.ts
@@ -83,7 +83,7 @@ test('Click through project access page', async ({ page }) => {
 
   await page.click('role=button[name*="Role"]')
   await page.click('role=option[name="Viewer"]')
-  await page.click('role=button[name="Update role"]')
+  await page.click('role=button[name="Save changes"]')
 
   await expectRowVisible(table, { Name: user4.display_name, 'Project role': 'viewer' })
 

--- a/test/e2e/project-access.e2e.ts
+++ b/test/e2e/project-access.e2e.ts
@@ -78,7 +78,7 @@ test('Click through project access page', async ({ page }) => {
     .click()
   await page.click('role=menuitem[name="Change role"]')
 
-  await expectVisible(page, ['role=heading[name*="Edit role"]'])
+  await expectVisible(page, ['role=heading[name*="Change role for Simone de Beauvoir"]'])
   await expectVisible(page, ['button:has-text("Collaborator")'])
 
   await page.click('role=button[name*="Role"]')

--- a/test/e2e/project-access.e2e.ts
+++ b/test/e2e/project-access.e2e.ts
@@ -78,12 +78,12 @@ test('Click through project access page', async ({ page }) => {
     .click()
   await page.click('role=menuitem[name="Change role"]')
 
-  await expectVisible(page, ['role=heading[name*="Change user role"]'])
+  await expectVisible(page, ['role=heading[name*="Edit role"]'])
   await expectVisible(page, ['button:has-text("Collaborator")'])
 
   await page.click('role=button[name*="Role"]')
   await page.click('role=option[name="Viewer"]')
-  await page.click('role=button[name="Save changes"]')
+  await page.click('role=button[name="Update role"]')
 
   await expectRowVisible(table, { Name: user4.display_name, 'Project role': 'viewer' })
 

--- a/test/e2e/silo-access.e2e.ts
+++ b/test/e2e/silo-access.e2e.ts
@@ -72,7 +72,7 @@ test('Click through silo access page', async ({ page }) => {
 
   await page.click('role=button[name*="Role"]')
   await page.click('role=option[name="Viewer"]')
-  await page.click('role=button[name="Update role"]')
+  await page.click('role=button[name="Save changes"]')
 
   await expectRowVisible(table, { Name: user3.display_name, 'Silo role': 'viewer' })
 

--- a/test/e2e/silo-access.e2e.ts
+++ b/test/e2e/silo-access.e2e.ts
@@ -67,7 +67,7 @@ test('Click through silo access page', async ({ page }) => {
     .click()
   await page.click('role=menuitem[name="Change role"]')
 
-  await expectVisible(page, ['role=heading[name*="Edit role"]'])
+  await expectVisible(page, ['role=heading[name*="Change role for Jacob Klein"]'])
   await expectVisible(page, ['button:has-text("Collaborator")'])
 
   await page.click('role=button[name*="Role"]')

--- a/test/e2e/silo-access.e2e.ts
+++ b/test/e2e/silo-access.e2e.ts
@@ -67,12 +67,12 @@ test('Click through silo access page', async ({ page }) => {
     .click()
   await page.click('role=menuitem[name="Change role"]')
 
-  await expectVisible(page, ['role=heading[name*="Change user role"]'])
+  await expectVisible(page, ['role=heading[name*="Edit role"]'])
   await expectVisible(page, ['button:has-text("Collaborator")'])
 
   await page.click('role=button[name*="Role"]')
   await page.click('role=option[name="Viewer"]')
-  await page.click('role=button[name="Save changes"]')
+  await page.click('role=button[name="Update role"]')
 
   await expectRowVisible(table, { Name: user3.display_name, 'Silo role': 'viewer' })
 


### PR DESCRIPTION
Fixes #984 

We had a few different strings we were using for the various edit forms. This PR aligns them, by adding a new `formType` (`'create' | 'edit'`) prop. For _edit_ forms, we have a default button label of "Save changes" (which we were already using in a few places).

This PR also removes an `id` prop, which we can generate dynamically, allowing us to clean the props up a little.

I'm ambivalent on whether `formType` should be a _required_ prop, as we're only using it to set the default label on `edit` forms. We could make it optional and clean up the various `create` form callsites.