### PR TITLE
Fix IP pools -> pool detail error for quick draw mcgraws

### DIFF
--- a/app/api/client.ts
+++ b/app/api/client.ts
@@ -50,7 +50,7 @@ export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       retry: false,
-      staleTime: 2000,
+      staleTime: 10000,
       refetchOnWindowFocus: false,
     },
   },

--- a/app/api/hooks.ts
+++ b/app/api/hooks.ts
@@ -278,6 +278,8 @@ export const wrapQueryClient = <A extends ApiClient>(api: A, queryClient: QueryC
           }),
       ...options,
     }),
+  getQueryState: <M extends keyof A>(method: M, params: Params<A[M]>) =>
+    queryClient.getQueryState([method, params]),
 })
 
 export const getUseApiQueryClient =

--- a/app/pages/system/networking/IpPoolPage.tsx
+++ b/app/pages/system/networking/IpPoolPage.tsx
@@ -77,14 +77,7 @@ IpPoolPage.loader = async function ({ params }: LoaderFunctionArgs) {
       query: { limit: 25 }, // match QueryTable
     }),
     // when wrapping up: change this back to prefetch and stick the cancel before it
-    apiQueryClient
-      .fetchQuery('ipPoolUtilizationView', { path: { pool } })
-      .then((result) => {
-        console.log('after prefetchQuery', result, getState(pool))
-      })
-      .catch((error) => {
-        console.log('after prefetchQuery (error)', error, getState(pool))
-      }),
+    apiQueryClient.prefetchQuery('ipPoolUtilizationView', { path: { pool } }),
 
     // fetch silos and preload into RQ cache so fetches by ID in SiloNameFromId
     // can be mostly instant yet gracefully fall back to fetching individually

--- a/mock-api/msw/handlers.ts
+++ b/mock-api/msw/handlers.ts
@@ -640,8 +640,6 @@ export const handlers = makeHandlers({
     const ipv4sInPool = allIps.filter((ip) => ipInAnyRange(ip, ipv4Ranges)).length
     const ipv6sInPool = allIps.filter((ip) => ipInAnyRange(ip, ipv6Ranges)).length
 
-    await delay(2000)
-
     return {
       ipv4: {
         allocated: ipv4sInPool,

--- a/mock-api/msw/handlers.ts
+++ b/mock-api/msw/handlers.ts
@@ -622,7 +622,7 @@ export const handlers = makeHandlers({
     return json(instance, { status: 202 })
   },
   ipPoolList: ({ query }) => paginated(query, db.ipPools),
-  ipPoolUtilizationView({ path }) {
+  async ipPoolUtilizationView({ path }) {
     const pool = lookup.ipPool(path)
     const ranges = db.ipPoolRanges
       .filter((r) => r.ip_pool_id === pool.id)
@@ -639,6 +639,8 @@ export const handlers = makeHandlers({
 
     const ipv4sInPool = allIps.filter((ip) => ipInAnyRange(ip, ipv4Ranges)).length
     const ipv6sInPool = allIps.filter((ip) => ipInAnyRange(ip, ipv6Ranges)).length
+
+    await delay(2000)
 
     return {
       ipv4: {


### PR DESCRIPTION
Closes #2107 

At moderate psychological expense, @charliepark and I were able to determine that the following sequence of events is happening:

1. Load IP pools list page
2. Render `useQuery` fetching utilization for `ip-pool-1` (an async fetch with loading state in table cell)
3. Click `ip-pool-1` to go to IP pool detail page before utilization fetch is complete
4. Loader runs for IP pool detail, _also_ fetching utilization for `ip-pool-1`
5. Table cells on list page unmount, causing `useQuery` to unmount and [`removeObserver`](https://github.com/TanStack/query/blob/21bde49d3848d8823d1c827ec90fac60572cc550/packages/query-core/src/query.ts#L301-L321) to get called (confirmed by adding logging inside `removeObserver`)
    * Call chain from component unmount to `removeObserver` goes from [`useSyncExternalStore` call](https://github.com/TanStack/query/blob/21bde49d3848d8823d1c827ec90fac60572cc550/packages/react-query/src/useBaseQuery.ts#L75-L83) to [`onUnsubscribe`](https://github.com/TanStack/query/blob/21bde49d3848d8823d1c827ec90fac60572cc550/packages/query-core/src/queryObserver.ts#L105-L109) to [`destroy`](https://github.com/TanStack/query/blob/21bde49d3848d8823d1c827ec90fac60572cc550/packages/query-core/src/queryObserver.ts#L127-L132)
    * **Unsolved:** why does unmount happen before the loader is complete? Page transition should only happen after loader is done.
7. `removeObserver` sees that there are no remaining observers (because **`prefetchQuery` is _not_ an observer**) on the utilization query and [cancels it](https://github.com/TanStack/query/blob/21bde49d3848d8823d1c827ec90fac60572cc550/packages/query-core/src/query.ts#L310), which causes a `CancelledError` to be thrown inside our `prefetchQuery` and ends it
8. Now the loader is complete, so the detail page for `ip-pool-1` renders, and the hook that expects that utilization is prefetched fails its invariant, hence the error page

### Mitigations

Pretty early on I figured out that if I call `cancelQueries` myself on the query in question before calling `prefetchQuery`, that kills all the previous page stuff before it has a chance to kill me. So that avoids the error. The problem with this is that it means we start the query over again, even if we've already gotten through 90% of the fetch by the time we start the loader. This is distasteful, but I could live with it.

Once we really figured out what was going on, we were able to come up with a sneaker solution, which currently what we're doing in the diff: instead of canceling the query, manually add an observer right before we call `prefetchQuery` so that `removeObserver` does not cancel the query. This works perfectly — if the request takes 2 seconds and we wait 1.5s to click the link, the next page loads very quick — but it is somewhat ridiculous.

### Solutions

One thing we could do is figure out why the unmount is happening earlier than we expect. If we can make that not happen, I think this problem goes away, because the first query doesn't get canceled until after the `prefetchQuery` call is complete.

Another way would be to make all prefetches behave like observers for the duration of their fetch:

```diff
diff --git a/app/api/hooks.ts b/app/api/hooks.ts
index 7e826f08..ee6c74e6 100644
--- a/app/api/hooks.ts
+++ b/app/api/hooks.ts
@@ -240,11 +240,14 @@ export const wrapQueryClient = <A extends ApiClient>(api: A, queryClient: QueryC
     params: Params<A[M]>,
     options: FetchQueryOtherOptions<Result<A[M]>, ApiError> = {}
   ) => {
+    const obs = new QueryObserver(queryClient, { queryKey: [method, params] })
+    const unsub = obs.subscribe(() => {})
     await queryClient.prefetchQuery({
       queryKey: [method, params],
       queryFn: () => api[method](params).then(handleResult(method)),
       ...options,
     })
+    unsub()
   },
   /**
    * Loader analog to `useApiQueryErrorsAllowed`. Prefetch a query that can

```

I doubt this is something RQ should take as a PR, it's too specific. Only way I can think of to swing it would be that `prefetchQuery` takes an option that makes it act as a subscriber.

### Next steps

I want to talk to the maintainer about this 😅 