### PR TITLE
Animate refresh button

### DIFF
--- a/app/components/RefreshButton.tsx
+++ b/app/components/RefreshButton.tsx
@@ -16,17 +16,14 @@ import { SpinnerLoader } from '~/ui/lib/Spinner'
 export function RefreshButton({ onClick }: { onClick: () => Promise<void> }) {
   const [refreshing, setRefreshing] = useState(false)
 
+  async function refresh() {
+    setRefreshing(true)
+    await onClick()
+    setRefreshing(false)
+  }
+
   return (
-    <Button
-      size="icon"
-      variant="ghost"
-      onClick={async () => {
-        setRefreshing(true)
-        await onClick()
-        setRefreshing(false)
-      }}
-      aria-label="Refresh data"
-    >
+    <Button size="icon" variant="ghost" onClick={refresh} aria-label="Refresh data">
       <SpinnerLoader isLoading={refreshing}>
         <Refresh16Icon />
       </SpinnerLoader>

--- a/app/components/RefreshButton.tsx
+++ b/app/components/RefreshButton.tsx
@@ -12,20 +12,18 @@ import { Refresh16Icon } from '@oxide/design-system/icons/react'
 
 import { Button } from '~/ui/lib/Button'
 import { SpinnerLoader } from '~/ui/lib/Spinner'
-import { useTimeout } from '~/ui/lib/use-timeout'
 
-export function RefreshButton({ onClick }: { onClick: () => void }) {
-  // fake timer on fetching because it's too annoying to actually track it
+export function RefreshButton({ onClick }: { onClick: () => Promise<void> }) {
   const [refreshing, setRefreshing] = useState(false)
-  useTimeout(() => setRefreshing(false), refreshing ? 500 : null)
 
   return (
     <Button
       size="icon"
       variant="ghost"
-      onClick={() => {
-        onClick()
+      onClick={async () => {
         setRefreshing(true)
+        await onClick()
+        setRefreshing(false)
       }}
       aria-label="Refresh data"
     >

--- a/app/components/RefreshButton.tsx
+++ b/app/components/RefreshButton.tsx
@@ -6,14 +6,32 @@
  * Copyright Oxide Computer Company
  */
 
+import { useState } from 'react'
+
 import { Refresh16Icon } from '@oxide/design-system/icons/react'
 
 import { Button } from '~/ui/lib/Button'
+import { SpinnerLoader } from '~/ui/lib/Spinner'
+import { useTimeout } from '~/ui/lib/use-timeout'
 
 export function RefreshButton({ onClick }: { onClick: () => void }) {
+  // fake timer on fetching because it's too annoying to actually track it
+  const [refreshing, setRefreshing] = useState(false)
+  useTimeout(() => setRefreshing(false), refreshing ? 500 : null)
+
   return (
-    <Button size="icon" variant="ghost" onClick={onClick} aria-label="Refresh data">
-      <Refresh16Icon />
+    <Button
+      size="icon"
+      variant="ghost"
+      onClick={() => {
+        onClick()
+        setRefreshing(true)
+      }}
+      aria-label="Refresh data"
+    >
+      <SpinnerLoader isLoading={refreshing}>
+        <Refresh16Icon />
+      </SpinnerLoader>
     </Button>
   )
 }

--- a/app/pages/project/instances/InstancesPage.tsx
+++ b/app/pages/project/instances/InstancesPage.tsx
@@ -123,7 +123,7 @@ export function InstancesPage() {
         <PageTitle icon={<Instances24Icon />}>Instances</PageTitle>
       </PageHeader>
       <TableActions>
-        <RefreshButton onClick={() => apiQueryClient.invalidateQueries('instanceList')} />
+        <RefreshButton onClick={refetchInstances} />
         <Link to={pb.instancesNew({ project })} className={buttonStyle({ size: 'sm' })}>
           New Instance
         </Link>

--- a/app/pages/project/instances/instance/InstancePage.tsx
+++ b/app/pages/project/instances/instance/InstancePage.tsx
@@ -38,12 +38,17 @@ function getPrimaryVpcId(nics: InstanceNetworkInterface[]) {
 }
 
 // this is meant to cover everything that we fetch in the page
-function refreshData() {
-  apiQueryClient.invalidateQueries('instanceView')
-  apiQueryClient.invalidateQueries('instanceExternalIpList')
-  apiQueryClient.invalidateQueries('instanceNetworkInterfaceList')
-  apiQueryClient.invalidateQueries('instanceDiskList') // storage tab
-  apiQueryClient.invalidateQueries('diskMetricsList') // metrics tab
+// TODO: try awaiting this inside of the function and using that to power the thing
+async function refreshData() {
+  console.log('start')
+  await Promise.all([
+    apiQueryClient.invalidateQueries('instanceView'),
+    apiQueryClient.invalidateQueries('instanceExternalIpList'),
+    apiQueryClient.invalidateQueries('instanceNetworkInterfaceList'),
+    apiQueryClient.invalidateQueries('instanceDiskList'), // storage tab
+    apiQueryClient.invalidateQueries('diskMetricsList'), // metrics tab
+  ])
+  console.log('end')
 }
 
 InstancePage.loader = async ({ params }: LoaderFunctionArgs) => {

--- a/app/pages/project/instances/instance/InstancePage.tsx
+++ b/app/pages/project/instances/instance/InstancePage.tsx
@@ -38,9 +38,7 @@ function getPrimaryVpcId(nics: InstanceNetworkInterface[]) {
 }
 
 // this is meant to cover everything that we fetch in the page
-// TODO: try awaiting this inside of the function and using that to power the thing
 async function refreshData() {
-  console.log('start')
   await Promise.all([
     apiQueryClient.invalidateQueries('instanceView'),
     apiQueryClient.invalidateQueries('instanceExternalIpList'),
@@ -48,7 +46,6 @@ async function refreshData() {
     apiQueryClient.invalidateQueries('instanceDiskList'), // storage tab
     apiQueryClient.invalidateQueries('diskMetricsList'), // metrics tab
   ])
-  console.log('end')
 }
 
 InstancePage.loader = async ({ params }: LoaderFunctionArgs) => {


### PR DESCRIPTION
Closes #1995 

Imagine my delight discovering that `invalidateQueries` returns a promise that completes when the actual query finishes refetching! That makes it extremely easy to turn on a spinner when it starts and turn it off when it ends. How great is that!

https://github.com/oxidecomputer/console/assets/3612203/49481520-22ef-4334-bd15-452c2d9bf7a6

