### PR TITLE
Fix e2e CI failure debug script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,6 @@
 .DS_Store
 Thumbs.db
 test-results/
+ci-e2e-traces/
 playwright-report/
 .vercel

--- a/test/e2e/vpcs.e2e.ts
+++ b/test/e2e/vpcs.e2e.ts
@@ -12,7 +12,7 @@ test('can nav to VpcPage from /', async ({ page }) => {
   await page.click('table :text("mock-project")')
   await page.click('a:has-text("VPCs")')
   await page.click('a:has-text("mock-vpc")')
-  await expect(page.locator('text=mork-subnet')).toBeVisible()
+  await expect(page.locator('text=mock-subnet')).toBeVisible()
   expect(await page.title()).toEqual('mock-vpc / VPCs / mock-project / Oxide Console')
 })
 

--- a/test/e2e/vpcs.e2e.ts
+++ b/test/e2e/vpcs.e2e.ts
@@ -12,7 +12,7 @@ test('can nav to VpcPage from /', async ({ page }) => {
   await page.click('table :text("mock-project")')
   await page.click('a:has-text("VPCs")')
   await page.click('a:has-text("mock-vpc")')
-  await expect(page.locator('text=mock-subnet')).toBeVisible()
+  await expect(page.locator('text=mork-subnet')).toBeVisible()
   expect(await page.title()).toEqual('mock-vpc / VPCs / mock-project / Oxide Console')
 })
 

--- a/tools/debug-ci-e2e-fail.sh
+++ b/tools/debug-ci-e2e-fail.sh
@@ -6,32 +6,50 @@
 #  
 # Copyright Oxide Computer Company
 
+# Run this script on a branch to download the E2E failure traces from the
+# latest run on that branch. Pass a commit (full hash, not abbreviated)
+# to pull the traces for that commit.
+
 set -e
 set -o pipefail
 
 DIR="ci-e2e-traces"
 
-# Get the ID of the last github actions run if there was one
-BRANCH=$(git rev-parse --abbrev-ref HEAD)
-RUN_ID=$(gh run list -b "$BRANCH" -w CI -L 1 --json databaseId --jq '.[0].databaseId')
+COMMIT=$1
 
-if [ -z "$RUN_ID" ]; then
-  echo "No action runs found for this branch"
-  exit 0
+# Get the ID of the last github actions run if there was one. If a commit
+# is specified, use that, otherwise
+if [ -n "$COMMIT" ]; then
+    echo -e "Looking at latest run on commit $COMMIT"
+    RUN_ID=$(gh run list --commit "$COMMIT" -w CI -L 1 --json databaseId --jq '.[0].databaseId')
+    if [ -z "$RUN_ID" ]; then
+      echo "No action runs found. Make sure to use full commit SHA."
+      exit 0
+    fi
+else 
+    BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    echo -e "Looking at latest run on branch $BRANCH"
+    RUN_ID=$(gh run list -b "$BRANCH" -w CI -L 1 --json databaseId --jq '.[0].databaseId')
+    if [ -z "$RUN_ID" ]; then
+      echo "No action runs found"
+      exit 0
+    fi
 fi
+
 
 if [ -e "$DIR/.run" ] && [ "$RUN_ID" == "$(cat $DIR/.run)" ]; then
     : # Do nothing, the test results are already up to date
 else
     rm -rf $DIR
-    echo "Attempting to download test failure traces for current branch..."
+    echo "Downloading traces..."
     gh run download $RUN_ID --dir $DIR
     echo $RUN_ID > $DIR/.run
 fi
 
-
-echo "Choose a test trace to view"
-select trace in $(find $DIR -name "trace.zip"); do
-    npx playwright show-trace $trace
+# gnarly select and re-find is to take filepath noise out of the select list
+echo "Choose a trace to view"
+select trace in $(find $DIR -name "trace.zip" | sed 's/.*\/\(.*\)\/trace.zip/\1/'); do
+    selected_trace=$(find $DIR -path "*/$trace"/trace.zip)
+    npx playwright show-trace "$selected_trace"
     exit 0
 done

--- a/tools/debug-ci-e2e-fail.sh
+++ b/tools/debug-ci-e2e-fail.sh
@@ -22,7 +22,7 @@ if [ -d "test-results" ] && [ -f "test-results/.run" ] && [ "$RUN_ID" == "$(cat 
 else
     rm -rf test-results
     echo "Attempting to download test failure traces for current branch..."
-    gh run download $RUN_ID
+    gh run download $RUN_ID --dir test-results
     echo $RUN_ID > test-results/.run
 fi
 

--- a/tools/debug-ci-e2e-fail.sh
+++ b/tools/debug-ci-e2e-fail.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at https://mozilla.org/MPL/2.0/.
@@ -7,6 +8,8 @@
 
 set -e
 set -o pipefail
+
+DIR="ci-e2e-traces"
 
 # Get the ID of the last github actions run if there was one
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
@@ -17,18 +20,18 @@ if [ -z "$RUN_ID" ]; then
   exit 0
 fi
 
-if [ -d "test-results" ] && [ -f "test-results/.run" ] && [ "$RUN_ID" == "$(cat test-results/.run)" ]; then
+if [ -e "$DIR/.run" ] && [ "$RUN_ID" == "$(cat $DIR/.run)" ]; then
     : # Do nothing, the test results are already up to date
 else
-    rm -rf test-results
+    rm -rf $DIR
     echo "Attempting to download test failure traces for current branch..."
-    gh run download $RUN_ID --dir test-results
-    echo $RUN_ID > test-results/.run
+    gh run download $RUN_ID --dir $DIR
+    echo $RUN_ID > $DIR/.run
 fi
 
 
 echo "Choose a test trace to view"
-select test in $(ls test-results); do
-    npx playwright show-trace test-results/$test/trace.zip
+select trace in $(find $DIR -name "trace.zip"); do
+    npx playwright show-trace $trace
     exit 0
 done


### PR DESCRIPTION
Closes #2103 

Works like this. Wish the list was less noisy, but this is bash.

```
$ ./tools/debug-ci-e2e-fail.sh
Attempting to download test failure traces for current branch...
Choose a test trace to view
 1) ci-e2e-traces/test-results-chrome/vpcs.e2e.ts-can-nav-to-VpcPage-from--chrome/trace.zip
 2) ci-e2e-traces/test-results-chrome/vpcs.e2e.ts-can-nav-to-VpcPage-from--chrome-retry2/trace.zip
 3) ci-e2e-traces/test-results-chrome/vpcs.e2e.ts-can-nav-to-VpcPage-from--chrome-retry1/trace.zip
 4) ci-e2e-traces/test-results-firefox/vpcs.e2e.ts-can-nav-to-VpcPage-from--firefox/trace.zip
 5) ci-e2e-traces/test-results-firefox/vpcs.e2e.ts-can-nav-to-VpcPage-from--firefox-retry2/trace.zip
 6) ci-e2e-traces/test-results-firefox/ip-pools.e2e.ts-IP-pool-silo-list-firefox/trace.zip
 7) ci-e2e-traces/test-results-firefox/vpcs.e2e.ts-can-nav-to-VpcPage-from--firefox-retry1/trace.zip
 8) ci-e2e-traces/test-results-safari/vpcs.e2e.ts-can-nav-to-VpcPage-from--safari/trace.zip
 9) ci-e2e-traces/test-results-safari/vpcs.e2e.ts-can-nav-to-VpcPage-from--safari-retry2/trace.zip
10) ci-e2e-traces/test-results-safari/vpcs.e2e.ts-can-nav-to-VpcPage-from--safari-retry1/trace.zip
11) ci-e2e-traces/test-results-safari/ip-pools.e2e.ts-IP-pool-silo-list-safari/trace.zip
12) ci-e2e-traces/test-results-safari/silos.e2e.ts-Silo-IP-pools-safari/trace.zip
#? 7
```