### PR TITLE
Regen TS client with response on `ApiResult`

### DIFF
--- a/app/api/__tests__/errors.spec.ts
+++ b/app/api/__tests__/errors.spec.ts
@@ -23,21 +23,19 @@ describe('getParseError', () => {
 
 describe('processServerError', () => {
   const makeError = ({
-    statusCode = 400,
+    status = 400,
     errorCode = 'ObjectAlreadyExists',
     message = 'already exists: instance "instance-name"',
   } = {}) => ({
     type: 'error' as const,
-    statusCode,
-    headers: new Headers(),
+    response: new Response(undefined, { status }),
     data: { requestId: '2', errorCode, message },
   })
 
   it('extracts message from parse errors', () => {
     const parseError = {
       type: 'error' as const,
-      statusCode: 400,
-      headers: new Headers(),
+      response: new Response(undefined, { status: 400 }),
       data: {
         requestId: '1',
         message: 'unable to parse JSON body: hi, you have an error at line 129 column 4',
@@ -53,8 +51,7 @@ describe('processServerError', () => {
   it('handles client errors', () => {
     const clientError = {
       type: 'client_error' as const,
-      statusCode: 200,
-      headers: new Headers(),
+      response: new Response(undefined, { status: 200 }),
       text: 'this was not json',
       error: new Error('failed to parse JSON'),
     }
@@ -88,7 +85,7 @@ describe('processServerError', () => {
       const error = makeError({
         errorCode: 'ObjectNotFound',
         message: 'not found: whatever',
-        statusCode: 404,
+        status: 404,
       })
       expect(processServerError('fakeThingCreate', error)).toEqual({
         errorCode: 'ObjectNotFound',

--- a/app/api/errors.ts
+++ b/app/api/errors.ts
@@ -46,7 +46,7 @@ export function processServerError(method: string, resp: ErrorResult): ApiError 
     if (process.env.NODE_ENV !== 'test') console.error(resp)
     return {
       message: 'Error reading API response',
-      statusCode: resp.statusCode,
+      statusCode: resp.response.status,
     }
   }
 
@@ -76,7 +76,7 @@ export function processServerError(method: string, resp: ErrorResult): ApiError 
   return {
     message,
     errorCode: resp.data.errorCode || undefined,
-    statusCode: resp.statusCode,
+    statusCode: resp.response.status,
   }
 }
 

--- a/app/api/hooks.ts
+++ b/app/api/hooks.ts
@@ -51,7 +51,7 @@ const handleResult =
 
     // if logged out, hit /login to trigger login redirect
     // Exception: 401 on password login POST needs to be handled in-page
-    if (result.statusCode === 401 && method !== 'loginLocal') {
+    if (result.response.status === 401 && method !== 'loginLocal') {
       // TODO-usability: for background requests, a redirect to login without
       // warning could come as a surprise to the user, especially because
       // sometimes background requests are not directly triggered by a user


### PR DESCRIPTION
See https://github.com/oxidecomputer/oxide.ts/pull/239

I have another WIP that wants the URL from the response, so instead of adding a URL field to `ApiResult`, I realized I should just include the whole response and stop manually pulling out status and headers.