### PR TITLE
Set table cells to have shorter default height

### DIFF
--- a/app/pages/project/instances/InstancesPage.tsx
+++ b/app/pages/project/instances/InstancesPage.tsx
@@ -132,7 +132,7 @@ export function InstancesPage() {
           New Instance
         </Link>
       </TableActions>
-      <Table columns={columns} emptyState={<EmptyState />} />
+      <Table columns={columns} emptyState={<EmptyState />} rowHeight="large" />
     </>
   )
 }

--- a/app/pages/project/vpcs/VpcPage/tabs/VpcFirewallRulesTab.tsx
+++ b/app/pages/project/vpcs/VpcPage/tabs/VpcFirewallRulesTab.tsx
@@ -151,7 +151,7 @@ export const VpcFirewallRulesTab = () => {
           />
         )}
       </div>
-      {rules.length > 0 ? <Table table={table} /> : emptyState}
+      {rules.length > 0 ? <Table table={table} rowHeight="large" /> : emptyState}
     </>
   )
 }

--- a/app/pages/system/UtilizationPage.tsx
+++ b/app/pages/system/UtilizationPage.tsx
@@ -172,41 +172,43 @@ function UsageTab() {
       <Table.Body>
         {siloUtilizations.items.map((silo) => (
           <Table.Row key={silo.siloName}>
-            <Table.Cell width="16%">{silo.siloName}</Table.Cell>
-            <Table.Cell width="14%">
+            <Table.Cell width="16%" height="large">
+              {silo.siloName}
+            </Table.Cell>
+            <Table.Cell width="14%" height="large">
               <UsageCell
                 provisioned={silo.provisioned.cpus}
                 allocated={silo.allocated.cpus}
               />
             </Table.Cell>
-            <Table.Cell width="14%">
+            <Table.Cell width="14%" height="large">
               <UsageCell
                 provisioned={bytesToGiB(silo.provisioned.memory)}
                 allocated={bytesToGiB(silo.allocated.memory)}
                 unit="GiB"
               />
             </Table.Cell>
-            <Table.Cell width="14%">
+            <Table.Cell width="14%" height="large">
               <UsageCell
                 provisioned={bytesToTiB(silo.provisioned.storage)}
                 allocated={bytesToTiB(silo.allocated.storage)}
                 unit="TiB"
               />
             </Table.Cell>
-            <Table.Cell width="14%" className="relative">
+            <Table.Cell width="14%" className="relative" height="large">
               <AvailableCell
                 provisioned={silo.provisioned.cpus}
                 allocated={silo.allocated.cpus}
               />
             </Table.Cell>
-            <Table.Cell width="14%" className="relative">
+            <Table.Cell width="14%" className="relative" height="large">
               <AvailableCell
                 provisioned={bytesToGiB(silo.provisioned.memory)}
                 allocated={bytesToGiB(silo.allocated.memory)}
                 unit="GiB"
               />
             </Table.Cell>
-            <Table.Cell width="14%" className="relative">
+            <Table.Cell width="14%" className="relative" height="large">
               <AvailableCell
                 provisioned={bytesToTiB(silo.provisioned.storage)}
                 allocated={bytesToTiB(silo.allocated.storage)}

--- a/app/table/QueryTable.tsx
+++ b/app/table/QueryTable.tsx
@@ -73,7 +73,7 @@ const makeQueryTable = <Item extends Record<string, unknown>>(
     debug,
     pagination = 'page',
     pageSize = PAGE_SIZE,
-    rowHeight,
+    rowHeight = 'small',
     emptyState,
     columns,
   }: QueryTableProps<Item>) {

--- a/app/table/QueryTable.tsx
+++ b/app/table/QueryTable.tsx
@@ -56,7 +56,7 @@ type QueryTableProps<Item> = {
   /** Function that produces a list of actions from a row item */
   pagination?: 'inline' | 'page'
   pageSize?: number
-  rowHeight?: 'small' | 'large' | 'auto'
+  rowHeight?: 'small' | 'large'
   emptyState: React.ReactElement
   columns: ColumnDef<Item, any>[]
 }

--- a/app/table/QueryTable.tsx
+++ b/app/table/QueryTable.tsx
@@ -56,6 +56,7 @@ type QueryTableProps<Item> = {
   /** Function that produces a list of actions from a row item */
   pagination?: 'inline' | 'page'
   pageSize?: number
+  rowHeight?: 'small' | 'large' | 'auto'
   emptyState: React.ReactElement
   columns: ColumnDef<Item, any>[]
 }
@@ -70,6 +71,7 @@ const makeQueryTable = <Item extends Record<string, unknown>>(
     debug,
     pagination = 'page',
     pageSize = 25,
+    rowHeight,
     emptyState,
     columns,
   }: QueryTableProps<Item>) {
@@ -109,7 +111,7 @@ const makeQueryTable = <Item extends Record<string, unknown>>(
 
     return (
       <>
-        <Table table={table} />
+        <Table table={table} rowHeight={rowHeight} />
         <Pagination
           inline={pagination === 'inline'}
           pageSize={pageSize}

--- a/app/table/Table.tsx
+++ b/app/table/Table.tsx
@@ -12,6 +12,7 @@ import { Table as UITable } from '~/ui/lib/Table'
 
 export type TableProps<TData> = JSX.IntrinsicElements['table'] & {
   rowClassName?: string
+  rowHeight?: 'small' | 'large' | 'auto'
   table: TableInstance<TData>
   singleSelect?: boolean
   multiSelect?: boolean
@@ -20,6 +21,7 @@ export type TableProps<TData> = JSX.IntrinsicElements['table'] & {
 /** Render a React Table table instance */
 export const Table = <TData,>({
   rowClassName,
+  rowHeight,
   table,
   singleSelect,
   multiSelect,
@@ -70,6 +72,7 @@ export const Table = <TData,>({
                 key={cell.column.id}
                 {...(i === 0 ? firstCellProps : {})}
                 className={cell.column.columnDef.meta?.tdClassName}
+                height={rowHeight}
               >
                 {flexRender(cell.column.columnDef.cell, cell.getContext())}
               </UITable.Cell>

--- a/app/table/Table.tsx
+++ b/app/table/Table.tsx
@@ -12,7 +12,7 @@ import { Table as UITable } from '~/ui/lib/Table'
 
 export type TableProps<TData> = JSX.IntrinsicElements['table'] & {
   rowClassName?: string
-  rowHeight?: 'small' | 'large' | 'auto'
+  rowHeight?: 'small' | 'large'
   table: TableInstance<TData>
   singleSelect?: boolean
   multiSelect?: boolean

--- a/app/table/Table.tsx
+++ b/app/table/Table.tsx
@@ -21,7 +21,7 @@ export type TableProps<TData> = JSX.IntrinsicElements['table'] & {
 /** Render a React Table table instance */
 export const Table = <TData,>({
   rowClassName,
-  rowHeight,
+  rowHeight = 'small',
   table,
   singleSelect,
   multiSelect,

--- a/app/ui/lib/Table.tsx
+++ b/app/ui/lib/Table.tsx
@@ -93,9 +93,7 @@ Table.Body = ({ className, children, ...props }: TableBodyProps) => {
   )
 }
 
-export type TableCellProps = JSX.IntrinsicElements['td'] & {
-  height?: 'large' | 'small' | 'auto'
-}
+export type TableCellProps = JSX.IntrinsicElements['td'] & { height?: 'small' | 'large' }
 Table.Cell = ({ height = 'small', className, children, ...props }: TableCellProps) => {
   const heightClass = height === 'small' ? 'h-12' : height === 'large' ? 'h-16' : ''
   return (

--- a/app/ui/lib/Table.tsx
+++ b/app/ui/lib/Table.tsx
@@ -95,20 +95,20 @@ Table.Body = ({ className, children, ...props }: TableBodyProps) => {
 
 export type TableCellProps = JSX.IntrinsicElements['td'] & { height?: 'small' | 'large' }
 Table.Cell = ({ height = 'small', className, children, ...props }: TableCellProps) => {
-  const heightClass = height === 'small' ? 'h-12' : height === 'large' ? 'h-16' : ''
+  const heightClasses = { 'h-12': height === 'small', 'h-16': height === 'large' }
   return (
     <td
       className={cn(
         className,
         'pl-0 text-default border-default children:first:border-l-0 children:last:-mr-[1px]',
-        heightClass
+        heightClasses
       )}
       {...props}
     >
       <div
         className={cn(
           'relative -my-[1px] -mr-[2px] flex items-center border-b border-l py-3 pl-3 pr-3 border-secondary',
-          heightClass
+          heightClasses
         )}
       >
         {children}

--- a/app/ui/lib/Table.tsx
+++ b/app/ui/lib/Table.tsx
@@ -96,8 +96,8 @@ Table.Body = ({ className, children, ...props }: TableBodyProps) => {
 export type TableCellProps = JSX.IntrinsicElements['td'] & {
   height?: 'large' | 'small' | 'auto'
 }
-Table.Cell = ({ height = 'large', className, children, ...props }: TableCellProps) => {
-  const heightClass = height === 'large' ? 'h-16' : height === 'small' ? 'h-8' : ''
+Table.Cell = ({ height = 'small', className, children, ...props }: TableCellProps) => {
+  const heightClass = height === 'small' ? 'h-12' : height === 'large' ? 'h-16' : ''
   return (
     <td
       className={cn(


### PR DESCRIPTION
This PR sets the default table row height to the `h-12` height, rather than the larger `h-16`.

So we move from a table looking like this:
<img width="1214" alt="Screenshot 2024-04-17 at 1 30 27 PM" src="https://github.com/oxidecomputer/console/assets/22547/af44713d-cca8-41d8-979a-5d8e6e4cfc33">

To something more compact, like this:
<img width="1214" alt="Screenshot 2024-04-17 at 1 30 55 PM" src="https://github.com/oxidecomputer/console/assets/22547/ee5a15eb-78e4-4783-9067-ef94ecb5704f">

37.5% more data on the screen*!

There are still some tables that require a larger height, and we can pass in a `rowHeight` prop to enable that. Here we have the `InstancesPage` table, which uses the `useQueryTable` hook, which invokes the `app/table/Table.tsx` component. With this wrapper component, we can pass in `rowHeight` as a prop to the overall `Table` component and the component passes it through to the `Table.Cell` in `ui/lib/Table.tsx`.
<img width="1225" alt="Screenshot 2024-04-17 at 1 29 49 PM" src="https://github.com/oxidecomputer/console/assets/22547/7107bbba-8fef-4595-8db6-074b3079b724">

We also sometimes use the `ui/lib/Table.tsx` file directly, as in the `UtilizationPage` table. In cases like that, we have to pass the `height` prop directly to each `Table.Cell`, as the `Table` wrapper component doesn't pass anything directly along to its children table cells.
<img width="1225" alt="Screenshot 2024-04-17 at 1 29 57 PM" src="https://github.com/oxidecomputer/console/assets/22547/f833abeb-da04-42bd-b660-3833ea55b4e4">

I'd prefer, I think, for us to not be involved at all in the height of these elements, and to instead just pass the data in and let the table cells dynamically update, with the appropriate cell-padding. The table would then flex to handle whatever the tallest content in the cells is. At the moment, though, the way we're doing borders on the cells would be a little fussy to get sorted, and there are a few things on our plate for V8. Happy to revisit that down the road.