### PR TITLE
Show disk origin

### DIFF
--- a/mock-api/disk.ts
+++ b/mock-api/disk.ts
@@ -37,6 +37,8 @@ export const disks: Json<Disk>[] = [
     device_path: '/def',
     size: 4 * GiB,
     block_size: 2048,
+    // snapshot 1 ID, hardcoded to avoid circular ref between files
+    snapshot_id: 'ab805e59-b6b8-4c73-8081-6a224b6b0698',
   },
   {
     id: '3b768903-1d0b-4d78-9308-c12d3889bdfb',
@@ -49,6 +51,8 @@ export const disks: Json<Disk>[] = [
     device_path: '/ghi',
     size: 6 * GiB,
     block_size: 2048,
+    // image 1 ID, hardcoded to avoid circular ref between files
+    image_id: '7ea31aad-7004-4d1e-ada6-a2e447da40b7',
   },
   {
     id: '5695b16d-e1d6-44b0-a75c-7b4299831540',

--- a/mock-api/snapshot.ts
+++ b/mock-api/snapshot.ts
@@ -14,10 +14,6 @@ import { disks } from './disk'
 import type { Json } from './json-type'
 import { project } from './project'
 
-const generatedSnapshots: Json<Snapshot>[] = Array.from({ length: 25 }, (_, i) =>
-  generateSnapshot(i)
-)
-
 export const snapshots: Json<Snapshot>[] = [
   {
     id: 'ab805e59-b6b8-4c73-8081-6a224b6b0698',
@@ -74,19 +70,15 @@ export const snapshots: Json<Snapshot>[] = [
     disk_id: 'a6f61e3f-25c1-49b0-a013-ac6a2d98a948',
     state: 'ready',
   },
-  ...generatedSnapshots,
-]
-
-function generateSnapshot(index: number): Json<Snapshot> {
-  return {
+  ...Array.from({ length: 25 }, (_, i) => ({
     id: uuid(),
-    name: `disk-1-snapshot-${index + 5}`,
+    name: `disk-1-snapshot-${i + 5}`,
     description: '',
     project_id: project.id,
     time_created: new Date().toISOString(),
     time_modified: new Date().toISOString(),
-    size: 1024 * (index + 1),
+    size: 1024 * (i + 1),
     disk_id: disks[0].id,
-    state: 'ready',
-  }
-}
+    state: 'ready' as const,
+  })),
+]


### PR DESCRIPTION
Was curious what #2057 would look like. I think this has some issues to resolve with design.

* We don't have a snapshot detail URL to link to from the snapshot cell
* Snapshot may no longer exist — do we fall back to deleted like we do with a snapshot of a deleted disk? probably
* We do have an image detail URL to link to, but the image may be silo or project image and the link URL depends on which one it is, but we don't actually know from the `imageView` response which it is

<img width="1106" alt="image" src="https://github.com/oxidecomputer/console/assets/3612203/8f10bbe8-c6de-4e86-bdd8-b968735c802b">
