### PR TITLE
Wrap all the `makeActions` functions in `useCallback`

### DIFF
--- a/app/pages/ProjectsPage.tsx
+++ b/app/pages/ProjectsPage.tsx
@@ -5,7 +5,7 @@
  *
  * Copyright Oxide Computer Company
  */
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { Link, Outlet, useNavigate } from 'react-router-dom'
 
 import {
@@ -62,28 +62,31 @@ export function ProjectsPage() {
     },
   })
 
-  const makeActions = (project: Project): MenuAction[] => [
-    {
-      label: 'Edit',
-      onActivate: () => {
-        // the edit view has its own loader, but we can make the modal open
-        // instantaneously by preloading the fetch result
-        apiQueryClient.setQueryData(
-          'projectView',
-          { path: { project: project.name } },
-          project
-        )
-        navigate(pb.projectEdit({ project: project.name }))
+  const makeActions = useCallback(
+    (project: Project): MenuAction[] => [
+      {
+        label: 'Edit',
+        onActivate: () => {
+          // the edit view has its own loader, but we can make the modal open
+          // instantaneously by preloading the fetch result
+          apiQueryClient.setQueryData(
+            'projectView',
+            { path: { project: project.name } },
+            project
+          )
+          navigate(pb.projectEdit({ project: project.name }))
+        },
       },
-    },
-    {
-      label: 'Delete',
-      onActivate: confirmDelete({
-        doDelete: () => deleteProject.mutateAsync({ path: { project: project.name } }),
-        label: project.name,
-      }),
-    },
-  ]
+      {
+        label: 'Delete',
+        onActivate: confirmDelete({
+          doDelete: () => deleteProject.mutateAsync({ path: { project: project.name } }),
+          label: project.name,
+        }),
+      },
+    ],
+    [deleteProject, navigate]
+  )
 
   useQuickActions(
     useMemo(

--- a/app/pages/project/disks/DisksPage.tsx
+++ b/app/pages/project/disks/DisksPage.tsx
@@ -26,7 +26,7 @@ import { DateCell } from '~/table/cells/DateCell'
 import { InstanceLinkCell } from '~/table/cells/InstanceLinkCell'
 import { SizeCell } from '~/table/cells/SizeCell'
 import { useColsWithActions, type MenuAction } from '~/table/columns/action-col'
-import { useQueryTable2 } from '~/table/QueryTable2'
+import { useQueryTable } from '~/table/QueryTable2'
 import { buttonStyle } from '~/ui/lib/Button'
 import { EmptyMessage } from '~/ui/lib/EmptyMessage'
 import { PageHeader, PageTitle } from '~/ui/lib/PageHeader'
@@ -97,7 +97,7 @@ const staticCols = [
 export function DisksPage() {
   const queryClient = useApiQueryClient()
   const { project } = useProjectSelector()
-  const { Table } = useQueryTable2('diskList', { query: { project } })
+  const { Table } = useQueryTable('diskList', { query: { project } })
   const addToast = useToast()
 
   const deleteDisk = useApiMutation('diskDelete', {

--- a/app/pages/project/floating-ips/FloatingIpsPage.tsx
+++ b/app/pages/project/floating-ips/FloatingIpsPage.tsx
@@ -29,7 +29,7 @@ import { addToast } from '~/stores/toast'
 import { InstanceLinkCell } from '~/table/cells/InstanceLinkCell'
 import { makeLinkCell } from '~/table/cells/LinkCell'
 import { useColsWithActions, type MenuAction } from '~/table/columns/action-col'
-import { useQueryTable2 } from '~/table/QueryTable2'
+import { useQueryTable } from '~/table/QueryTable2'
 import { EmptyMessage } from '~/ui/lib/EmptyMessage'
 import { Listbox } from '~/ui/lib/Listbox'
 import { Message } from '~/ui/lib/Message'
@@ -180,7 +180,7 @@ export function FloatingIpsPage() {
     [deleteFloatingIp, floatingIpDetach, navigate, project, instances]
   )
 
-  const { Table } = useQueryTable2('floatingIpList', { query: { project } })
+  const { Table } = useQueryTable('floatingIpList', { query: { project } })
 
   const columns = useColsWithActions(staticCols, makeActions)
 

--- a/app/pages/project/images/ImagesPage.tsx
+++ b/app/pages/project/images/ImagesPage.tsx
@@ -5,7 +5,7 @@
  *
  * Copyright Oxide Computer Company
  */
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import { Link, Outlet, type LoaderFunctionArgs } from 'react-router-dom'
 
 import { apiQueryClient, useApiMutation, useApiQueryClient, type Image } from '@oxide/api'
@@ -59,20 +59,26 @@ export function ImagesPage() {
     },
   })
 
-  const makeActions = (image: Image): MenuAction[] => [
-    {
-      label: 'Promote',
-      onActivate: () => setPromoteImageName(image.name),
-    },
-    {
-      label: 'Delete',
-      onActivate: confirmDelete({
-        doDelete: () =>
-          deleteImage.mutateAsync({ path: { image: image.name }, query: projectSelector }),
-        label: image.name,
-      }),
-    },
-  ]
+  const makeActions = useCallback(
+    (image: Image): MenuAction[] => [
+      {
+        label: 'Promote',
+        onActivate: () => setPromoteImageName(image.name),
+      },
+      {
+        label: 'Delete',
+        onActivate: confirmDelete({
+          doDelete: () =>
+            deleteImage.mutateAsync({
+              path: { image: image.name },
+              query: projectSelector,
+            }),
+          label: image.name,
+        }),
+      },
+    ],
+    [deleteImage, projectSelector]
+  )
 
   return (
     <>

--- a/app/pages/project/vpcs/VpcPage/tabs/VpcSubnetsTab.tsx
+++ b/app/pages/project/vpcs/VpcPage/tabs/VpcSubnetsTab.tsx
@@ -5,7 +5,7 @@
  *
  * Copyright Oxide Computer Company
  */
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 
 import { useApiMutation, useApiQueryClient, type VpcSubnet } from '@oxide/api'
 
@@ -34,20 +34,23 @@ export const VpcSubnetsTab = () => {
     },
   })
 
-  const makeActions = (subnet: VpcSubnet): MenuAction[] => [
-    {
-      label: 'Edit',
-      onActivate: () => setEditing(subnet),
-    },
-    // TODO: only show if you have permission to do this
-    {
-      label: 'Delete',
-      onActivate: confirmDelete({
-        doDelete: () => deleteSubnet.mutateAsync({ path: { subnet: subnet.id } }),
-        label: subnet.name,
-      }),
-    },
-  ]
+  const makeActions = useCallback(
+    (subnet: VpcSubnet): MenuAction[] => [
+      {
+        label: 'Edit',
+        onActivate: () => setEditing(subnet),
+      },
+      // TODO: only show if you have permission to do this
+      {
+        label: 'Delete',
+        onActivate: confirmDelete({
+          doDelete: () => deleteSubnet.mutateAsync({ path: { subnet: subnet.id } }),
+          label: subnet.name,
+        }),
+      },
+    ],
+    [deleteSubnet]
+  )
 
   const emptyState = (
     <EmptyMessage

--- a/app/pages/settings/SSHKeysPage.tsx
+++ b/app/pages/settings/SSHKeysPage.tsx
@@ -5,6 +5,7 @@
  *
  * Copyright Oxide Computer Company
  */
+import { useCallback } from 'react'
 import { Link, Outlet, useNavigate } from 'react-router-dom'
 
 import { apiQueryClient, useApiMutation, useApiQueryClient, type SshKey } from '@oxide/api'
@@ -37,15 +38,18 @@ export function SSHKeysPage() {
     },
   })
 
-  const makeActions = (sshKey: SshKey): MenuAction[] => [
-    {
-      label: 'Delete',
-      onActivate: confirmDelete({
-        doDelete: () => deleteSshKey.mutateAsync({ path: { sshKey: sshKey.name } }),
-        label: sshKey.name,
-      }),
-    },
-  ]
+  const makeActions = useCallback(
+    (sshKey: SshKey): MenuAction[] => [
+      {
+        label: 'Delete',
+        onActivate: confirmDelete({
+          doDelete: () => deleteSshKey.mutateAsync({ path: { sshKey: sshKey.name } }),
+          label: sshKey.name,
+        }),
+      },
+    ],
+    [deleteSshKey]
+  )
 
   return (
     <>

--- a/app/pages/system/SiloImagesPage.tsx
+++ b/app/pages/system/SiloImagesPage.tsx
@@ -5,7 +5,7 @@
  *
  * Copyright Oxide Computer Company
  */
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { type FieldValues } from 'react-hook-form'
 import { Outlet } from 'react-router-dom'
 
@@ -65,19 +65,22 @@ export function SiloImagesPage() {
     },
   })
 
-  const makeActions = (image: Image): MenuAction[] => [
-    {
-      label: 'Demote',
-      onActivate: () => setDemoteImage(image),
-    },
-    {
-      label: 'Delete',
-      onActivate: confirmDelete({
-        doDelete: () => deleteImage.mutateAsync({ path: { image: image.name } }),
-        label: image.name,
-      }),
-    },
-  ]
+  const makeActions = useCallback(
+    (image: Image): MenuAction[] => [
+      {
+        label: 'Demote',
+        onActivate: () => setDemoteImage(image),
+      },
+      {
+        label: 'Delete',
+        onActivate: confirmDelete({
+          doDelete: () => deleteImage.mutateAsync({ path: { image: image.name } }),
+          label: image.name,
+        }),
+      },
+    ],
+    [deleteImage]
+  )
 
   return (
     <>

--- a/app/pages/system/inventory/sled/SledInstancesTab.tsx
+++ b/app/pages/system/inventory/sled/SledInstancesTab.tsx
@@ -38,6 +38,9 @@ SledInstancesTab.loader = async ({ params }: LoaderFunctionArgs) => {
   return null
 }
 
+// passing in empty function because we still want the copy ID button
+const makeActions = (): MenuAction[] => []
+
 export function SledInstancesTab() {
   const { sledId } = useSledParams()
   const { Table, Column } = useQueryTable(
@@ -45,8 +48,6 @@ export function SledInstancesTab() {
     { path: { sledId }, query: { limit: 25 } },
     { placeholderData: (x) => x }
   )
-
-  const makeActions = (): MenuAction[] => []
 
   return (
     <Table emptyState={<EmptyState />} makeActions={makeActions}>

--- a/app/pages/system/networking/IpPoolPage.tsx
+++ b/app/pages/system/networking/IpPoolPage.tsx
@@ -6,7 +6,7 @@
  * Copyright Oxide Computer Company
  */
 
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { Link, Outlet, type LoaderFunctionArgs } from 'react-router-dom'
 
 import {
@@ -161,32 +161,35 @@ function IpRangesTable() {
     />
   )
 
-  const makeRangeActions = ({ range }: IpPoolRange): MenuAction[] => [
-    {
-      label: 'Remove',
-      className: 'destructive',
-      onActivate: () =>
-        confirmAction({
-          doAction: () =>
-            removeRange.mutateAsync({
-              path: { pool },
-              body: range,
-            }),
-          errorTitle: 'Could not remove range',
-          modalTitle: 'Confirm remove range',
-          modalContent: (
-            <p>
-              Are you sure you want to remove range{' '}
-              <HL>
-                {range.first}&ndash;{range.last}
-              </HL>{' '}
-              from the pool? This will fail if the range has any addresses in use.
-            </p>
-          ),
-          actionType: 'danger',
-        }),
-    },
-  ]
+  const makeRangeActions = useCallback(
+    ({ range }: IpPoolRange): MenuAction[] => [
+      {
+        label: 'Remove',
+        className: 'destructive',
+        onActivate: () =>
+          confirmAction({
+            doAction: () =>
+              removeRange.mutateAsync({
+                path: { pool },
+                body: range,
+              }),
+            errorTitle: 'Could not remove range',
+            modalTitle: 'Confirm remove range',
+            modalContent: (
+              <p>
+                Are you sure you want to remove range{' '}
+                <HL>
+                  {range.first}&ndash;{range.last}
+                </HL>{' '}
+                from the pool? This will fail if the range has any addresses in use.
+              </p>
+            ),
+            actionType: 'danger',
+          }),
+      },
+    ],
+    [pool, removeRange]
+  )
 
   return (
     <>
@@ -223,33 +226,36 @@ function LinkedSilosTable() {
     },
   })
 
-  const makeActions = (link: IpPoolSiloLink): MenuAction[] => [
-    {
-      label: 'Unlink',
-      className: 'destructive',
-      onActivate() {
-        confirmAction({
-          doAction: () =>
-            unlinkSilo.mutateAsync({ path: { silo: link.siloId, pool: link.ipPoolId } }),
-          modalTitle: 'Confirm unlink silo',
-          // Would be nice to reference the silo by name like we reference the
-          // pool by name on unlink in the silo pools list, but it's a pain to
-          // get the name here. Could use useQueries to get all the names, and
-          // RQ would dedupe the requests since they're already being fetched
-          // for the table. Not worth it right now.
-          modalContent: (
-            <p>
-              Are you sure you want to unlink the silo? Users in this silo will no longer be
-              able to allocate IPs from this pool. Unlink will fail if there are any IPs
-              from the pool in use in this silo.
-            </p>
-          ),
-          errorTitle: 'Could not unlink silo',
-          actionType: 'danger',
-        })
+  const makeActions = useCallback(
+    (link: IpPoolSiloLink): MenuAction[] => [
+      {
+        label: 'Unlink',
+        className: 'destructive',
+        onActivate() {
+          confirmAction({
+            doAction: () =>
+              unlinkSilo.mutateAsync({ path: { silo: link.siloId, pool: link.ipPoolId } }),
+            modalTitle: 'Confirm unlink silo',
+            // Would be nice to reference the silo by name like we reference the
+            // pool by name on unlink in the silo pools list, but it's a pain to
+            // get the name here. Could use useQueries to get all the names, and
+            // RQ would dedupe the requests since they're already being fetched
+            // for the table. Not worth it right now.
+            modalContent: (
+              <p>
+                Are you sure you want to unlink the silo? Users in this silo will no longer
+                be able to allocate IPs from this pool. Unlink will fail if there are any
+                IPs from the pool in use in this silo.
+              </p>
+            ),
+            errorTitle: 'Could not unlink silo',
+            actionType: 'danger',
+          })
+        },
       },
-    },
-  ]
+    ],
+    [unlinkSilo]
+  )
 
   const [showLinkModal, setShowLinkModal] = useState(false)
 

--- a/app/pages/system/networking/IpPoolsTab.tsx
+++ b/app/pages/system/networking/IpPoolsTab.tsx
@@ -26,7 +26,7 @@ import { DateCell } from '~/table/cells/DateCell'
 import { SkeletonCell } from '~/table/cells/EmptyCell'
 import { makeLinkCell } from '~/table/cells/LinkCell'
 import { useColsWithActions, type MenuAction } from '~/table/columns/action-col'
-import { useQueryTable2 } from '~/table/QueryTable2'
+import { useQueryTable } from '~/table/QueryTable2'
 import { buttonStyle } from '~/ui/lib/Button'
 import { EmptyMessage } from '~/ui/lib/EmptyMessage'
 import { pb } from '~/util/path-builder'
@@ -71,7 +71,7 @@ IpPoolsTab.loader = async function () {
 
 export function IpPoolsTab() {
   const navigate = useNavigate()
-  const { Table } = useQueryTable2('ipPoolList', {})
+  const { Table } = useQueryTable('ipPoolList', {})
   const { data: pools } = usePrefetchedApiQuery('ipPoolList', { query: { limit: 25 } })
 
   const deletePool = useApiMutation('ipPoolDelete', {

--- a/app/pages/system/silos/SiloIpPoolsTab.tsx
+++ b/app/pages/system/silos/SiloIpPoolsTab.tsx
@@ -20,7 +20,7 @@ import { confirmAction } from '~/stores/confirm-action'
 import { addToast } from '~/stores/toast'
 import { makeLinkCell } from '~/table/cells/LinkCell'
 import { useColsWithActions, type MenuAction } from '~/table/columns/action-col'
-import { useQueryTable2 } from '~/table/QueryTable2'
+import { useQueryTable } from '~/table/QueryTable2'
 import { Badge } from '~/ui/lib/Badge'
 import { EmptyMessage } from '~/ui/lib/EmptyMessage'
 import { Message } from '~/ui/lib/Message'
@@ -60,7 +60,7 @@ const staticCols = [
 export function SiloIpPoolsTab() {
   const { silo } = useSiloSelector()
   const [showLinkModal, setShowLinkModal] = useState(false)
-  const { Table } = useQueryTable2('siloIpPoolList', { path: { silo } })
+  const { Table } = useQueryTable('siloIpPoolList', { path: { silo } })
   const queryClient = useApiQueryClient()
 
   // Fetch 1000 to we can be sure to get them all. There should only be a few

--- a/app/pages/system/silos/SilosPage.tsx
+++ b/app/pages/system/silos/SilosPage.tsx
@@ -5,7 +5,7 @@
  *
  * Copyright Oxide Computer Company
  */
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { Link, Outlet, useNavigate } from 'react-router-dom'
 
 import {
@@ -62,15 +62,18 @@ export function SilosPage() {
     },
   })
 
-  const makeActions = (silo: Silo): MenuAction[] => [
-    {
-      label: 'Delete',
-      onActivate: confirmDelete({
-        doDelete: () => deleteSilo.mutateAsync({ path: { silo: silo.name } }),
-        label: silo.name,
-      }),
-    },
-  ]
+  const makeActions = useCallback(
+    (silo: Silo): MenuAction[] => [
+      {
+        label: 'Delete',
+        onActivate: confirmDelete({
+          doDelete: () => deleteSilo.mutateAsync({ path: { silo: silo.name } }),
+          label: silo.name,
+        }),
+      },
+    ],
+    [deleteSilo]
+  )
 
   useQuickActions(
     useMemo(

--- a/app/table/QueryTable2.tsx
+++ b/app/table/QueryTable2.tsx
@@ -36,7 +36,7 @@ interface UseQueryTableResult<Item extends Record<string, unknown>> {
  * table level options and a `Column` component which governs the individual column
  * configuration
  */
-export const useQueryTable2 = <A extends ApiListMethods, M extends keyof A>(
+export const useQueryTable = <A extends ApiListMethods, M extends keyof A>(
   query: M,
   params: Params<A[M]>,
   options?: Omit<UseQueryOptions<Result<A[M]>, ApiError>, 'queryKey' | 'queryFn'>


### PR DESCRIPTION
This is a very noisy but empty change, so we're pulling it out, so the rest of our `useQueryTable` conversions will not be as noisy as #2111.