### PR TITLE
Cut React Query `staleTime` from 10s to 2s

### DIFF
--- a/app/api/client.ts
+++ b/app/api/client.ts
@@ -50,7 +50,7 @@ export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       retry: false,
-      staleTime: 10000,
+      staleTime: 2000,
       refetchOnWindowFocus: false,
     },
   },


### PR DESCRIPTION
The only practical effect this should have is making it less likely that we use cached data on navigation instead of refetching. I think my idea in bumping this up (a long time ago) was that it's cool to be able to rely on the cache if you're navigating back and forth quickly, but I think it's really the opposite — people are probably _trying_ to refresh the data if they're navigating away and back quickly. Related to the problems described in #2095.

The value could go lower because fundamentally we only need this to be big enough to dedupe requests that happen at roughly the same time, but I think 2s is a good starting point.