### PR TITLE
make all external IPs in header copyable

### DIFF
--- a/app/components/ExternalIps.tsx
+++ b/app/components/ExternalIps.tsx
@@ -22,30 +22,18 @@ export function ExternalIps({ project, instance }: InstanceSelector) {
   if (isPending) return <SkeletonCell />
 
   const ips = data?.items
-    ? intersperse(
-        data.items.map((eip) => <IpLink ip={eip.ip} key={eip.ip} />),
+  if (!ips || ips.length === 0) return <EmptyCell />
+  return (
+    <div className="flex items-center gap-1">
+      {intersperse(
+        ips.map((eip) => (
+          <span className="flex items-center" key={eip.ip}>
+            {eip.ip}
+            <CopyToClipboard text={eip.ip} />
+          </span>
+        )),
         <span className="text-quinary"> / </span>
-      )
-    : undefined
-
-  return (
-    <div className="flex items-center gap-1 text-secondary">
-      {ips && ips.length > 0 ? ips : <EmptyCell />}
-      {/* If there's exactly one IP here, render a copy to clipboard button */}
-      {data?.items.length === 1 && <CopyToClipboard text={data.items[0].ip} />}
+      )}
     </div>
-  )
-}
-
-function IpLink({ ip }: { ip: string }) {
-  return (
-    <a
-      className="link-with-underline text-sans-semi-md"
-      href={`https://${ip}`}
-      target="_blank"
-      rel="noreferrer"
-    >
-      {ip}
-    </a>
   )
 }

--- a/app/components/ExternalIps.tsx
+++ b/app/components/ExternalIps.tsx
@@ -28,7 +28,14 @@ export function ExternalIps({ project, instance }: InstanceSelector) {
       {intersperse(
         ips.map((eip) => (
           <span className="flex items-center" key={eip.ip}>
-            {eip.ip}
+            <a
+              className="link-with-underline text-sans-semi-md"
+              href={`https://${eip.ip}`}
+              target="_blank"
+              rel="noreferrer"
+            >
+              {eip.ip}
+            </a>
             <CopyToClipboard text={eip.ip} />
           </span>
         )),

--- a/app/components/ExternalIps.tsx
+++ b/app/components/ExternalIps.tsx
@@ -27,7 +27,7 @@ export function ExternalIps({ project, instance }: InstanceSelector) {
     <div className="flex items-center gap-1">
       {intersperse(
         ips.map((eip) => (
-          <span className="flex items-center" key={eip.ip}>
+          <span className="flex items-center gap-1" key={eip.ip}>
             <a
               className="link-with-underline text-sans-semi-md"
               href={`https://${eip.ip}`}

--- a/app/pages/project/instances/instance/InstancePage.tsx
+++ b/app/pages/project/instances/instance/InstancePage.tsx
@@ -190,7 +190,7 @@ export function InstancePage() {
               {instance.id}
             </span>
           </PropertiesTable.Row>
-          <PropertiesTable.Row label="external IP">
+          <PropertiesTable.Row label="external IPs">
             {<ExternalIps {...instanceSelector} />}
           </PropertiesTable.Row>
         </PropertiesTable>

--- a/test/e2e/instance-networking.e2e.ts
+++ b/test/e2e/instance-networking.e2e.ts
@@ -20,7 +20,7 @@ test('Instance networking tab — NIC table', async ({ page }) => {
 
   // links to VPC and external IPs appear in table
   await expect(page.getByRole('link', { name: 'mock-vpc' })).toBeVisible()
-  await expect(page.getByText('123.4.56.0')).toBeVisible()
+  await expect(page.getByRole('link', { name: '123.4.56.0' })).toBeVisible()
 
   // Instance networking tab
   await page.click('role=tab[name="Networking"]')

--- a/test/e2e/instance-networking.e2e.ts
+++ b/test/e2e/instance-networking.e2e.ts
@@ -20,7 +20,7 @@ test('Instance networking tab — NIC table', async ({ page }) => {
 
   // links to VPC and external IPs appear in table
   await expect(page.getByRole('link', { name: 'mock-vpc' })).toBeVisible()
-  await expect(page.getByRole('link', { name: '123.4.56.0' })).toBeVisible()
+  await expect(page.getByText('123.4.56.0')).toBeVisible()
 
   // Instance networking tab
   await page.click('role=tab[name="Networking"]')


### PR DESCRIPTION
Fixes #2171 

We currently only allow for a "copy to clipboard" function when there's a single external IP in the list in the header. This PR makes it so that any IP in the list is copyable.
<img width="605" alt="Screenshot 2024-04-19 at 12 07 26 PM" src="https://github.com/oxidecomputer/console/assets/22547/0ddbd2a1-0f9f-4429-ae55-9b99ccd6ef8e">

We should add a dropdown, a la ListPlusCell, for when there are more than … 3(? 2?) IPs, but that can be a subsequent PR.