### PR TITLE
Break up CapacityBar

### DIFF
--- a/app/components/CapacityBar.tsx
+++ b/app/components/CapacityBar.tsx
@@ -29,51 +29,73 @@ export const CapacityBar = <T extends number | bigint>({
   includeUnit?: boolean
 }) => {
   const pct = percentage(provisioned, capacity)
-  const [wholeNumber, decimal] = splitDecimal(pct)
+  const unitElt = includeUnit ? <>&nbsp;{unit}</> : null
 
   return (
     <div className="w-full min-w-min rounded-lg border border-default">
-      <div className="flex p-3">
-        {/* the icon, title, and hero datum */}
-        <div className="-ml-0.5 mr-1 flex h-6 w-6 items-start justify-center text-accent">
-          {icon}
-        </div>
-        <div className="flex flex-grow items-start">
-          <span className="!normal-case text-mono-sm text-secondary">{title}</span>
-          <span className="ml-1 !normal-case text-mono-sm text-quaternary">({unit})</span>
-        </div>
-        <div className="flex -translate-y-0.5 items-baseline">
-          <div className="font-light text-sans-2xl">{wholeNumber}</div>
-          <div className="text-sans-xl text-quaternary">{decimal}%</div>
-        </div>
+      <div className="flex justify-between p-3">
+        <TitleCell icon={icon} title={title} unit={unit} />
+        <PctCell pct={pct} />
       </div>
       <div className="p-3 pt-1">
-        {/* the bar */}
-        <div className="flex w-full gap-0.5">
-          <div
-            className="h-3 rounded-l border bg-accent-secondary border-accent-secondary"
-            style={{ width: `${pct.toFixed(2)}%` }}
-          ></div>
-          <div className="h-3 grow rounded-r border bg-info-secondary border-info-secondary"></div>
-        </div>
+        <Bar pct={pct} />
       </div>
-      <div>
-        <div className="flex justify-between border-t border-secondary">
-          <div className="p-3 text-mono-sm">
-            <div className="text-quaternary">{provisionedLabel}</div>
-            <div className="text-secondary">
-              <BigNum num={provisioned} />
-              <span className="normal-case">{includeUnit ? ' ' + unit : ''}</span>
-            </div>
-          </div>
-          <div className="p-3 text-mono-sm">
-            <div className="text-quaternary">{capacityLabel}</div>
-            <div className="!normal-case text-secondary">
-              <BigNum num={capacity} />
-              <span className="normal-case">{includeUnit ? ' ' + unit : ''}</span>
-            </div>
-          </div>
-        </div>
+      <div className="flex justify-between border-t border-secondary">
+        <ValueCell label={provisionedLabel} value={provisioned} unit={unitElt} />
+        <ValueCell label={capacityLabel} value={capacity} unit={unitElt} />
+      </div>
+    </div>
+  )
+}
+
+type TitleCellProps = { icon: JSX.Element; title: string; unit: string }
+function TitleCell({ icon, title, unit }: TitleCellProps) {
+  return (
+    <div>
+      <div className="flex flex-grow items-center">
+        <span className="mr-2 flex h-4 w-4 items-center text-accent">{icon}</span>
+        <span className="!normal-case text-mono-sm text-secondary">{title}</span>
+        <span className="ml-1 !normal-case text-mono-sm text-quaternary">({unit})</span>
+      </div>
+    </div>
+  )
+}
+
+function PctCell({ pct }: { pct: number }) {
+  const [wholeNumber, decimal] = splitDecimal(pct)
+  return (
+    <div className="flex -translate-y-0.5 items-baseline">
+      <div className="font-light text-sans-2xl">{wholeNumber}</div>
+      <div className="text-sans-xl text-quaternary">{decimal}%</div>
+    </div>
+  )
+}
+
+function Bar({ pct }: { pct: number }) {
+  return (
+    <div className="flex w-full gap-0.5">
+      <div
+        className="h-3 rounded-l border bg-accent-secondary border-accent-secondary"
+        style={{ width: `${pct.toFixed(2)}%` }}
+      ></div>
+      <div className="h-3 grow rounded-r border bg-info-secondary border-info-secondary"></div>
+    </div>
+  )
+}
+
+type ValueCellProps = {
+  label: string
+  value: number | bigint
+  unit: React.ReactNode
+}
+
+function ValueCell({ label, value, unit }: ValueCellProps) {
+  return (
+    <div className="p-3 text-mono-sm">
+      <div className="text-quaternary">{label}</div>
+      <div className="!normal-case text-secondary">
+        <BigNum num={value} />
+        {unit}
       </div>
     </div>
   )

--- a/app/components/CapacityBar.tsx
+++ b/app/components/CapacityBar.tsx
@@ -37,7 +37,7 @@ export const CapacityBar = <T extends number | bigint>({
         <TitleCell icon={icon} title={title} unit={unit} />
         <PctCell pct={pct} />
       </div>
-      <div className="p-3 pt-1">
+      <div className="p-3 pb-4 pt-1">
         <Bar pct={pct} />
       </div>
       <div className="flex justify-between border-t border-secondary">
@@ -92,7 +92,7 @@ type ValueCellProps = {
 function ValueCell({ label, value, unit }: ValueCellProps) {
   return (
     <div className="p-3 text-mono-sm">
-      <div className="text-quaternary">{label}</div>
+      <div className="mb-px text-quaternary">{label}</div>
       <div className="!normal-case text-secondary">
         <BigNum num={value} />
         {unit}


### PR DESCRIPTION
Closes #2081, whatever. We can further break it up later.

Just breaking it up internally for readability, didn't change the external props at all.

I was hoping in #2081 that we'd end up with a set of components that gets composed at the call site, but that might be kind of silly when the layout is so strict and specific. That's why #2085 did it this way too.

After breaking it up I tweaked it very slightly to match what I saw in [Figma](https://www.figma.com/file/GxsrGUQkWwDg6LuiWM9Rft/Capacity-%26-Utilization-v2?type=design&node-id=1636%3A44077&mode=design&t=hlo0iiVTaI667bUl-1):

* icon/title thing's left edge aligns with left edge of bar
* 1rem under bar instead of 3/4
* a tiny bit more space between "provisioned" and the number underneath (not really noticeable)

![2024-03-26-utilization-style](https://github.com/oxidecomputer/console/assets/3612203/16550182-02d6-46d5-b04a-8739b71c4cb7)
