### PR TITLE
Maintain state of fields across tab navigation

### DIFF
--- a/app/components/form/fields/ImageSelectField.tsx
+++ b/app/components/form/fields/ImageSelectField.tsx
@@ -19,19 +19,21 @@ type ImageSelectFieldProps = {
   images: Image[]
   control: Control<InstanceCreateInput>
   disabled?: boolean
+  name?: 'bootDiskSource' | 'siloImageSource' | 'projectImageSource'
 }
 
 export function BootDiskImageSelectField({
   images,
   control,
   disabled,
+  name,
 }: ImageSelectFieldProps) {
   const diskSizeField = useController({ control, name: 'bootDiskSize' }).field
   return (
     <ListboxField
       disabled={disabled}
       control={control}
-      name="bootDiskSource"
+      name={name || 'bootDiskSource'}
       label="Image"
       placeholder="Select an image"
       items={images.map((i) => toListboxItem(i))}

--- a/app/components/form/fields/ImageSelectField.tsx
+++ b/app/components/form/fields/ImageSelectField.tsx
@@ -11,6 +11,7 @@ import type { Image } from '@oxide/api'
 
 import type { InstanceCreateInput } from '~/forms/instance-create'
 import type { ListboxItem } from '~/ui/lib/Listbox'
+import { nearest10 } from '~/util/math'
 import { bytesToGiB, GiB } from '~/util/units'
 
 import { ListboxField } from './ListboxField'
@@ -19,7 +20,7 @@ type ImageSelectFieldProps = {
   images: Image[]
   control: Control<InstanceCreateInput>
   disabled?: boolean
-  name?: 'bootDiskSource' | 'siloImageSource' | 'projectImageSource'
+  name: 'siloImageSource' | 'projectImageSource'
 }
 
 export function BootDiskImageSelectField({
@@ -33,7 +34,7 @@ export function BootDiskImageSelectField({
     <ListboxField
       disabled={disabled}
       control={control}
-      name={name || 'bootDiskSource'}
+      name={name}
       label="Image"
       placeholder="Select an image"
       items={images.map((i) => toListboxItem(i))}
@@ -42,8 +43,7 @@ export function BootDiskImageSelectField({
         const image = images.find((i) => i.id === id)! // if it's selected, it must be present
         const imageSizeGiB = image.size / GiB
         if (diskSizeField.value < imageSizeGiB) {
-          const nearest10 = Math.ceil(imageSizeGiB / 10) * 10
-          diskSizeField.onChange(nearest10)
+          diskSizeField.onChange(nearest10(imageSizeGiB))
         }
       }}
     />

--- a/app/forms/instance-create.tsx
+++ b/app/forms/instance-create.tsx
@@ -176,7 +176,7 @@ export function CreateInstanceForm() {
     projectImageSource: projectImages?.[0]?.id || '',
     diskSource: disks?.[0]?.value || '',
     sshPublicKeys: allKeys,
-    bootDiskSize: Math.max(nearest10(defaultImage?.size / GiB), 10),
+    bootDiskSize: nearest10(defaultImage?.size / GiB),
   }
 
   const form = useForm({ defaultValues })

--- a/app/util/math.spec.ts
+++ b/app/util/math.spec.ts
@@ -7,7 +7,14 @@
  */
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-import { displayBigNum, percentage, round, splitDecimal, toEngNotation } from './math'
+import {
+  displayBigNum,
+  nearest10,
+  percentage,
+  round,
+  splitDecimal,
+  toEngNotation,
+} from './math'
 import { GiB } from './units'
 
 function roundTest() {
@@ -207,4 +214,25 @@ it.each([
   // ['ar-SA'], // saudi arabia, arabic script
 ])('toEngNotation commas %s', (locale) => {
   expect(toEngNotation(n, locale)).toEqual('23,1e27')
+})
+
+it.each([
+  [0, 0],
+  [1, 10],
+  [1.5, 10],
+  [9, 10],
+  [10, 10],
+  [10.0001, 20],
+  [11, 20],
+  [19, 20],
+  [20, 20],
+  [21, 30],
+  [99, 100],
+  [100, 100],
+  [101, 110],
+  [109, 110],
+  [110, 110],
+  [111, 120],
+])('nearest10 %d → %d', (input, output) => {
+  expect(nearest10(input)).toEqual(output)
 })

--- a/app/util/math.ts
+++ b/app/util/math.ts
@@ -88,3 +88,10 @@ export function displayBigNum(num: bigint | number): [string, boolean] {
 
   return [result, abbreviated]
 }
+
+/**
+ * Gets the closest multiple of 10 larger than the passed-in number
+ */
+export function nearest10(num: number): number {
+  return Math.ceil(num / 10) * 10
+}

--- a/test/e2e/instance-create.e2e.ts
+++ b/test/e2e/instance-create.e2e.ts
@@ -119,24 +119,24 @@ test('can create an instance with custom hardware', async ({ page }) => {
   await page.getByRole('textbox', { name: 'Disk name' }).fill('my-boot-disk')
   const diskSizeInput = page.getByRole('textbox', { name: 'Disk size (GiB)' })
   await diskSizeInput.fill('20')
+  await page.keyboard.press('Tab')
 
   // pick a project image just to show we can
   await page.getByRole('tab', { name: 'Project images' }).click()
   await page.getByRole('button', { name: 'Image' }).click()
   await page.getByRole('option', { name: images[2].name }).click()
+  // the disk size should bot have been changed from what was entered earlier
+  await expect(diskSizeInput).toHaveValue('20')
 
   // test disk size validation against image size
+  // the minimum on the number input will be the size of the image (6GiB),
+  // so manually entering a number less than that will be corrected
   await diskSizeInput.fill('5')
+  await page.keyboard.press('Tab')
+  await expect(diskSizeInput).toHaveValue('6')
 
   const submitButton = page.getByRole('button', { name: 'Create instance' })
   await submitButton.click() // submit to trigger validation
-
-  await expectVisible(page, [
-    'main >> text=Must be as large as selected image (min. 6 GiB)',
-  ])
-  await diskSizeInput.fill('10')
-
-  await submitButton.click()
 
   await expect(page).toHaveURL(`/projects/mock-project/instances/${instanceName}/storage`)
 
@@ -157,6 +157,7 @@ test('automatically updates disk size when larger image selected', async ({ page
   // set the disk size larger than it needs to be, to verify it doesn't get reduced
   const diskSizeInput = page.getByRole('textbox', { name: 'Disk size (GiB)' })
   await diskSizeInput.fill('5')
+  await page.keyboard.press('Tab')
 
   // pick a disk image that's smaller than 5GiB (the first project image works [4GiB])
   await page.getByRole('tab', { name: 'Project images' }).click()
@@ -228,4 +229,46 @@ test('shows object not found error on no default pool', async ({ page }) => {
   await page.getByRole('button', { name: 'Create instance' }).click()
 
   await expect(page.getByText('Not found: default IP pool')).toBeVisible()
+})
+
+test('create instance with existing disk', async ({ page }) => {
+  const instanceName = 'my-existing-disk-instance'
+  await page.goto('/projects/mock-project/instances-new')
+  await page.getByRole('textbox', { name: 'Name', exact: true }).fill(instanceName)
+  await page.getByRole('tab', { name: 'Existing disks' }).click()
+  await page.getByRole('button', { name: 'Create instance' }).click()
+  await expect(page).toHaveURL(`/projects/mock-project/instances/${instanceName}/storage`)
+  await expectVisible(page, [`h1:has-text("${instanceName}")`, 'text=8 GiB'])
+  await expectRowVisible(page.getByRole('table'), { name: 'disk-3' })
+})
+
+test('create instance with a different existing disk', async ({ page }) => {
+  const instanceName = 'my-existing-disk-2'
+  await page.goto('/projects/mock-project/instances-new')
+  await page.getByRole('textbox', { name: 'Name', exact: true }).fill(instanceName)
+  await page.getByRole('tab', { name: 'Existing disks' }).click()
+  // test some keyboard navigation to select existing disk
+  await page.keyboard.press('Tab')
+  await page.keyboard.press('Tab')
+  await page.keyboard.press('Enter') // focus the disk select
+  await page.keyboard.press('ArrowDown')
+  await page.keyboard.press('Enter')
+  await page.getByRole('button', { name: 'Create instance' }).click()
+  await expect(page).toHaveURL(`/projects/mock-project/instances/${instanceName}/storage`)
+  await expectVisible(page, [`h1:has-text("${instanceName}")`, 'text=8 GiB'])
+  await expectRowVisible(page.getByRole('table'), { name: 'disk-4' })
+})
+
+test('start with an existing disk, but then switch to a silo image', async ({ page }) => {
+  const instanceName = 'silo-image-instance'
+  await page.goto('/projects/mock-project/instances-new')
+  await page.getByRole('textbox', { name: 'Name', exact: true }).fill(instanceName)
+  await page.getByRole('tab', { name: 'Existing disks' }).click()
+  await page.getByLabel('Disk', { exact: true }).click()
+  await page.getByRole('option', { name: 'disk-7' }).click()
+  await page.getByRole('tab', { name: 'Silo images' }).click()
+  await page.getByRole('button', { name: 'Create instance' }).click()
+  await expect(page).toHaveURL(`/projects/mock-project/instances/${instanceName}/storage`)
+  await expectVisible(page, [`h1:has-text("${instanceName}")`, 'text=8 GiB'])
+  await expectNotVisible(page, ['text=disk-7'])
 })

--- a/test/e2e/instance-create.e2e.ts
+++ b/test/e2e/instance-create.e2e.ts
@@ -272,3 +272,20 @@ test('start with an existing disk, but then switch to a silo image', async ({ pa
   await expectVisible(page, [`h1:has-text("${instanceName}")`, 'text=8 GiB'])
   await expectNotVisible(page, ['text=disk-7'])
 })
+
+test('maintains selected values even when changing tabs', async ({ page }) => {
+  await page.goto('/projects/mock-project/instances-new')
+  await page.getByRole('button', { name: 'Image' }).click()
+  // select the arch option
+  await page.getByRole('option', { name: 'arch-2022-06-01' }).click()
+  // expect to find name of the image on page
+  await expect(page.getByText('arch-2022-06-01')).toBeVisible()
+  // change to a different tab
+  await page.getByRole('tab', { name: 'Existing disks' }).click()
+  // the image should no longer be visible
+  await expect(page.getByText('arch-2022-06-01')).toBeHidden()
+  // change back to the tab with the image
+  await page.getByRole('tab', { name: 'Silo images' }).click()
+  // arch should still be selected
+  await expect(page.getByText('arch-2022-06-01')).toBeVisible()
+})


### PR DESCRIPTION
In order to have the form retain the input values into the various tab's forms, I had to update a few fields in the form.

I'll want to take a look at this in the morning, as I suspect there are a few gnarly bits in it.

If this works as I believe it does, though, we'd merge it back into `fix-form-sourceType-bug`, which is, itself, waiting to get merged to `existing-boot-disk`. I was wary enough about the changes here that I didn't want to just Leeroy Jenkins it into `fix-form-sourceType-bug`.