### PR TITLE
Use list fetches  + `setQueryData` to prefetch items for `*NameFromId` cells

### DIFF
--- a/app/api/hooks.ts
+++ b/app/api/hooks.ts
@@ -219,6 +219,11 @@ export const wrapQueryClient = <A extends ApiClient>(api: A, queryClient: QueryC
     queryClient.invalidateQueries({ queryKey: [method], ...filters }),
   setQueryData: <M extends keyof A>(method: M, params: Params<A[M]>, data: Result<A[M]>) =>
     queryClient.setQueryData([method, params], data),
+  setQueryDataErrorsAllowed: <M extends keyof A>(
+    method: M,
+    params: Params<A[M]>,
+    data: ErrorsAllowed<Result<A[M]>, ApiError>
+  ) => queryClient.setQueryData([method, params, ERRORS_ALLOWED], data),
   fetchQuery: <M extends string & keyof A>(
     method: M,
     params: Params<A[M]>,

--- a/app/pages/system/networking/IpPoolPage.tsx
+++ b/app/pages/system/networking/IpPoolPage.tsx
@@ -54,6 +54,15 @@ IpPoolPage.loader = async function ({ params }: LoaderFunctionArgs) {
       path: { pool },
       query: { limit: 25 }, // match QueryTable
     }),
+
+    // fetch silos and preload into RQ cache so fetches by ID in SiloNameFromId
+    // can be mostly instant yet gracefully fall back to fetching individually
+    // if we don't fetch them all here
+    apiQueryClient.fetchQuery('siloList', { query: { limit: 200 } }).then((silos) => {
+      for (const silo of silos.items) {
+        apiQueryClient.setQueryData('siloView', { path: { silo: silo.id } }, silo)
+      }
+    }),
   ])
   return null
 }


### PR DESCRIPTION
Closes #1946

I love this. Using React Query's cache as a go-between, we can do the list prefetch idea with perfect fallback behavior (if the disk is not in the list we fetched, fetch it directly) without having to change the calling code.

I decided to limit each fetch to 200 items, as in general that should cover us. We could easily bump this higher if we wanted — no other code changes are required. In both FF and Chrome on M1 Mac, I timed how long it takes to loop through the items and call `setQueryData` on 200 items and it took 2-4ms. With a possibly more typical 10 items, it takes under 1ms as one would expect.

<details>
<summary>diff showing code changes for testing perf</summary>

```diff
diff --git a/app/pages/project/snapshots/SnapshotsPage.tsx b/app/pages/project/snapshots/SnapshotsPage.tsx
index 0d09cd89..9216acc4 100644
--- a/app/pages/project/snapshots/SnapshotsPage.tsx
+++ b/app/pages/project/snapshots/SnapshotsPage.tsx
@@ -67,6 +67,7 @@ SnapshotsPage.loader = async ({ params }: LoaderFunctionArgs) => {
     apiQueryClient
       .fetchQuery('diskList', { query: { project, limit: 200 } })
       .then((disks) => {
+        const t = performance.now()
         for (const disk of disks.items) {
           apiQueryClient.setQueryDataErrorsAllowed(
             'diskView',
@@ -74,6 +75,7 @@ SnapshotsPage.loader = async ({ params }: LoaderFunctionArgs) => {
             { type: 'success', data: disk }
           )
         }
+        console.log(performance.now() - t, 'ms')
       }),
   ])
   return null
diff --git a/mock-api/disk.ts b/mock-api/disk.ts
index c58ff18e..4b3cab6a 100644
--- a/mock-api/disk.ts
+++ b/mock-api/disk.ts
@@ -147,13 +147,13 @@ export const disks: Json<Disk>[] = [
     block_size: 2048,
   },
   // put a ton of disks in project 2 so we can use it to test pagination
-  ...new Array(55).fill(0).map((_, i) => {
-    const numStr = (i + 1).toString().padStart(2, '0')
+  ...new Array(1000).fill(0).map((_, i) => {
+    const numStr = (i + 30).toString().padStart(2, '0')
     return {
       id: '9747d936-795d-4d76-8ee0-15561f4cbb' + numStr,
       name: 'disk-' + numStr,
       description: '',
-      project_id: project2.id,
+      project_id: project.id,
       time_created: new Date().toISOString(),
       time_modified: new Date().toISOString(),
       state: { state: 'detached' as const },
```
</detail>