### PR TITLE
Fix instance delete success callback

### DIFF
--- a/app/pages/project/instances/InstancesPage.tsx
+++ b/app/pages/project/instances/InstancesPage.tsx
@@ -59,7 +59,10 @@ export function InstancesPage() {
   const queryClient = useApiQueryClient()
   const refetchInstances = () => queryClient.invalidateQueries('instanceList')
 
-  const makeActions = useMakeInstanceActions({ project }, { onSuccess: refetchInstances })
+  const makeActions = useMakeInstanceActions(
+    { project },
+    { onSuccess: refetchInstances, onDelete: refetchInstances }
+  )
 
   const { data: instances } = usePrefetchedApiQuery('instanceList', {
     query: { project, limit: PAGE_SIZE },

--- a/app/pages/project/instances/actions.tsx
+++ b/app/pages/project/instances/actions.tsx
@@ -40,7 +40,8 @@ export const useMakeInstanceActions = (
   const startInstance = useApiMutation('instanceStart', opts)
   const stopInstance = useApiMutation('instanceStop', opts)
   const rebootInstance = useApiMutation('instanceReboot', opts)
-  const deleteInstance = useApiMutation('instanceDelete', opts)
+  // delete has its own
+  const deleteInstance = useApiMutation('instanceDelete', { onSuccess: options.onDelete })
 
   return useCallback(
     (instance) => {
@@ -123,10 +124,8 @@ export const useMakeInstanceActions = (
           onActivate: confirmDelete({
             doDelete: () =>
               deleteInstance.mutateAsync(instanceParams, {
-                onSuccess: () => {
-                  options.onDelete?.()
-                  addToast({ title: `Deleting instance '${instance.name}'` })
-                },
+                onSuccess: () =>
+                  addToast({ title: `Deleting instance '${instance.name}'` }),
               }),
             label: instance.name,
             resourceKind: 'instance',
@@ -138,14 +137,6 @@ export const useMakeInstanceActions = (
         },
       ]
     },
-    [
-      projectSelector,
-      deleteInstance,
-      navigate,
-      options,
-      rebootInstance,
-      startInstance,
-      stopInstance,
-    ]
+    [projectSelector, deleteInstance, navigate, rebootInstance, startInstance, stopInstance]
   )
 }

--- a/test/e2e/instance-disks.e2e.ts
+++ b/test/e2e/instance-disks.e2e.ts
@@ -13,7 +13,7 @@ import {
   expectVisible,
   stopInstance,
   test,
-} from '../utils'
+} from './utils'
 
 test('Attach disk', async ({ page }) => {
   await page.goto('/projects/mock-project/instances/db1')

--- a/test/e2e/instance-networking.e2e.ts
+++ b/test/e2e/instance-networking.e2e.ts
@@ -13,9 +13,9 @@ import {
   expectRowVisible,
   expectVisible,
   stopInstance,
-} from '../utils'
+} from './utils'
 
-test('Instance networking tab — NIC table', async ({ page }) => {
+test('Instance networking tab — NIC table', async ({ page }) => {
   await page.goto('/projects/mock-project/instances/db1')
 
   // links to VPC and external IPs appear in table

--- a/test/e2e/instance.e2e.ts
+++ b/test/e2e/instance.e2e.ts
@@ -5,7 +5,7 @@
  *
  * Copyright Oxide Computer Company
  */
-import { expect, test } from '../utils'
+import { expect, test } from './utils'
 
 test('can delete a failed instance', async ({ page }) => {
   await page.goto('/projects/mock-project/instances')
@@ -59,4 +59,15 @@ test('can stop a starting instance', async ({ page }) => {
   await page.getByRole('button', { name: 'Confirm' }).click()
 
   await expect(row.getByRole('cell', { name: /stopped/ })).toBeVisible()
+})
+
+test('delete from instance detail', async ({ page }) => {
+  await page.goto('/projects/mock-project/instances/you-fail')
+
+  await page.getByRole('button', { name: 'Instance actions' }).click()
+  await page.getByRole('menuitem', { name: 'Delete' }).click()
+  await page.getByRole('button', { name: 'Confirm' }).click()
+
+  await expect(page.getByRole('heading', { name: 'Instances' })).toBeVisible()
+  await expect(page).toHaveURL('/projects/mock-project/instances')
 })


### PR DESCRIPTION
https://github.com/oxidecomputer/console/pull/2156 revealed an existing bug (not sure why it was working before!) where we try to call both `onSuccess` and `onDelete` on successful instance delete. Once the bug started happening, `onSuccess` meant that we'd try to navigate to instance detail after deleting that instance, which 404s. This fixes it so we only call `onDelete` on successful delete, which takes us back to the instance list. I also added a test that would have caught this, and added an `onDelete` to instances list which refreshes the list.