### PR TITLE
Highlight NavLink when on create form

### DIFF
--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -6,7 +6,7 @@
  * Copyright Oxide Computer Company
  */
 import cn from 'classnames'
-import { NavLink } from 'react-router-dom'
+import { NavLink, useLocation } from 'react-router-dom'
 
 import { Action16Icon, Document16Icon } from '@oxide/design-system/icons/react'
 
@@ -88,20 +88,24 @@ export const NavLinkItem = (props: {
   children: React.ReactNode
   end?: boolean
   disabled?: boolean
-}) => (
-  <li>
-    <NavLink
-      to={props.to}
-      className={({ isActive }) =>
-        cn(linkStyles, {
-          'text-accent !bg-accent-secondary hover:!bg-accent-secondary-hover svg:!text-accent-tertiary':
-            isActive,
-          'pointer-events-none text-disabled': props.disabled,
-        })
-      }
-      end={props.end}
-    >
-      {props.children}
-    </NavLink>
-  </li>
-)
+}) => {
+  // If the current page's URL matches the create form for this NavLink resource, we want to highlight the NavLink in the sidebar.
+  const currentPathIsCreateForm = useLocation().pathname === `${props.to}-new`
+  return (
+    <li>
+      <NavLink
+        to={props.to}
+        className={({ isActive }) =>
+          cn(linkStyles, {
+            'text-accent !bg-accent-secondary hover:!bg-accent-secondary-hover svg:!text-accent-tertiary':
+              isActive || currentPathIsCreateForm,
+            'pointer-events-none text-disabled': props.disabled,
+          })
+        }
+        end={props.end}
+      >
+        {props.children}
+      </NavLink>
+    </li>
+  )
+}

--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -89,8 +89,8 @@ export const NavLinkItem = (props: {
   end?: boolean
   disabled?: boolean
 }) => {
-  // If the current page's URL matches the create form for this NavLink resource, we want to highlight the NavLink in the sidebar.
-  const currentPathIsCreateForm = useLocation().pathname === `${props.to}-new`
+  // If the current page is the create form for this NavLinkItem's resource, highlight the NavLink in the sidebar
+  const currentPathIsCreateForm = useLocation().pathname.startsWith(`${props.to}-new`)
   return (
     <li>
       <NavLink


### PR DESCRIPTION
A simplification of https://github.com/oxidecomputer/console/pull/2060, which I'll close.
Fixes #2038 

This PR fixes an issue where clicking on the create form of a resource left the sidebar navigation un-highlighted.

Now, if the URL matches the NavLink's `to` property with a `-new` on the end of it (which is our pattern for new resource form URLs), the relevant NavLink will be highlighted. That's a bit cumbersome to describe, but screenshots should help:

If I'm on the Instances page:
<img width="661" alt="Screenshot 2024-03-13 at 4 08 20 PM" src="https://github.com/oxidecomputer/console/assets/22547/cdf4fcd7-bdda-49d9-9d42-01fe3a9b3978">

and I click on the "New instance" button to go into the form to create a new instance, the NavLink on the side stays highlighted:
<img width="888" alt="Screenshot 2024-03-13 at 4 08 26 PM" src="https://github.com/oxidecomputer/console/assets/22547/7ccb804b-9437-43a5-8c93-a5c0f03db72d">

This also works for other forms that are contained in sidebars:
<img width="817" alt="Screenshot 2024-03-13 at 4 11 32 PM" src="https://github.com/oxidecomputer/console/assets/22547/52a90097-5082-4140-b80c-347c7ccfb0af">