### PR TITLE
Error toasts last 15s instead of 5s, log error info to console

### DIFF
--- a/app/api/__tests__/errors.spec.ts
+++ b/app/api/__tests__/errors.spec.ts
@@ -45,6 +45,8 @@ describe('processServerError', () => {
       code: undefined,
       message: 'Hi, you have an error',
       statusCode: 400,
+      errorCode: undefined,
+      requestId: '1',
     })
   })
 
@@ -67,6 +69,7 @@ describe('processServerError', () => {
         errorCode: 'ObjectAlreadyExists',
         message: 'Instance name already exists',
         statusCode: 400,
+        requestId: '2',
       })
     })
 
@@ -76,6 +79,7 @@ describe('processServerError', () => {
         errorCode: 'ObjectAlreadyExists',
         message: 'Thing name already exists',
         statusCode: 400,
+        requestId: '2',
       })
     })
   })
@@ -91,6 +95,7 @@ describe('processServerError', () => {
         errorCode: 'ObjectNotFound',
         message: 'Not found: whatever',
         statusCode: 404,
+        requestId: '2',
       })
     })
   })
@@ -101,6 +106,7 @@ describe('processServerError', () => {
       errorCode: 'WeirdError',
       message: 'Whatever',
       statusCode: 400,
+      requestId: '2',
     })
   })
 })

--- a/app/api/errors.ts
+++ b/app/api/errors.ts
@@ -18,6 +18,7 @@ export type ApiError = {
   message: string
   errorCode?: string
   statusCode?: number
+  requestId?: string
 }
 
 /**
@@ -45,6 +46,7 @@ export function processServerError(method: string, resp: ErrorResult): ApiError 
     return {
       message: 'Error reading API response',
       statusCode: resp.response.status,
+      requestId: undefined,
     }
   }
 
@@ -75,6 +77,7 @@ export function processServerError(method: string, resp: ErrorResult): ApiError 
     message,
     errorCode: resp.data.errorCode || undefined,
     statusCode: resp.response.status,
+    requestId: resp.data.requestId,
   }
 }
 

--- a/app/api/errors.ts
+++ b/app/api/errors.ts
@@ -42,8 +42,6 @@ export function processServerError(method: string, resp: ErrorResult): ApiError 
   // client error is a JSON parse or processing error and is highly unlikely to
   // be end-user readable
   if (resp.type === 'client_error') {
-    // nice to log but don't clutter test output
-    if (process.env.NODE_ENV !== 'test') console.error(resp)
     return {
       message: 'Error reading API response',
       statusCode: resp.response.status,

--- a/app/api/hooks.ts
+++ b/app/api/hooks.ts
@@ -58,8 +58,29 @@ const handleResult =
       // action, e.g., polling or refetching when window regains focus
       navToLogin({ includeCurrent: true })
     }
+
+    const error = processServerError(method, result)
+
+    // log to the console so it's there in case they open the dev tools, unlike
+    // network tab, which only records if dev tools are already open. but don't
+    // clutter test output
+    if (process.env.NODE_ENV !== 'test') {
+      const consolePage = window.location.pathname + window.location.search
+      // TODO: need to change oxide.ts to put the HTTP method on the result in
+      // order to log it here
+      // TODO: also add request ID to oxide.ts and show it here
+      console.error(
+        `More info about API ${error.statusCode || 'error'} on ${consolePage}
+
+API URL:       ${result.response.url}
+Error code:    ${error.errorCode}
+Error message: ${error.message}
+`
+      )
+    }
+
     // we need to rethrow because that's how react-query knows it's an error
-    throw processServerError(method, result)
+    throw error
   }
 
 /**

--- a/app/api/hooks.ts
+++ b/app/api/hooks.ts
@@ -68,11 +68,11 @@ const handleResult =
       const consolePage = window.location.pathname + window.location.search
       // TODO: need to change oxide.ts to put the HTTP method on the result in
       // order to log it here
-      // TODO: also add request ID to oxide.ts and show it here
       console.error(
         `More info about API ${error.statusCode || 'error'} on ${consolePage}
 
 API URL:       ${result.response.url}
+Request ID:    ${error.requestId}
 Error code:    ${error.errorCode}
 Error message: ${error.message}
 `

--- a/app/ui/lib/Toast.tsx
+++ b/app/ui/lib/Toast.tsx
@@ -75,9 +75,11 @@ export const Toast = ({
   content,
   onClose,
   variant = 'success',
-  timeout = 5000,
+  timeout: timeoutArg,
   cta,
 }: ToastProps) => {
+  const defaultTimeout = variant === 'error' ? 15000 : 5000
+  const timeout = timeoutArg === undefined ? defaultTimeout : timeoutArg
   // TODO: consider assertive announce for error toasts
   useEffect(
     () => announce((title || defaultTitle[variant]) + ' ' + content, 'polite'),

--- a/mock-api/msw/util.ts
+++ b/mock-api/msw/util.ts
@@ -93,7 +93,7 @@ export function getTimestamps() {
 }
 
 export const unavailableErr = () =>
-  json({ error_code: 'ServiceUnavailable' }, { status: 503 })
+  json({ error_code: 'ServiceUnavailable', request_id: 'fake-id' }, { status: 503 })
 
 export const NotImplemented = () => {
   // This doesn't just return the response because it broadens the type to be usable


### PR DESCRIPTION
I have some other work in progress that is more elaborate, but I'm not sure we will be able to make it work. This, however, is definitely fine and should be quite useful for internal debugging at least.

Closes #1945

The key thing is that unlike the network tab, this will log regardless of whether the dev tools are open at request time, so you can open the console after the fact. This will _not_ stick around across refreshes however (unless `Persist logs` is on in the dev tools).

![Screenshot 2024-04-08 at 12 27 16 PM](https://github.com/oxidecomputer/console/assets/3612203/d2fa25da-a6ac-465c-ad9c-0059e370d6ea)