### PR TITLE
Small table cell refactor

### DIFF
--- a/app/pages/project/vpcs/VpcPage/tabs/VpcSubnetsTab.tsx
+++ b/app/pages/project/vpcs/VpcPage/tabs/VpcSubnetsTab.tsx
@@ -83,7 +83,7 @@ export const VpcSubnetsTab = () => {
         {creating && <CreateSubnetForm onDismiss={() => setCreating(false)} />}
         {editing && <EditSubnetForm editing={editing} onDismiss={() => setEditing(null)} />}
       </div>
-      <Table columns={columns} emptyState={emptyState} />
+      <Table columns={columns} emptyState={emptyState} rowHeight="large" />
     </>
   )
 }

--- a/app/pages/system/inventory/sled/SledInstancesTab.tsx
+++ b/app/pages/system/inventory/sled/SledInstancesTab.tsx
@@ -78,5 +78,5 @@ export function SledInstancesTab() {
 
   const columns = useColsWithActions(staticCols, makeActions)
 
-  return <Table columns={columns} emptyState={<EmptyState />} />
+  return <Table columns={columns} emptyState={<EmptyState />} rowHeight="large" />
 }

--- a/app/ui/lib/Table.tsx
+++ b/app/ui/lib/Table.tsx
@@ -94,27 +94,24 @@ Table.Body = ({ className, children, ...props }: TableBodyProps) => {
 }
 
 export type TableCellProps = JSX.IntrinsicElements['td'] & { height?: 'small' | 'large' }
-Table.Cell = ({ height = 'small', className, children, ...props }: TableCellProps) => {
-  const heightClasses = { 'h-12': height === 'small', 'h-16': height === 'large' }
-  return (
-    <td
+Table.Cell = ({ height = 'small', className, children, ...props }: TableCellProps) => (
+  <td
+    className={cn(
+      className,
+      'pl-0 text-default border-default children:first:border-l-0 children:last:-mr-[1px]'
+    )}
+    {...props}
+  >
+    <div
       className={cn(
-        className,
-        'pl-0 text-default border-default children:first:border-l-0 children:last:-mr-[1px]'
+        'relative -my-[1px] -mr-[2px] flex items-center border-b border-l p-3 border-secondary',
+        { 'h-12': height === 'small', 'h-16': height === 'large' }
       )}
-      {...props}
     >
-      <div
-        className={cn(
-          'relative -my-[1px] -mr-[2px] flex items-center border-b border-l p-3 border-secondary',
-          heightClasses
-        )}
-      >
-        {children}
-      </div>
-    </td>
-  )
-}
+      {children}
+    </div>
+  </td>
+)
 
 /**
  * Used _outside_ of the `Table`, this element wraps buttons that sit on top

--- a/app/ui/lib/Table.tsx
+++ b/app/ui/lib/Table.tsx
@@ -100,14 +100,13 @@ Table.Cell = ({ height = 'small', className, children, ...props }: TableCellProp
     <td
       className={cn(
         className,
-        'pl-0 text-default border-default children:first:border-l-0 children:last:-mr-[1px]',
-        heightClasses
+        'pl-0 text-default border-default children:first:border-l-0 children:last:-mr-[1px]'
       )}
       {...props}
     >
       <div
         className={cn(
-          'relative -my-[1px] -mr-[2px] flex items-center border-b border-l py-3 pl-3 pr-3 border-secondary',
+          'relative -my-[1px] -mr-[2px] flex items-center border-b border-l p-3 border-secondary',
           heightClasses
         )}
       >


### PR DESCRIPTION
Our tables are constructed by dropping a `div` inside each `td` and then putting the contents of the cell into that div. I tried simplifying things by moving the borders to the cells, but it proved to be trickier than I thought it would be, and I wasn't confident that I wouldn't introduce edge case CSS bugs. So I've mostly left it as it was.

One change that I did make was to only apply the height class to the contained `<div>`, rather than to the `<div>` and the `<td>` that wraps it. There was no reason I could find to apply the class to both, as the `<td>` will occupy the proper size based on the child element (the `<div>`). I tried to see if there were any unexpected rendering issues with the class in only one place, but did not find anything. If @benjaminleonard or @david-crespo has any reason they can recall as to why we were applying the `height` to both the `<div>` _and_ the `<td>`, I'd love to hear it! But with the logic only needed for one place, we're able to simplify things a little bit.

Visually, the tables all still look the same.

<img width="1219" alt="Screenshot 2024-04-18 at 4 12 58 PM" src="https://github.com/oxidecomputer/console/assets/22547/3b7bd347-6754-4183-a73d-0f431039dfc6">

I also found one spot where we should have the taller row height, so I embiggened the VPC Subnets table cells.

<img width="1214" alt="Screenshot 2024-04-18 at 3 55 56 PM" src="https://github.com/oxidecomputer/console/assets/22547/9fd9408e-e660-4c68-9c8d-fdd2da2c1207">
