### PR TITLE
Add column for effective role on access table

### DIFF
--- a/app/pages/project/access/ProjectAccessPage.tsx
+++ b/app/pages/project/access/ProjectAccessPage.tsx
@@ -129,6 +129,10 @@ export function ProjectAccessPage() {
   const columns = useMemo(
     () => [
       colHelper.accessor('name', { header: 'Name', cell: AccessNameCell }),
+      colHelper.accessor('effectiveRole', {
+        header: 'Effective role',
+        cell: RoleBadgeCell,
+      }),
       colHelper.accessor('siloRole', {
         header: 'Silo role',
         cell: RoleBadgeCell,


### PR DESCRIPTION
Open to discussion on whether we want to add this or not.

We have an "effective role", derived from the silo and project roles, which is essentially the "most permissive" role assigned to a user or group. We already highlight the effective role by marking it in green on the table, but it could be clearer, and accessibility best practices dictate that … "Color is not used as the only visual means of conveying information, indicating an action, prompting a response, or distinguishing a visual element." ([WCAG](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html))

#2047 requests explanatory copy above the table (and we can still add that), but I thought this might help make it more clear.

![image](https://github.com/oxidecomputer/console/assets/22547/2f08dec1-bde0-4b12-b6e5-77357e1d3f7f)
