### PR TITLE
add confirmation indicator when refresh finishes

### DIFF
--- a/app/components/RefreshButton.tsx
+++ b/app/components/RefreshButton.tsx
@@ -5,28 +5,52 @@
  *
  * Copyright Oxide Computer Company
  */
-
+import { animated, config, useTransition } from '@react-spring/web'
 import { useState } from 'react'
 
-import { Refresh16Icon } from '@oxide/design-system/icons/react'
+import { Refresh16Icon, Success12Icon } from '@oxide/design-system/icons/react'
 
 import { Button } from '~/ui/lib/Button'
 import { SpinnerLoader } from '~/ui/lib/Spinner'
+import { useTimeout } from '~/ui/lib/use-timeout'
 
 export function RefreshButton({ onClick }: { onClick: () => Promise<void> }) {
   const [refreshing, setRefreshing] = useState(false)
+  const [hasReloaded, setHasReloaded] = useState(false)
+  useTimeout(() => setHasReloaded(false), hasReloaded ? 1000 : null)
+
+  const transitions = useTransition(hasReloaded, {
+    from: { opacity: 0, transform: 'scale(0.8)' },
+    enter: { opacity: 1, transform: 'scale(1)' },
+    leave: { opacity: 0, transform: 'scale(0.8)' },
+    config: config.stiff,
+    trail: 100,
+    initial: null,
+  })
 
   async function refresh() {
     setRefreshing(true)
     await onClick()
     setRefreshing(false)
+    setHasReloaded(true)
   }
 
   return (
     <Button size="icon" variant="ghost" onClick={refresh} aria-label="Refresh data">
-      <SpinnerLoader isLoading={refreshing}>
-        <Refresh16Icon />
-      </SpinnerLoader>
+      {transitions((styles, item) => (
+        <animated.div
+          style={styles}
+          className="absolute inset-0 flex items-center justify-center"
+        >
+          {item ? (
+            <Success12Icon className="text-accent bg-accent-secondary" />
+          ) : (
+            <SpinnerLoader isLoading={refreshing}>
+              <Refresh16Icon />
+            </SpinnerLoader>
+          )}
+        </animated.div>
+      ))}
     </Button>
   )
 }


### PR DESCRIPTION
This PR builds on #2161, adding in an indicator to confirm that the refresh has completed.

![refresh](https://github.com/oxidecomputer/console/assets/22547/33a3fca3-f236-4ff7-b13b-e09b7c115808)
