### PR TITLE
Add properties table to IP Pool page

### DIFF
--- a/app/components/CapacityBar.tsx
+++ b/app/components/CapacityBar.tsx
@@ -32,7 +32,7 @@ export const CapacityBar = <T extends number | bigint>({
   const unitElt = includeUnit ? <>&nbsp;{unit}</> : null
 
   return (
-    <div className="w-full min-w-min rounded-lg border border-default lg+:max-w-[50%]">
+    <div className="w-full min-w-min rounded-lg border border-default lg+:max-w-[calc(50%-0.5rem)]">
       <div className="flex justify-between p-3">
         <TitleCell icon={icon} title={title} unit={unit} />
         <PctCell pct={pct} />

--- a/app/pages/system/networking/IpPoolPage.tsx
+++ b/app/pages/system/networking/IpPoolPage.tsx
@@ -120,9 +120,9 @@ function UtilizationBars() {
 
   return (
     <>
-      <h2 className="mb-3 pl-3 text-mono-xs text-secondary">Capacity available</h2>
-      <div className="mb-8 flex min-w-min flex-col gap-3 lg+:flex-row">
-        {ipv4.capacity > 0 ? (
+      <h2 className="mb-3 pl-3 text-mono-xs text-secondary">Utilization</h2>
+      <div className="mb-8 flex min-w-min flex-col gap-4 lg+:flex-row">
+        {ipv4.capacity > 0 && (
           <CapacityBar
             icon={<IpGlobal16Icon />}
             title="IPv4"
@@ -133,11 +133,8 @@ function UtilizationBars() {
             unit="IPs"
             includeUnit={false}
           />
-        ) : (
-          // necessary for aligning capacity bar with Properties Table
-          <div className="w-full"></div>
         )}
-        {ipv6.capacity > 0 ? (
+        {ipv6.capacity > 0 && (
           <CapacityBar
             icon={<IpGlobal16Icon />}
             title="IPv6"
@@ -148,10 +145,10 @@ function UtilizationBars() {
             unit="IPs"
             includeUnit={false}
           />
-        ) : (
-          // necessary for aligning capacity bar with Properties Table
-          <div className="w-full"></div>
         )}
+        {/* necessary for aligning capacity bar with Properties Table */}
+        {((ipv4.capacity > 0 && ipv6.capacity === 0n) ||
+          (ipv4.capacity === 0 && ipv6.capacity > 0n)) && <div className="w-full"></div>}
       </div>
     </>
   )

--- a/app/pages/system/networking/IpPoolPage.tsx
+++ b/app/pages/system/networking/IpPoolPage.tsx
@@ -88,18 +88,8 @@ export function IpPoolPage() {
           <PropertiesTable.Row label="Created">
             <DateTime date={pool.timeCreated} />
           </PropertiesTable.Row>
-          <PropertiesTable.Row label="Linked Silos">
+          <PropertiesTable.Row label="Last modified">
             <DateTime date={pool.timeModified} />
-            {/*
-              *
-              *
-              * 
-              ROUGH EDGE: You're working on getting the list of Linked Silos to show up here;
-              haven't started that yet
-              *
-              *
-              *
-            */}
           </PropertiesTable.Row>
         </PropertiesTable>
       </PropertiesTable.Group>

--- a/app/pages/system/networking/IpPoolPage.tsx
+++ b/app/pages/system/networking/IpPoolPage.tsx
@@ -79,10 +79,10 @@ export function IpPoolPage() {
       </PageHeader>
       <PropertiesTable.Group className="mb-12">
         <PropertiesTable>
+          <PropertiesTable.Row label="ID">{pool.id}</PropertiesTable.Row>
           <PropertiesTable.Row label="Description">
             {pool.description || <EmptyCell />}
           </PropertiesTable.Row>
-          <PropertiesTable.Row label="ID">{pool.id}</PropertiesTable.Row>
         </PropertiesTable>
         <PropertiesTable>
           <PropertiesTable.Row label="Created">
@@ -120,7 +120,7 @@ function UtilizationBars() {
 
   return (
     <>
-      <h2 className="mb-3 pl-3 text-mono-xs text-secondary">Utilization</h2>
+      <h2 className="mb-3 pl-3 text-mono-sm text-secondary">Utilization</h2>
       <div className="mb-8 flex min-w-min flex-col gap-4 lg+:flex-row">
         {ipv4.capacity > 0 && (
           <CapacityBar

--- a/app/pages/system/networking/IpPoolPage.tsx
+++ b/app/pages/system/networking/IpPoolPage.tsx
@@ -31,16 +31,18 @@ import { getIpPoolSelector, useForm, useIpPoolSelector } from '~/hooks'
 import { confirmAction } from '~/stores/confirm-action'
 import { addToast } from '~/stores/toast'
 import { DefaultPoolCell } from '~/table/cells/DefaultPoolCell'
-import { SkeletonCell } from '~/table/cells/EmptyCell'
+import { EmptyCell, SkeletonCell } from '~/table/cells/EmptyCell'
 import { LinkCell } from '~/table/cells/LinkCell'
 import { useColsWithActions, type MenuAction } from '~/table/columns/action-col'
 import { Columns } from '~/table/columns/common'
 import { PAGE_SIZE, useQueryTable } from '~/table/QueryTable'
 import { CreateButton, CreateLink } from '~/ui/lib/CreateButton'
+import { DateTime } from '~/ui/lib/DateTime'
 import { EmptyMessage } from '~/ui/lib/EmptyMessage'
 import { Message } from '~/ui/lib/Message'
 import { Modal } from '~/ui/lib/Modal'
 import { PageHeader, PageTitle } from '~/ui/lib/PageHeader'
+import { PropertiesTable } from '~/ui/lib/PropertiesTable'
 import { TableControls, TableControlsText } from '~/ui/lib/Table'
 import { Tabs } from '~/ui/lib/Tabs'
 import { links } from '~/util/links'
@@ -75,6 +77,32 @@ export function IpPoolPage() {
       <PageHeader>
         <PageTitle icon={<Networking24Icon />}>{pool.name}</PageTitle>
       </PageHeader>
+      <PropertiesTable.Group className="mb-12">
+        <PropertiesTable>
+          <PropertiesTable.Row label="Description">
+            {pool.description || <EmptyCell />}
+          </PropertiesTable.Row>
+          <PropertiesTable.Row label="ID">{pool.id}</PropertiesTable.Row>
+        </PropertiesTable>
+        <PropertiesTable>
+          <PropertiesTable.Row label="Created">
+            <DateTime date={pool.timeCreated} />
+          </PropertiesTable.Row>
+          <PropertiesTable.Row label="Linked Silos">
+            <DateTime date={pool.timeModified} />
+            {/*
+              *
+              *
+              * 
+              ROUGH EDGE: You're working on getting the list of Linked Silos to show up here;
+              haven't started that yet
+              *
+              *
+              *
+            */}
+          </PropertiesTable.Row>
+        </PropertiesTable>
+      </PropertiesTable.Group>
       <UtilizationBars />
       <QueryParamTabs className="full-width" defaultValue="ranges">
         <Tabs.List>
@@ -101,32 +129,43 @@ function UtilizationBars() {
   if (ipv4.capacity === 0 && ipv6.capacity === 0n) return null
 
   return (
-    <div className="-mt-8 mb-8 flex min-w-min flex-col gap-3 lg+:flex-row">
-      {ipv4.capacity > 0 && (
-        <CapacityBar
-          icon={<IpGlobal16Icon />}
-          title="IPv4"
-          provisioned={ipv4.allocated}
-          capacity={ipv4.capacity}
-          provisionedLabel="Allocated"
-          capacityLabel="Capacity"
-          unit="IPs"
-          includeUnit={false}
-        />
-      )}
-      {ipv6.capacity > 0 && (
-        <CapacityBar
-          icon={<IpGlobal16Icon />}
-          title="IPv6"
-          provisioned={ipv6.allocated}
-          capacity={ipv6.capacity}
-          provisionedLabel="Allocated"
-          capacityLabel="Capacity"
-          unit="IPs"
-          includeUnit={false}
-        />
-      )}
-    </div>
+    <>
+      <h2 className="mb-3 flex items-center pl-3 text-mono-xs text-secondary ">
+        Capacity available
+      </h2>
+      <div className="mb-8 flex min-w-min flex-col gap-3 lg+:flex-row">
+        {ipv4.capacity > 0 ? (
+          <CapacityBar
+            icon={<IpGlobal16Icon />}
+            title="IPv4"
+            provisioned={ipv4.allocated}
+            capacity={ipv4.capacity}
+            provisionedLabel="Allocated"
+            capacityLabel="Capacity"
+            unit="IPs"
+            includeUnit={false}
+          />
+        ) : (
+          // necessary for aligning capacity bar with Properties Table
+          <div className="w-full"></div>
+        )}
+        {ipv6.capacity > 0 ? (
+          <CapacityBar
+            icon={<IpGlobal16Icon />}
+            title="IPv6"
+            provisioned={ipv6.allocated}
+            capacity={ipv6.capacity}
+            provisionedLabel="Allocated"
+            capacityLabel="Capacity"
+            unit="IPs"
+            includeUnit={false}
+          />
+        ) : (
+          // necessary for aligning capacity bar with Properties Table
+          <div className="w-full"></div>
+        )}
+      </div>
+    </>
   )
 }
 

--- a/app/pages/system/networking/IpPoolPage.tsx
+++ b/app/pages/system/networking/IpPoolPage.tsx
@@ -120,9 +120,7 @@ function UtilizationBars() {
 
   return (
     <>
-      <h2 className="mb-3 flex items-center pl-3 text-mono-xs text-secondary ">
-        Capacity available
-      </h2>
+      <h2 className="mb-3 pl-3 text-mono-xs text-secondary">Capacity available</h2>
       <div className="mb-8 flex min-w-min flex-col gap-3 lg+:flex-row">
         {ipv4.capacity > 0 ? (
           <CapacityBar

--- a/app/pages/system/networking/IpPoolPage.tsx
+++ b/app/pages/system/networking/IpPoolPage.tsx
@@ -146,9 +146,6 @@ function UtilizationBars() {
             includeUnit={false}
           />
         )}
-        {/* necessary for aligning capacity bar with Properties Table */}
-        {((ipv4.capacity > 0 && ipv6.capacity === 0n) ||
-          (ipv4.capacity === 0 && ipv6.capacity > 0n)) && <div className="w-full"></div>}
       </div>
     </>
   )


### PR DESCRIPTION
Fixes #2177 

This PR adds a properties table to the top of the IP Pool page.
<img width="1227" alt="Screenshot 2024-04-22 at 12 41 26 PM" src="https://github.com/oxidecomputer/console/assets/22547/b8e42dde-3fb7-49eb-8002-bad5499c74cf">

It also makes a slight tweak to the half-width capacity bar, to make sure that it aligns with the properties table.

The code differs from Figma in that the original design lists the linked silos in the bottom-right property slot. Because the linked silos are so available, though (a bit further down the page), @david-crespo and I decided to put something else in the bottom-right slot. I used the existing pattern of "last modified", but there might be a more useful one.

Eugene suggested possibly using "is this the default IP Pool for this Silo?"
