### PR TITLE
Go back to React 18.2.0

### DIFF
--- a/app/layouts/RootLayout.tsx
+++ b/app/layouts/RootLayout.tsx
@@ -18,11 +18,12 @@ import { useTitle } from '~/hooks/use-title'
  */
 export function RootLayout() {
   const title = useTitle()
+  useEffect(() => {
+    document.title = title
+  }, [title])
 
   return (
     <>
-      {/* https://react.dev/reference/react-dom/components/title */}
-      <title>{title}</title>
       <LoadingBar />
       {process.env.MSW_BANNER ? <MswBanner /> : null}
       <Outlet />

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,9 +32,9 @@
         "p-map": "^7.0.1",
         "p-retry": "^6.2.0",
         "prop-types": "^15.7.2",
-        "react": "18.3.0-canary-a515d753b-20240220",
+        "react": "^18.2.0",
         "react-aria": "^3.31.1",
-        "react-dom": "18.3.0-canary-a515d753b-20240220",
+        "react-dom": "^18.2.0",
         "react-error-boundary": "^4.0.12",
         "react-hook-form": "^7.50.1",
         "react-is": "^18.2.0",
@@ -63,8 +63,8 @@
         "@testing-library/react": "^14.2.1",
         "@types/lodash.throttle": "^4.1.9",
         "@types/mousetrap": "^1.6.15",
-        "@types/react": "^18.2.55",
-        "@types/react-dom": "^18.2.19",
+        "@types/react": "^18.2.69",
+        "@types/react-dom": "^18.2.22",
         "@types/react-is": "^18.2.4",
         "@types/semver": "^7.5.7",
         "@types/uuid": "^9.0.8",
@@ -6169,9 +6169,9 @@
       "devOptional": true
     },
     "node_modules/@types/react": {
-      "version": "18.2.55",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.55.tgz",
-      "integrity": "sha512-Y2Tz5P4yz23brwm2d7jNon39qoAtMMmalOQv6+fEFt1mT+FcM3D841wDpoUvFXhaYenuROCy3FZYqdTjM7qVyA==",
+      "version": "18.2.69",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.69.tgz",
+      "integrity": "sha512-W1HOMUWY/1Yyw0ba5TkCV+oqynRjG7BnteBB+B7JmAK7iw3l2SW+VGOxL+akPweix6jk2NNJtyJKpn4TkpfK3Q==",
       "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -6180,9 +6180,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.2.19",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.19.tgz",
-      "integrity": "sha512-aZvQL6uUbIJpjZk4U8JZGbau9KDeAwMfmhyWorxgBkqDIEf6ROjRozcmPIicqsUwPUjbkDfHKgGee1Lq65APcA==",
+      "version": "18.2.22",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.22.tgz",
+      "integrity": "sha512-fHkBXPeNtfvri6gdsMYyW+dW7RXFo6Ad09nLFK0VQWR7yGLai/Cyvyj696gbwYvBnhGtevUG9cET0pmUbMtoPQ==",
       "devOptional": true,
       "dependencies": {
         "@types/react": "*"
@@ -16302,9 +16302,9 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.0-canary-a515d753b-20240220",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.0-canary-a515d753b-20240220.tgz",
-      "integrity": "sha512-myxzvvb5hadnnhuedEWBX55M9nIJjQs/zCdfbCmdGpDMasnjSyaLJSG67Aolx+wF0oEeKTfAOS/1YZ+KqUuaDQ==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -16361,15 +16361,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.0-canary-a515d753b-20240220",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.0-canary-a515d753b-20240220.tgz",
-      "integrity": "sha512-oz3+bhB4ripEVTGCb62NsfkrL+ui3MBu/dkiIP8IN0Dy4OC7YiTEogeJru2GaQ01rWgtTlBt50AS3xY3gDO/Yw==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "scheduler": "0.24.0-canary-a515d753b-20240220"
+        "scheduler": "^0.23.0"
       },
       "peerDependencies": {
-        "react": "18.3.0-canary-a515d753b-20240220"
+        "react": "^18.2.0"
       }
     },
     "node_modules/react-error-boundary": {
@@ -17504,9 +17504,9 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.24.0-canary-a515d753b-20240220",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.24.0-canary-a515d753b-20240220.tgz",
-      "integrity": "sha512-KROh3MEx5EV9dGiijfHnS8FLDfkSlit8k2QSPsm4Z/zG1Rx7jRRKAcn4jvMepoIbMgp33qZPfNaCKYAtbqUctA==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -25086,9 +25086,9 @@
       "devOptional": true
     },
     "@types/react": {
-      "version": "18.2.55",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.55.tgz",
-      "integrity": "sha512-Y2Tz5P4yz23brwm2d7jNon39qoAtMMmalOQv6+fEFt1mT+FcM3D841wDpoUvFXhaYenuROCy3FZYqdTjM7qVyA==",
+      "version": "18.2.69",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.69.tgz",
+      "integrity": "sha512-W1HOMUWY/1Yyw0ba5TkCV+oqynRjG7BnteBB+B7JmAK7iw3l2SW+VGOxL+akPweix6jk2NNJtyJKpn4TkpfK3Q==",
       "devOptional": true,
       "requires": {
         "@types/prop-types": "*",
@@ -25097,9 +25097,9 @@
       }
     },
     "@types/react-dom": {
-      "version": "18.2.19",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.19.tgz",
-      "integrity": "sha512-aZvQL6uUbIJpjZk4U8JZGbau9KDeAwMfmhyWorxgBkqDIEf6ROjRozcmPIicqsUwPUjbkDfHKgGee1Lq65APcA==",
+      "version": "18.2.22",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.22.tgz",
+      "integrity": "sha512-fHkBXPeNtfvri6gdsMYyW+dW7RXFo6Ad09nLFK0VQWR7yGLai/Cyvyj696gbwYvBnhGtevUG9cET0pmUbMtoPQ==",
       "devOptional": true,
       "requires": {
         "@types/react": "*"
@@ -32219,9 +32219,9 @@
       }
     },
     "react": {
-      "version": "18.3.0-canary-a515d753b-20240220",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.0-canary-a515d753b-20240220.tgz",
-      "integrity": "sha512-myxzvvb5hadnnhuedEWBX55M9nIJjQs/zCdfbCmdGpDMasnjSyaLJSG67Aolx+wF0oEeKTfAOS/1YZ+KqUuaDQ==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "requires": {
         "loose-envify": "^1.1.0"
       }
@@ -32271,12 +32271,12 @@
       }
     },
     "react-dom": {
-      "version": "18.3.0-canary-a515d753b-20240220",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.0-canary-a515d753b-20240220.tgz",
-      "integrity": "sha512-oz3+bhB4ripEVTGCb62NsfkrL+ui3MBu/dkiIP8IN0Dy4OC7YiTEogeJru2GaQ01rWgtTlBt50AS3xY3gDO/Yw==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
       "requires": {
         "loose-envify": "^1.1.0",
-        "scheduler": "0.24.0-canary-a515d753b-20240220"
+        "scheduler": "^0.23.0"
       }
     },
     "react-error-boundary": {
@@ -33103,9 +33103,9 @@
       }
     },
     "scheduler": {
-      "version": "0.24.0-canary-a515d753b-20240220",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.24.0-canary-a515d753b-20240220.tgz",
-      "integrity": "sha512-KROh3MEx5EV9dGiijfHnS8FLDfkSlit8k2QSPsm4Z/zG1Rx7jRRKAcn4jvMepoIbMgp33qZPfNaCKYAtbqUctA==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
       "requires": {
         "loose-envify": "^1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -52,9 +52,9 @@
     "p-map": "^7.0.1",
     "p-retry": "^6.2.0",
     "prop-types": "^15.7.2",
-    "react": "18.3.0-canary-a515d753b-20240220",
+    "react": "^18.2.0",
     "react-aria": "^3.31.1",
-    "react-dom": "18.3.0-canary-a515d753b-20240220",
+    "react-dom": "^18.2.0",
     "react-error-boundary": "^4.0.12",
     "react-hook-form": "^7.50.1",
     "react-is": "^18.2.0",
@@ -83,8 +83,8 @@
     "@testing-library/react": "^14.2.1",
     "@types/lodash.throttle": "^4.1.9",
     "@types/mousetrap": "^1.6.15",
-    "@types/react": "^18.2.55",
-    "@types/react-dom": "^18.2.19",
+    "@types/react": "^18.2.69",
+    "@types/react-dom": "^18.2.22",
     "@types/react-is": "^18.2.4",
     "@types/semver": "^7.5.7",
     "@types/uuid": "^9.0.8",
@@ -128,10 +128,6 @@
     "vite-plugin-html": "^3.2.2",
     "vite-tsconfig-paths": "^4.3.1",
     "vitest": "^1.3.1"
-  },
-  "overrides": {
-    "react": "18.3.0-canary-a515d753b-20240220",
-    "react-dom": "18.3.0-canary-a515d753b-20240220"
   },
   "browserslist": [
     "defaults",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
     "sourceMap": true,
     "strict": true,
     "target": "es2020",
-    "types": ["node", "vite/client", "vitest/importMeta", "react/canary"]
+    "types": ["node", "vite/client", "vitest/importMeta"]
   },
   "exclude": ["tools/deno"]
 }


### PR DESCRIPTION
We just noticed the confirm modal flashes briefly before navigating to instance detail after instance create. We've seen this issue before and fixed it, but it turns out React Canary reintroduces it. We're probably relying on something in React stable that is ultimately a kind of bug, but for now we don't need anything in React Canary, so we can put off figuring it out.

![image](https://github.com/oxidecomputer/console/assets/3612203/75e1db4f-1a23-4826-ad03-713a4f36a378)
