### PR TITLE
Refactor CapacityBar

### DIFF
--- a/app/components/CapacityBar.tsx
+++ b/app/components/CapacityBar.tsx
@@ -6,75 +6,141 @@
  * Copyright Oxide Computer Company
  */
 
-import { splitDecimal } from '~/util/math'
+import { Cpu16Icon, Ram16Icon, Ssd16Icon } from '@oxide/design-system/icons/react'
 
-export const CapacityBar = ({
-  icon,
-  title,
+import type { VirtualResourceCounts } from '~/api'
+import { classed } from '~/util/classed'
+import { splitDecimal } from '~/util/math'
+import { bytesToGiB, bytesToTiB } from '~/util/units'
+
+const CapacityBarContainer = classed.div`w-full min-w-min rounded-lg border border-default`
+const CapacityBarHeader = classed.div`flex p-3`
+const CapacityBarIcon = classed.div`-ml-0.5 mr-1 flex h-6 w-6 items-start justify-center text-accent`
+
+const CapacityBarLabel = ({ label, unit }: { label: string; unit: string }) => (
+  <div className="flex flex-grow items-start">
+    <span className="text-mono-sm text-secondary">{label}</span>
+    <span className="ml-1 !normal-case text-mono-sm text-quaternary">({unit})</span>
+  </div>
+)
+
+const CapacityBarHeroNumber = ({ percentUsed }: { percentUsed: number }) => {
+  const [wholeNumber, decimal] = splitDecimal(percentUsed)
+  return (
+    <div className="flex -translate-y-0.5 items-baseline">
+      <div className="font-light text-sans-2xl">{wholeNumber}</div>
+      <div className="text-sans-xl text-quaternary">{decimal}%</div>
+    </div>
+  )
+}
+
+const CapacityBarChart = ({ percentUsed }: { percentUsed: number }) => (
+  <div className="p-3 pt-1">
+    <div className="flex w-full gap-0.5">
+      <div
+        className="h-3 rounded-l border bg-accent-secondary border-accent-secondary"
+        style={{ width: `${percentUsed}%` }}
+      ></div>
+      <div className="h-3 grow rounded-r border bg-info-secondary border-info-secondary"></div>
+    </div>
+  </div>
+)
+
+const CapacityBarNumberParts = classed.div`flex justify-between border-t border-secondary`
+
+const CapacityBarNumberPart = ({
+  label,
+  amount,
   unit,
+}: {
+  label: string
+  amount: number
+  unit: string
+}) => {
+  const includeUnit = unit !== unitOptions.cpus
+  return (
+    <div className="p-3 text-mono-sm">
+      <div className="text-quaternary">{label}</div>
+      <div className="text-secondary">
+        {amount.toLocaleString()}
+        <span className="normal-case">{includeUnit ? ' ' + unit : ''}</span>
+      </div>
+    </div>
+  )
+}
+
+type CapacityBarKind = 'cpus' | 'memory' | 'storage'
+
+const titleOptions = {
+  cpus: 'CPU',
+  memory: 'Memory',
+  storage: 'Storage',
+}
+
+const unitOptions = {
+  cpus: 'nCPUs',
+  memory: 'GiB',
+  storage: 'TiB',
+}
+
+const iconOptions = {
+  cpus: <Cpu16Icon />,
+  memory: <Ram16Icon />,
+  storage: <Ssd16Icon />,
+}
+
+const getCapacityBarSubAmount = (
+  kind: CapacityBarKind,
+  rawCounts: VirtualResourceCounts
+) => {
+  if (kind === 'cpus') {
+    return rawCounts.cpus
+  }
+  if (kind === 'memory') {
+    return bytesToGiB(rawCounts.memory)
+  }
+  return bytesToTiB(rawCounts.storage)
+}
+
+export type CapacityBarProps = {
+  kind: CapacityBarKind
+  provisioned: VirtualResourceCounts
+  allocated: VirtualResourceCounts
+  allocatedLabel: 'Quota' | 'Quota (Total)'
+}
+
+/**
+ * Shows a visual representation of the capacity and utilization of a resource.
+ * "provisioned" is the amount of the resource being used at this layer of the service
+ * "allocated" is the total amount of the resource available to this layer, as defined by the parent layer
+ */
+export const CapacityBar = ({
+  kind,
   provisioned,
   allocated,
   allocatedLabel,
-  includeUnit = true,
-}: {
-  icon: JSX.Element
-  title: 'CPU' | 'Memory' | 'Storage'
-  unit: 'nCPUs' | 'GiB' | 'TiB'
-  provisioned: number
-  allocated: number
-  allocatedLabel: string
-  includeUnit?: boolean
-}) => {
-  const percentOfAllocatedUsed = (provisioned / allocated) * 100
-
-  const [wholeNumber, decimal] = splitDecimal(percentOfAllocatedUsed)
-
-  const formattedPercentUsed = `${percentOfAllocatedUsed}%`
+}: CapacityBarProps) => {
+  const unit = unitOptions[kind]
+  const provisionedAmount = getCapacityBarSubAmount(kind, provisioned)
+  const allocatedAmount = getCapacityBarSubAmount(kind, allocated)
+  const percentUsed = (provisionedAmount / allocatedAmount) * 100
 
   return (
-    <div className="w-full min-w-min rounded-lg border border-default">
-      <div className="flex p-3">
-        {/* the icon, title, and hero datum */}
-        <div className="-ml-0.5 mr-1 flex h-6 w-6 items-start justify-center text-accent">
-          {icon}
-        </div>
-        <div className="flex flex-grow items-start">
-          <span className="text-mono-sm text-secondary">{title}</span>
-          <span className="ml-1 !normal-case text-mono-sm text-quaternary">({unit})</span>
-        </div>
-        <div className="flex -translate-y-0.5 items-baseline">
-          <div className="font-light text-sans-2xl">{wholeNumber}</div>
-          <div className="text-sans-xl text-quaternary">{decimal}%</div>
-        </div>
-      </div>
-      <div className="p-3 pt-1">
-        {/* the bar */}
-        <div className="flex w-full gap-0.5">
-          <div
-            className="h-3 rounded-l border bg-accent-secondary border-accent-secondary"
-            style={{ width: formattedPercentUsed }}
-          ></div>
-          <div className="h-3 grow rounded-r border bg-info-secondary border-info-secondary"></div>
-        </div>
-      </div>
-      <div>
-        <div className="flex justify-between border-t border-secondary">
-          <div className="p-3 text-mono-sm">
-            <div className="text-quaternary">Provisioned</div>
-            <div className="text-secondary">
-              {provisioned.toLocaleString()}
-              <span className="normal-case">{includeUnit ? ' ' + unit : ''}</span>
-            </div>
-          </div>
-          <div className="p-3 text-mono-sm">
-            <div className="text-quaternary">{allocatedLabel}</div>
-            <div className="text-secondary">
-              {allocated.toLocaleString()}
-              <span className="normal-case">{includeUnit ? ' ' + unit : ''}</span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
+    <CapacityBarContainer>
+      <CapacityBarHeader>
+        <CapacityBarIcon>{iconOptions[kind]}</CapacityBarIcon>
+        <CapacityBarLabel label={titleOptions[kind]} unit={unit} />
+        <CapacityBarHeroNumber percentUsed={percentUsed} />
+      </CapacityBarHeader>
+      <CapacityBarChart percentUsed={percentUsed} />
+      <CapacityBarNumberParts>
+        <CapacityBarNumberPart label="Provisioned" amount={provisionedAmount} unit={unit} />
+        <CapacityBarNumberPart
+          label={allocatedLabel}
+          amount={allocatedAmount}
+          unit={unit}
+        />
+      </CapacityBarNumberParts>
+    </CapacityBarContainer>
   )
 }

--- a/app/components/CapacityBars.tsx
+++ b/app/components/CapacityBars.tsx
@@ -6,33 +6,37 @@
  * Copyright Oxide Computer Company
  */
 
-import { CapacityBar, type CapacityBarProps } from './CapacityBar'
+import { CapacityBar, CapacityBarsRow, type CapacityBarProps } from './CapacityBar'
 
 export const CapacityBars = ({
-  allocated,
   provisioned,
-  allocatedLabel,
+  provisionedLabel,
+  capacity,
+  capacityLabel,
 }: Omit<CapacityBarProps, 'kind'>) => {
   return (
-    <div className="mb-12 flex min-w-min flex-col gap-3 lg+:flex-row">
+    <CapacityBarsRow>
       <CapacityBar
         kind="cpus"
         provisioned={provisioned}
-        allocated={allocated}
-        allocatedLabel={allocatedLabel}
+        provisionedLabel={provisionedLabel}
+        capacity={capacity}
+        capacityLabel={capacityLabel}
       />
       <CapacityBar
         kind="memory"
         provisioned={provisioned}
-        allocated={allocated}
-        allocatedLabel={allocatedLabel}
+        provisionedLabel={provisionedLabel}
+        capacity={capacity}
+        capacityLabel={capacityLabel}
       />
       <CapacityBar
         kind="storage"
         provisioned={provisioned}
-        allocated={allocated}
-        allocatedLabel={allocatedLabel}
+        provisionedLabel={provisionedLabel}
+        capacity={capacity}
+        capacityLabel={capacityLabel}
       />
-    </div>
+    </CapacityBarsRow>
   )
 }

--- a/app/components/CapacityBars.tsx
+++ b/app/components/CapacityBars.tsx
@@ -6,47 +6,31 @@
  * Copyright Oxide Computer Company
  */
 
-import type { VirtualResourceCounts } from '@oxide/api'
-import { Cpu16Icon, Ram16Icon, Ssd16Icon } from '@oxide/design-system/icons/react'
-
-import { bytesToGiB, bytesToTiB } from '~/util/units'
-
-import { CapacityBar } from './CapacityBar'
+import { CapacityBar, type CapacityBarProps } from './CapacityBar'
 
 export const CapacityBars = ({
   allocated,
   provisioned,
   allocatedLabel,
-}: {
-  allocated: VirtualResourceCounts
-  provisioned: VirtualResourceCounts
-  allocatedLabel: string
-}) => {
+}: Omit<CapacityBarProps, 'kind'>) => {
   return (
     <div className="mb-12 flex min-w-min flex-col gap-3 lg+:flex-row">
       <CapacityBar
-        icon={<Cpu16Icon />}
-        title="CPU"
-        unit="nCPUs"
-        provisioned={provisioned.cpus}
-        allocated={allocated.cpus}
-        includeUnit={false}
+        kind="cpus"
+        provisioned={provisioned}
+        allocated={allocated}
         allocatedLabel={allocatedLabel}
       />
       <CapacityBar
-        icon={<Ram16Icon />}
-        title="Memory"
-        unit="GiB"
-        provisioned={bytesToGiB(provisioned.memory)}
-        allocated={bytesToGiB(allocated.memory)}
+        kind="memory"
+        provisioned={provisioned}
+        allocated={allocated}
         allocatedLabel={allocatedLabel}
       />
       <CapacityBar
-        icon={<Ssd16Icon />}
-        title="Storage"
-        unit="TiB"
-        provisioned={bytesToTiB(provisioned.storage)}
-        allocated={bytesToTiB(allocated.storage)}
+        kind="storage"
+        provisioned={provisioned}
+        allocated={allocated}
         allocatedLabel={allocatedLabel}
       />
     </div>

--- a/app/pages/SiloUtilizationPage.tsx
+++ b/app/pages/SiloUtilizationPage.tsx
@@ -76,8 +76,9 @@ export function SiloUtilizationPage() {
 
       <CapacityBars
         provisioned={utilization.provisioned}
-        allocated={utilization.capacity}
-        allocatedLabel="Quota"
+        provisionedLabel="Provisioned"
+        capacity={utilization.capacity}
+        capacityLabel="Quota"
       />
 
       <Divider className="my-6" />

--- a/app/pages/system/UtilizationPage.tsx
+++ b/app/pages/system/UtilizationPage.tsx
@@ -50,9 +50,10 @@ export function SystemUtilizationPage() {
       </PageHeader>
 
       <CapacityBars
-        allocated={totalAllocated}
         provisioned={totalProvisioned}
-        allocatedLabel="Quota (Total)"
+        provisionedLabel="Provisioned"
+        capacity={totalAllocated}
+        capacityLabel="Quota (Total)"
       />
       <QueryParamTabs defaultValue="summary" className="full-width">
         <Tabs.List>


### PR DESCRIPTION
Fixes #2081 

I left everything inside the `CapacityBar` component, rather than creating a bunch of other files, though if it'd be cleaner if we broke it up further, I'm happy to do that.

It's possible I'm being too clever with the, say, `titleOptions`, `unitOptions`, `iconOptions`, if we decide to use these bars for wholly other kinds of bar charts. At the same time, adding new options to each `Options` object is pretty straightforward, and keeps the props design simpler than it had been before. Open to feedback, as always, on that.

The end UI isn't any different than the current layout. These two screenshots are using the updated component:
![Screenshot 2024-03-20 at 5 27 25 PM](https://github.com/oxidecomputer/console/assets/22547/7a100c94-162b-4d55-81e8-2d11704ec8f7)
![Screenshot 2024-03-20 at 5 27 32 PM](https://github.com/oxidecomputer/console/assets/22547/27eea988-4de3-42c8-820c-b107ccdfcc2a)
