### PR TITLE
Timeouts on individual image upload chunk POSTs

### DIFF
--- a/app/api/hooks.ts
+++ b/app/api/hooks.ts
@@ -23,6 +23,7 @@ import { type SetNonNullable } from 'type-fest'
 import { invariant } from '~/util/invariant'
 
 import type { ApiResult } from './__generated__/Api'
+import { type FetchParams } from './__generated__/http-client'
 import { processServerError, type ApiError } from './errors'
 import { navToLogin } from './nav-to-login'
 
@@ -199,10 +200,11 @@ export const getUseApiMutation =
   <A extends ApiClient>(api: A) =>
   <M extends string & keyof A>(
     method: M,
-    options?: Omit<UseMutationOptions<Result<A[M]>, ApiError, Params<A[M]>>, 'mutationFn'>
+    options?: Omit<UseMutationOptions<Result<A[M]>, ApiError, Params<A[M]>>, 'mutationFn'>,
+    fetchParams?: FetchParams
   ) =>
     useMutation({
-      mutationFn: (params) => api[method](params).then(handleResult(method)),
+      mutationFn: (params) => api[method](params, fetchParams).then(handleResult(method)),
       // no catch, let unexpected errors bubble up
       ...options,
     })

--- a/app/api/hooks.ts
+++ b/app/api/hooks.ts
@@ -23,7 +23,6 @@ import { type SetNonNullable } from 'type-fest'
 import { invariant } from '~/util/invariant'
 
 import type { ApiResult } from './__generated__/Api'
-import { type FetchParams } from './__generated__/http-client'
 import { processServerError, type ApiError } from './errors'
 import { navToLogin } from './nav-to-login'
 
@@ -200,11 +199,14 @@ export const getUseApiMutation =
   <A extends ApiClient>(api: A) =>
   <M extends string & keyof A>(
     method: M,
-    options?: Omit<UseMutationOptions<Result<A[M]>, ApiError, Params<A[M]>>, 'mutationFn'>,
-    fetchParams?: FetchParams
+    options?: Omit<
+      UseMutationOptions<Result<A[M]>, ApiError, Params<A[M]> & { signal?: AbortSignal }>,
+      'mutationFn'
+    >
   ) =>
     useMutation({
-      mutationFn: (params) => api[method](params, fetchParams).then(handleResult(method)),
+      mutationFn: ({ signal, ...params }) =>
+        api[method](params, { signal }).then(handleResult(method)),
       // no catch, let unexpected errors bubble up
       ...options,
     })

--- a/app/forms/image-upload.tsx
+++ b/app/forms/image-upload.tsx
@@ -215,11 +215,8 @@ export function CreateImageSideModalForm() {
   const uploadChunk = useApiMutation(
     'diskBulkWriteImport',
     {},
-    {
-      // AbortSignal.any is too new, just came out in FF and Safar:
-      // https://caniuse.com/mdn-api_abortsignal_any_static
-      signal: anySignal([AbortSignal.timeout(5000), abortController.current?.signal]),
-    }
+    // use both the general abort signal for the whole process and a per-request timeout
+    { signal: anySignal([AbortSignal.timeout(30000), abortController.current?.signal]) }
   )
 
   // synthetic state for upload step because it consists of multiple requests

--- a/app/forms/image-upload.tsx
+++ b/app/forms/image-upload.tsx
@@ -37,6 +37,7 @@ import { Message } from '~/ui/lib/Message'
 import { Modal } from '~/ui/lib/Modal'
 import { Progress } from '~/ui/lib/Progress'
 import { Spinner } from '~/ui/lib/Spinner'
+import { anySignal } from '~/util/abort'
 import { readBlobAsBase64 } from '~/util/file'
 import { invariant } from '~/util/invariant'
 import { pb } from '~/util/path-builder'
@@ -211,7 +212,15 @@ export function CreateImageSideModalForm() {
 
   const createDisk = useApiMutation('diskCreate')
   const startImport = useApiMutation('diskBulkWriteImportStart')
-  const uploadChunk = useApiMutation('diskBulkWriteImport')
+  const uploadChunk = useApiMutation(
+    'diskBulkWriteImport',
+    {},
+    {
+      // AbortSignal.any is too new, just came out in FF and Safar:
+      // https://caniuse.com/mdn-api_abortsignal_any_static
+      signal: anySignal([AbortSignal.timeout(5000), abortController.current?.signal]),
+    }
+  )
 
   // synthetic state for upload step because it consists of multiple requests
   const [syntheticUploadState, setSyntheticUploadState] =

--- a/app/util/abort.ts
+++ b/app/util/abort.ts
@@ -1,0 +1,37 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
+ */
+
+/**
+ * Combine multiple abort signals into one.
+ *
+ * Borrowed from: https://github.com/whatwg/fetch/issues/905#issuecomment-1816547024
+ *
+ * Can be replaced by AbortSignal.any once browser support improves. It is in
+ * all major browsers as of March 2024.
+ * https://caniuse.com/mdn-api_abortsignal_any_static
+ */
+export function anySignal(signals: Array<AbortSignal | undefined>): AbortSignal {
+  const controller = new AbortController()
+
+  for (const signal of signals) {
+    if (!signal) continue
+
+    // if any are already aborted, abort
+    if (signal.aborted) {
+      controller.abort(signal.reason)
+      return controller.signal
+    }
+
+    signal.addEventListener('abort', () => controller.abort(signal.reason), {
+      once: true,
+      signal: controller.signal,
+    })
+  }
+
+  return controller.signal
+}

--- a/mock-api/msw/handlers.ts
+++ b/mock-api/msw/handlers.ts
@@ -50,6 +50,8 @@ import {
 // client camel-cases the keys and parses date fields. Inside the mock API everything
 // is *JSON type.
 
+let hung = false
+
 export const handlers = makeHandlers({
   ping: () => ({ status: 'ok' }),
   deviceAuthRequest: () => 200,
@@ -192,11 +194,15 @@ export const handlers = makeHandlers({
     disk.state = { state: 'import_ready' }
     return 204
   },
-  diskBulkWriteImport: ({ path, query, body }) => {
+  async diskBulkWriteImport({ path, query, body }) {
     const disk = lookup.disk({ ...path, ...query })
     const diskImport = db.diskBulkImportState.get(disk.id)
     if (!diskImport) throw notFoundErr
     // if (Math.random() < 0.01) throw 400
+    if (body.offset === 5242880 && !hung) {
+      hung = true
+      await delay(30000)
+    }
     diskImport.blocks[body.offset] = true
     return 204
   },

--- a/mock-api/msw/handlers.ts
+++ b/mock-api/msw/handlers.ts
@@ -50,8 +50,6 @@ import {
 // client camel-cases the keys and parses date fields. Inside the mock API everything
 // is *JSON type.
 
-let hung = false
-
 export const handlers = makeHandlers({
   ping: () => ({ status: 'ok' }),
   deviceAuthRequest: () => 200,
@@ -194,15 +192,11 @@ export const handlers = makeHandlers({
     disk.state = { state: 'import_ready' }
     return 204
   },
-  async diskBulkWriteImport({ path, query, body }) {
+  diskBulkWriteImport: ({ path, query, body }) => {
     const disk = lookup.disk({ ...path, ...query })
     const diskImport = db.diskBulkImportState.get(disk.id)
     if (!diskImport) throw notFoundErr
     // if (Math.random() < 0.01) throw 400
-    if (body.offset === 5242880 && !hung) {
-      hung = true
-      await delay(30000)
-    }
     diskImport.blocks[body.offset] = true
     return 204
   },


### PR DESCRIPTION
I forgot who suggested this, but it's such a good idea it seems obvious in hindsight. I'm not 100% sure whether we're still seeing the image upload hang from #1469 and #3559 — I think we are, occasionally. Having requests time out after some relatively long amount of time might mitigate the issue entirely.

The first commit here uses a timeout of 5 seconds and simulates a hang of 30 seconds in the mock API handler. With the timeout change commented out, the test fails. With the timeout change in, it passes.

This PR also improves something irrespective of hanging requests: before this PR, when the image upload is canceled, any outstanding chunk POSTs are allowed to finish. Here we pass that abort signal to every request, which means they get canceled immediately when the overall upload is canceled.