### PR TITLE
Floating point fix for scroll restore

### DIFF
--- a/app/hooks/use-scroll-restoration.ts
+++ b/app/hooks/use-scroll-restoration.ts
@@ -10,7 +10,7 @@ import { useLocation, useNavigation } from 'react-router-dom'
 
 function getScrollPosition(key: string) {
   const pos = window.sessionStorage.getItem(key)
-  return pos && /^[0-9]+$/.test(pos) ? parseInt(pos, 10) : 0
+  return Number(pos) || 0
 }
 
 function setScrollPosition(key: string, pos: number) {


### PR DESCRIPTION
I posted about `useScrollRestoration` on a PR in the react-router repo and someone used it but noticed a bug. This is their fix. Thanks @julamb!

https://github.com/remix-run/react-router/pull/10468#issuecomment-1877312374