### PR TITLE
Remove id col from Groups table on profile page

### DIFF
--- a/app/pages/settings/ProfilePage.tsx
+++ b/app/pages/settings/ProfilePage.tsx
@@ -21,7 +21,8 @@ const colHelper = createColumnHelper<Group>()
 
 const columns = [
   colHelper.accessor('displayName', { header: 'Name' }),
-  getActionsCol(() => []),
+  // use _row to prevent eslint from complaining about the unused variable
+  getActionsCol((_row: Group) => []),
 ]
 
 export function ProfilePage() {

--- a/app/pages/settings/ProfilePage.tsx
+++ b/app/pages/settings/ProfilePage.tsx
@@ -14,13 +14,14 @@ import { TextField } from '~/components/form/fields/TextField'
 import { FullPageForm } from '~/components/form/FullPageForm'
 import { useForm } from '~/hooks'
 import { useCurrentUser } from '~/layouts/AuthenticatedLayout'
+import { getActionsCol } from '~/table/columns/action-col'
 import { Table } from '~/table/Table'
 
 const colHelper = createColumnHelper<Group>()
 
 const columns = [
-  colHelper.accessor('id', { header: 'ID' }),
   colHelper.accessor('displayName', { header: 'Name' }),
+  getActionsCol(() => []),
 ]
 
 export function ProfilePage() {


### PR DESCRIPTION
A quick one; Fixes #2053

This removes the "ID" column from the Groups table on the Profile page, moving it to the standard "Copy ID" button for the table row.

![Screenshot 2024-03-20 at 3 26 37 PM](https://github.com/oxidecomputer/console/assets/22547/9be187e9-a4a1-4587-9ca2-8a6ae8dbdb66)
