### PR TITLE
set max-width of capacity bar to 50%

### DIFF
--- a/app/components/CapacityBar.tsx
+++ b/app/components/CapacityBar.tsx
@@ -32,7 +32,7 @@ export const CapacityBar = <T extends number | bigint>({
   const unitElt = includeUnit ? <>&nbsp;{unit}</> : null
 
   return (
-    <div className="w-full min-w-min rounded-lg border border-default">
+    <div className="w-full min-w-min rounded-lg border border-default lg+:max-w-[50%]">
       <div className="flex justify-between p-3">
         <TitleCell icon={icon} title={title} unit={unit} />
         <PctCell pct={pct} />

--- a/app/pages/system/networking/IpPoolPage.tsx
+++ b/app/pages/system/networking/IpPoolPage.tsx
@@ -103,28 +103,32 @@ function UtilizationBars() {
   return (
     <div className="-mt-8 mb-8 flex min-w-min flex-col gap-3 lg+:flex-row">
       {ipv4.capacity > 0 && (
-        <CapacityBar
-          icon={<IpGlobal16Icon />}
-          title="IPv4"
-          provisioned={ipv4.allocated}
-          capacity={ipv4.capacity}
-          provisionedLabel="Allocated"
-          capacityLabel="Capacity"
-          unit="IPs"
-          includeUnit={false}
-        />
+        <div className="w-full lg+:max-w-[50%]">
+          <CapacityBar
+            icon={<IpGlobal16Icon />}
+            title="IPv4"
+            provisioned={ipv4.allocated}
+            capacity={ipv4.capacity}
+            provisionedLabel="Allocated"
+            capacityLabel="Capacity"
+            unit="IPs"
+            includeUnit={false}
+          />
+        </div>
       )}
       {ipv6.capacity > 0 && (
-        <CapacityBar
-          icon={<IpGlobal16Icon />}
-          title="IPv6"
-          provisioned={ipv6.allocated}
-          capacity={ipv6.capacity}
-          provisionedLabel="Allocated"
-          capacityLabel="Capacity"
-          unit="IPs"
-          includeUnit={false}
-        />
+        <div className="w-full lg+:max-w-[50%]">
+          <CapacityBar
+            icon={<IpGlobal16Icon />}
+            title="IPv6"
+            provisioned={ipv6.allocated}
+            capacity={ipv6.capacity}
+            provisionedLabel="Allocated"
+            capacityLabel="Capacity"
+            unit="IPs"
+            includeUnit={false}
+          />
+        </div>
       )}
     </div>
   )

--- a/app/pages/system/networking/IpPoolPage.tsx
+++ b/app/pages/system/networking/IpPoolPage.tsx
@@ -103,32 +103,28 @@ function UtilizationBars() {
   return (
     <div className="-mt-8 mb-8 flex min-w-min flex-col gap-3 lg+:flex-row">
       {ipv4.capacity > 0 && (
-        <div className="w-full lg+:max-w-[50%]">
-          <CapacityBar
-            icon={<IpGlobal16Icon />}
-            title="IPv4"
-            provisioned={ipv4.allocated}
-            capacity={ipv4.capacity}
-            provisionedLabel="Allocated"
-            capacityLabel="Capacity"
-            unit="IPs"
-            includeUnit={false}
-          />
-        </div>
+        <CapacityBar
+          icon={<IpGlobal16Icon />}
+          title="IPv4"
+          provisioned={ipv4.allocated}
+          capacity={ipv4.capacity}
+          provisionedLabel="Allocated"
+          capacityLabel="Capacity"
+          unit="IPs"
+          includeUnit={false}
+        />
       )}
       {ipv6.capacity > 0 && (
-        <div className="w-full lg+:max-w-[50%]">
-          <CapacityBar
-            icon={<IpGlobal16Icon />}
-            title="IPv6"
-            provisioned={ipv6.allocated}
-            capacity={ipv6.capacity}
-            provisionedLabel="Allocated"
-            capacityLabel="Capacity"
-            unit="IPs"
-            includeUnit={false}
-          />
-        </div>
+        <CapacityBar
+          icon={<IpGlobal16Icon />}
+          title="IPv6"
+          provisioned={ipv6.allocated}
+          capacity={ipv6.capacity}
+          provisionedLabel="Allocated"
+          capacityLabel="Capacity"
+          unit="IPs"
+          includeUnit={false}
+        />
       )}
     </div>
   )


### PR DESCRIPTION
Fixes #2178 

This PR just adds some CSS capping the max-width of the capacity bar to 50% of the screen for the IP Pool page.

<img width="1221" alt="Screenshot 2024-04-19 at 2 41 35 PM" src="https://github.com/oxidecomputer/console/assets/22547/f0fc9897-8649-457c-89f7-5380946b7b8f">

I tested with spoofed data, and At whatever point IPv6 IPs are in the mix, the left (IPv4) and right (IPv6) side should have equal widths.