### PR TITLE
Refresh button on instance detail page

### DIFF
--- a/app/api/hooks.ts
+++ b/app/api/hooks.ts
@@ -239,9 +239,11 @@ export const wrapQueryClient = <A extends ApiClient>(api: A, queryClient: QueryC
    * accidentally overspecifying and therefore failing to match the desired
    * query. The params argument can be added back in if we ever have a use case
    * for it.
+   *
+   * Passing no arguments will invalidate all queries.
    */
-  invalidateQueries: <M extends keyof A>(method: M, filters?: InvalidateQueryFilters) =>
-    queryClient.invalidateQueries({ queryKey: [method], ...filters }),
+  invalidateQueries: <M extends keyof A>(method?: M, filters?: InvalidateQueryFilters) =>
+    queryClient.invalidateQueries(method ? { queryKey: [method], ...filters } : undefined),
   setQueryData: <M extends keyof A>(method: M, params: Params<A[M]>, data: Result<A[M]>) =>
     queryClient.setQueryData([method, params], data),
   setQueryDataErrorsAllowed: <M extends keyof A>(

--- a/app/components/RefreshButton.tsx
+++ b/app/components/RefreshButton.tsx
@@ -1,0 +1,19 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
+ */
+
+import { Refresh16Icon } from '@oxide/design-system/icons/react'
+
+import { Button } from '~/ui/lib/Button'
+
+export function RefreshButton({ onClick }: { onClick: () => void }) {
+  return (
+    <Button size="icon" variant="ghost" onClick={onClick} aria-label="Refresh data">
+      <Refresh16Icon />
+    </Button>
+  )
+}

--- a/app/pages/project/instances/InstancesPage.tsx
+++ b/app/pages/project/instances/InstancesPage.tsx
@@ -15,8 +15,9 @@ import {
   usePrefetchedApiQuery,
   type Instance,
 } from '@oxide/api'
-import { Instances24Icon, Refresh16Icon } from '@oxide/design-system/icons/react'
+import { Instances24Icon } from '@oxide/design-system/icons/react'
 
+import { RefreshButton } from '~/components/RefreshButton'
 import { getProjectSelector, useProjectSelector, useQuickActions } from '~/hooks'
 import { InstanceResourceCell } from '~/table/cells/InstanceResourceCell'
 import { InstanceStatusCell } from '~/table/cells/InstanceStatusCell'
@@ -24,7 +25,7 @@ import { makeLinkCell } from '~/table/cells/LinkCell'
 import { getActionsCol } from '~/table/columns/action-col'
 import { Columns } from '~/table/columns/common'
 import { useQueryTable } from '~/table/QueryTable'
-import { Button, buttonStyle } from '~/ui/lib/Button'
+import { buttonStyle } from '~/ui/lib/Button'
 import { EmptyMessage } from '~/ui/lib/EmptyMessage'
 import { PageHeader, PageTitle } from '~/ui/lib/PageHeader'
 import { TableActions } from '~/ui/lib/Table'
@@ -120,14 +121,7 @@ export function InstancesPage() {
         <PageTitle icon={<Instances24Icon />}>Instances</PageTitle>
       </PageHeader>
       <TableActions>
-        <Button
-          size="icon"
-          variant="ghost"
-          onClick={refetchInstances}
-          aria-label="Refresh instances table"
-        >
-          <Refresh16Icon />
-        </Button>
+        <RefreshButton onClick={() => apiQueryClient.invalidateQueries('instanceList')} />
         <Link to={pb.instancesNew({ project })} className={buttonStyle({ size: 'sm' })}>
           New Instance
         </Link>

--- a/app/pages/project/instances/instance/InstancePage.tsx
+++ b/app/pages/project/instances/instance/InstancePage.tsx
@@ -12,7 +12,6 @@ import { Link, useNavigate, type LoaderFunctionArgs } from 'react-router-dom'
 import {
   apiQueryClient,
   useApiQuery,
-  useApiQueryClient,
   usePrefetchedApiQuery,
   type InstanceNetworkInterface,
 } from '@oxide/api'
@@ -85,11 +84,8 @@ export function InstancePage() {
   const instanceSelector = useInstanceSelector()
 
   const navigate = useNavigate()
-  const queryClient = useApiQueryClient()
   const makeActions = useMakeInstanceActions(instanceSelector, {
-    onSuccess: () => {
-      queryClient.invalidateQueries('instanceView')
-    },
+    onSuccess: refreshData,
     // go to project instances list since there's no more instance
     onDelete: () => navigate(pb.instances(instanceSelector)),
   })

--- a/app/pages/project/instances/instance/InstancePage.tsx
+++ b/app/pages/project/instances/instance/InstancePage.tsx
@@ -20,6 +20,7 @@ import { Instances24Icon } from '@oxide/design-system/icons/react'
 
 import { ExternalIps } from '~/components/ExternalIps'
 import { MoreActionsMenu } from '~/components/MoreActionsMenu'
+import { RefreshButton } from '~/components/RefreshButton'
 import { RouteTabs, Tab } from '~/components/RouteTabs'
 import { InstanceStatusBadge } from '~/components/StatusBadge'
 import { getInstanceSelector, useInstanceSelector, useQuickActions } from '~/hooks'
@@ -35,6 +36,15 @@ import { useMakeInstanceActions } from '../actions'
 function getPrimaryVpcId(nics: InstanceNetworkInterface[]) {
   const nic = nics.find((nic) => nic.primary)
   return nic ? nic.vpcId : undefined
+}
+
+// this is meant to cover everything that we fetch in the page
+function refreshData() {
+  apiQueryClient.invalidateQueries('instanceView')
+  apiQueryClient.invalidateQueries('instanceExternalIpList')
+  apiQueryClient.invalidateQueries('instanceNetworkInterfaceList')
+  apiQueryClient.invalidateQueries('instanceDiskList') // storage tab
+  apiQueryClient.invalidateQueries('diskMetricsList') // metrics tab
 }
 
 InstancePage.loader = async ({ params }: LoaderFunctionArgs) => {
@@ -137,7 +147,10 @@ export function InstancePage() {
     <>
       <PageHeader>
         <PageTitle icon={<Instances24Icon />}>{instance.name}</PageTitle>
-        <MoreActionsMenu label="Instance actions" actions={actions} />
+        <div className="inline-flex gap-2">
+          <RefreshButton onClick={refreshData} />
+          <MoreActionsMenu label="Instance actions" actions={actions} />
+        </div>
       </PageHeader>
       <PropertiesTable.Group className="-mt-8 mb-16">
         <PropertiesTable>


### PR DESCRIPTION
Necessary stopgap until we do more polling. I have some followup work that simulates state changes more fancily in the mock server, which will let us test the button in an e2e.

<img width="876" alt="image" src="https://github.com/oxidecomputer/console/assets/3612203/586d9fdf-9914-4749-a080-0c82a5775bfc">
