### PR TITLE
Proof of concept: Take column logic out of QueryTable

### DIFF
--- a/app/pages/project/disks/DisksPage.tsx
+++ b/app/pages/project/disks/DisksPage.tsx
@@ -6,7 +6,7 @@
  * Copyright Oxide Computer Company
  */
 import { createColumnHelper } from '@tanstack/react-table'
-import { useCallback, useMemo } from 'react'
+import { useCallback } from 'react'
 import { Link, Outlet, type LoaderFunctionArgs } from 'react-router-dom'
 
 import {
@@ -26,7 +26,7 @@ import { DateCell } from '~/table/cells/DateCell'
 import { defaultCell } from '~/table/cells/DefaultCell'
 import { InstanceLinkCell } from '~/table/cells/InstanceLinkCell'
 import { SizeCell } from '~/table/cells/SizeCell'
-import { getActionsCol, type MenuAction } from '~/table/columns/action-col'
+import { useColsWithActions, type MenuAction } from '~/table/columns/action-col'
 import { useQueryTable2 } from '~/table/QueryTable2'
 import { buttonStyle } from '~/ui/lib/Button'
 import { EmptyMessage } from '~/ui/lib/EmptyMessage'
@@ -158,7 +158,7 @@ export function DisksPage() {
     [addToast, createSnapshot, deleteDisk, project]
   )
 
-  const columns = useMemo(() => [...staticCols, getActionsCol(makeActions)], [makeActions])
+  const columns = useColsWithActions(staticCols, makeActions)
 
   return (
     <>

--- a/app/pages/system/networking/IpPoolsTab.tsx
+++ b/app/pages/system/networking/IpPoolsTab.tsx
@@ -66,6 +66,7 @@ const staticColumns = [
     cell: (props) => <UtilizationCell pool={props.getValue()} />,
   }),
   colHelper.accessor('timeCreated', {
+    header: 'Created',
     cell: (props) => <DateCell value={props.getValue()} />,
   }),
 ]

--- a/app/pages/system/networking/IpPoolsTab.tsx
+++ b/app/pages/system/networking/IpPoolsTab.tsx
@@ -25,7 +25,7 @@ import { confirmDelete } from '~/stores/confirm-delete'
 import { DateCell } from '~/table/cells/DateCell'
 import { defaultCell } from '~/table/cells/DefaultCell'
 import { SkeletonCell } from '~/table/cells/EmptyCell'
-import { LinkCell } from '~/table/cells/LinkCell'
+import { makeLinkCell } from '~/table/cells/LinkCell'
 import { getActionsCol, type MenuAction } from '~/table/columns/action-col'
 import { useQueryTable2 } from '~/table/QueryTable2'
 import { buttonStyle } from '~/ui/lib/Button'
@@ -52,11 +52,7 @@ function UtilizationCell({ pool }: { pool: string }) {
 const colHelper = createColumnHelper<IpPool>()
 
 const staticColumns = [
-  colHelper.accessor('name', {
-    cell: (props) => (
-      <LinkCell to={pb.ipPool({ pool: props.getValue() })}>{props.getValue()}</LinkCell>
-    ),
-  }),
+  colHelper.accessor('name', { cell: makeLinkCell((pool) => pb.ipPool({ pool })) }),
   colHelper.accessor('description', { cell: defaultCell }),
   colHelper.accessor('name', {
     id: 'Utilization',

--- a/app/pages/system/networking/IpPoolsTab.tsx
+++ b/app/pages/system/networking/IpPoolsTab.tsx
@@ -26,7 +26,7 @@ import { DateCell } from '~/table/cells/DateCell'
 import { defaultCell } from '~/table/cells/DefaultCell'
 import { SkeletonCell } from '~/table/cells/EmptyCell'
 import { makeLinkCell } from '~/table/cells/LinkCell'
-import { getActionsCol, type MenuAction } from '~/table/columns/action-col'
+import { useColsWithActions, type MenuAction } from '~/table/columns/action-col'
 import { useQueryTable2 } from '~/table/QueryTable2'
 import { buttonStyle } from '~/ui/lib/Button'
 import { EmptyMessage } from '~/ui/lib/EmptyMessage'
@@ -103,10 +103,7 @@ export function IpPoolsTab() {
     [deletePool, navigate]
   )
 
-  const columns = useMemo(
-    () => [...staticColumns, getActionsCol(makeActions)],
-    [makeActions]
-  )
+  const columns = useColsWithActions(staticColumns, makeActions)
 
   useQuickActions(
     useMemo(

--- a/app/pages/system/networking/IpPoolsTab.tsx
+++ b/app/pages/system/networking/IpPoolsTab.tsx
@@ -23,7 +23,7 @@ import { IpUtilCell } from '~/components/IpPoolUtilization'
 import { useQuickActions } from '~/hooks'
 import { confirmDelete } from '~/stores/confirm-delete'
 import { DateCell } from '~/table/cells/DateCell'
-import { DefaultCell } from '~/table/cells/DefaultCell'
+import { defaultCell } from '~/table/cells/DefaultCell'
 import { SkeletonCell } from '~/table/cells/EmptyCell'
 import { LinkCell } from '~/table/cells/LinkCell'
 import { getActionsCol, type MenuAction } from '~/table/columns/action-col'
@@ -57,9 +57,7 @@ const staticColumns = [
       <LinkCell to={pb.ipPool({ pool: props.getValue() })}>{props.getValue()}</LinkCell>
     ),
   }),
-  colHelper.accessor('description', {
-    cell: (props) => <DefaultCell value={props.getValue()} />,
-  }),
+  colHelper.accessor('description', { cell: defaultCell }),
   colHelper.accessor('name', {
     id: 'Utilization',
     header: 'Utilization',

--- a/app/table/QueryTable2.tsx
+++ b/app/table/QueryTable2.tsx
@@ -1,0 +1,124 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { hashKey, type UseQueryOptions } from '@tanstack/react-query'
+import { getCoreRowModel, useReactTable, type ColumnDef } from '@tanstack/react-table'
+import React, { useCallback, useMemo, type ComponentType } from 'react'
+
+import {
+  useApiQuery,
+  type ApiError,
+  type ApiListMethods,
+  type Params,
+  type Result,
+  type ResultItem,
+} from '@oxide/api'
+
+import { Pagination } from '~/components/Pagination'
+import { usePagination } from '~/hooks/use-pagination'
+import { EmptyMessage } from '~/ui/lib/EmptyMessage'
+import { TableEmptyBox } from '~/ui/lib/Table'
+
+import { Table } from './Table'
+
+interface UseQueryTableResult<Item extends Record<string, unknown>> {
+  Table: ComponentType<QueryTableProps<Item>>
+}
+/**
+ * This hook builds a table that's linked to a given query. It's a combination
+ * of react-query and react-table. It generates a `Table` component that controls
+ * table level options and a `Column` component which governs the individual column
+ * configuration
+ */
+export const useQueryTable2 = <A extends ApiListMethods, M extends keyof A>(
+  query: M,
+  params: Params<A[M]>,
+  options?: Omit<UseQueryOptions<Result<A[M]>, ApiError>, 'queryKey' | 'queryFn'>
+): UseQueryTableResult<ResultItem<A[M]>> => {
+  const Table = useMemo(
+    () => makeQueryTable<ResultItem<A[M]>>(query, params, options),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [query, hashKey(params as any), hashKey(options as any)]
+  )
+
+  return { Table }
+}
+
+type QueryTableProps<Item> = {
+  /** Prints table data in the console when enabled */
+  debug?: boolean
+  /** Function that produces a list of actions from a row item */
+  pagination?: 'inline' | 'page'
+  pageSize?: number
+  emptyState: React.ReactElement
+  columns: ColumnDef<Item, any>[]
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const makeQueryTable = <Item extends Record<string, unknown>>(
+  query: any,
+  params: any,
+  options: any
+): ComponentType<QueryTableProps<Item>> =>
+  function QueryTable({
+    debug,
+    pagination = 'page',
+    pageSize = 25,
+    emptyState,
+    columns,
+  }: QueryTableProps<Item>) {
+    const { currentPage, goToNextPage, goToPrevPage, hasPrev } = usePagination()
+
+    const { data, isLoading } = useApiQuery(
+      query,
+      {
+        path: params.path,
+        query: { ...params.query, page_token: currentPage, limit: pageSize },
+      },
+      options
+    )
+
+    const tableData: any[] = useMemo(() => (data as any)?.items || [], [data])
+
+    const getRowId = useCallback((row: any) => row.name, [])
+
+    const table = useReactTable({
+      columns,
+      data: tableData,
+      getRowId,
+      getCoreRowModel: getCoreRowModel(),
+      manualPagination: true,
+    })
+
+    if (debug) console.table((data as { items?: any[] })?.items || data)
+
+    if (isLoading) return null
+
+    const isEmpty = tableData.length === 0 && !hasPrev
+    if (isEmpty) {
+      return (
+        <TableEmptyBox>{emptyState || <EmptyMessage title="No results" />}</TableEmptyBox>
+      )
+    }
+
+    return (
+      <>
+        <Table table={table} />
+        <Pagination
+          inline={pagination === 'inline'}
+          pageSize={pageSize}
+          hasNext={tableData.length === pageSize}
+          hasPrev={hasPrev}
+          nextPage={(data as any)?.nextPage}
+          onNext={goToNextPage}
+          onPrev={goToPrevPage}
+        />
+      </>
+    )
+  }

--- a/app/table/cells/DefaultCell.tsx
+++ b/app/table/cells/DefaultCell.tsx
@@ -5,8 +5,14 @@
  *
  * Copyright Oxide Computer Company
  */
+import type { CellContext } from '@tanstack/react-table'
+
 import type { Cell } from './Cell'
 
 export const DefaultCell = ({ value }: Cell<string>) => (
   <span className="text-secondary">{value}</span>
+)
+
+export const defaultCell = <T, U extends React.ReactNode>(props: CellContext<T, U>) => (
+  <span className="text-secondary">{props.getValue()}</span>
 )

--- a/app/table/cells/LinkCell.tsx
+++ b/app/table/cells/LinkCell.tsx
@@ -5,6 +5,7 @@
  *
  * Copyright Oxide Computer Company
  */
+import type { CellContext } from '@tanstack/react-table'
 import { Link } from 'react-router-dom'
 
 import { classed } from '~/util/classed'
@@ -20,6 +21,13 @@ const Pusher = classed.div`absolute inset-0 right-px group-hover:bg-raise`
 export const linkCell =
   (makeHref: (value: string) => string) =>
   ({ value }: Cell<string>) => {
+    return <LinkCell to={makeHref(value)}>{value}</LinkCell>
+  }
+
+export const makeLinkCell =
+  (makeHref: (value: string) => string) =>
+  <T, U extends string>(props: CellContext<T, U>) => {
+    const value = props.getValue()
     return <LinkCell to={makeHref(value)}>{value}</LinkCell>
   }
 

--- a/app/table/columns/action-col.tsx
+++ b/app/table/columns/action-col.tsx
@@ -7,6 +7,7 @@
  */
 import type { ColumnDef } from '@tanstack/react-table'
 import cn from 'classnames'
+import { useMemo } from 'react'
 
 import { More12Icon } from '@oxide/design-system/icons/react'
 
@@ -22,6 +23,16 @@ export type MenuAction = {
   onActivate: () => void
   disabled?: false | React.ReactNode
   className?: string
+}
+
+/** Convenience helper to combine regular cols with actions col and memoize */
+export function useColsWithActions<TData extends { id?: string }>(
+  /** Should be static or memoized */
+  columns: ColumnDef<TData, any>[], // eslint-disable-line @typescript-eslint/no-explicit-any
+  /** Must be memoized to avoid re-renders */
+  makeActions: MakeActions<TData>
+) {
+  return useMemo(() => [...columns, getActionsCol(makeActions)], [columns, makeActions])
 }
 
 export const getActionsCol = <TData extends { id?: string }>(

--- a/mock-api/msw/handlers.ts
+++ b/mock-api/msw/handlers.ts
@@ -622,7 +622,7 @@ export const handlers = makeHandlers({
     return json(instance, { status: 202 })
   },
   ipPoolList: ({ query }) => paginated(query, db.ipPools),
-  ipPoolUtilizationView({ path }) {
+  async ipPoolUtilizationView({ path }) {
     const pool = lookup.ipPool(path)
     const ranges = db.ipPoolRanges
       .filter((r) => r.ip_pool_id === pool.id)
@@ -639,6 +639,8 @@ export const handlers = makeHandlers({
 
     const ipv4sInPool = allIps.filter((ip) => ipInAnyRange(ip, ipv4Ranges)).length
     const ipv6sInPool = allIps.filter((ip) => ipInAnyRange(ip, ipv6Ranges)).length
+
+    await delay(3000)
 
     return {
       ipv4: {

--- a/mock-api/msw/handlers.ts
+++ b/mock-api/msw/handlers.ts
@@ -640,8 +640,6 @@ export const handlers = makeHandlers({
     const ipv4sInPool = allIps.filter((ip) => ipInAnyRange(ip, ipv4Ranges)).length
     const ipv6sInPool = allIps.filter((ip) => ipInAnyRange(ip, ipv6Ranges)).length
 
-    await delay(3000)
-
     return {
       ipv4: {
         allocated: ipv4sInPool,

--- a/test/e2e/disks.e2e.ts
+++ b/test/e2e/disks.e2e.ts
@@ -15,16 +15,16 @@ test('List disks and snapshot', async ({ page }) => {
 
   // check one attached and one not attached
   await expectRowVisible(table, {
-    'Attached To': 'db1',
+    'Attached to': 'db1',
     name: 'disk-1',
-    Size: '2 GiB',
-    status: 'attached',
+    size: '2 GiB',
+    Status: 'attached',
   })
   await expectRowVisible(table, {
-    'Attached To': '',
+    'Attached to': '',
     name: 'disk-3',
-    Size: '6 GiB',
-    status: 'detached',
+    size: '6 GiB',
+    Status: 'detached',
   })
 
   await clickRowAction(page, 'disk-1 db1', 'Snapshot')

--- a/test/e2e/ip-pools.e2e.ts
+++ b/test/e2e/ip-pools.e2e.ts
@@ -49,6 +49,9 @@ test('IP pool silo list', async ({ page }) => {
   const siloLink = page.getByRole('link', { name: 'maze-war' })
   await siloLink.click()
   await expect(page).toHaveURL('/system/silos/maze-war?tab=ip-pools')
+  // these asserts are mostly here to kill some time before goBack
+  await expectRowVisible(table, { name: 'ip-pool-1', Default: 'default' })
+  await expectRowVisible(table, { name: 'ip-pool-2' })
   await page.goBack()
 
   // unlink silo and the row is gone


### PR DESCRIPTION
Closes #2107
Supersedes #2109

In #2109 I had a big outstanding mystery:

> **Unsolved:** why does unmount happen before the loader is complete? Page transition should only happen after loader is done.

To investigate, I tried to reproduce the #2107 problem on StackBlitz with a very minimal setup:

* https://stackblitz.com/edit/vitejs-vite-l4jbyr?file=src%2Fmain.tsx&terminal=dev
* https://stackblitz.com/edit/vitejs-vite-59zkej?file=src%2Fmain.tsx&terminal=dev

But it did not have the issue, so I had to go back to our code and ask myself what we're doing to cause it. The breakthrough came when I replaced the IP pools table with this and the problem went away.

```tsx
<Link to={pb.ipPool({ pool: 'ip-pool-1' })}>ip-pool-1</Link>
<UtilizationCell pool="ip-pool-1" />
```

So most likely it was `QueryTable` causing the `UtilizationCell` to unmount and remount at a weird time. Then I remembered: `QueryTable` is full of shenanigans, it would totally do that. The culprit was my least favorite part of `QueryTable`:

https://github.com/oxidecomputer/console/blob/44c646f973ce9951c2819165582f0db0eb6abee0/app/table/QueryTable.tsx#L132-L167

Turning `QueryTable` inside out and getting rid of all the `any` bits has been a long-term goal of mine, but it is pretty hard to untangle. What hadn't occurred to me until now is that we can pretty easily stop doing the `columns` part altogether, passing in a native React Table `columns` array as a prop instead of doing the `<Column />` business.

So in this PR, I've introduced `useQueryTable2`, which is the same as `useQueryTable` but with the bad `columns` thing deleted.

I think we should convert all existing `useQueryTable` calls to `useQueryTable2`, then delete the original and rename `useQueryTable2` back to `useQueryTable`. There are 21 `useQueryTable` calls (not including the IP pools one I changed here), and some will be pretty involved, so we probably don't want to do them all in one PR.