### PR TITLE
Rearrange firewall rules form and add help text

### DIFF
--- a/app/api/util.spec.ts
+++ b/app/api/util.spec.ts
@@ -23,6 +23,12 @@ describe('parsePortRange', () => {
       expect(parsePortRange('1-45690')).toEqual([1, 45690])
       expect(parsePortRange('5-5')).toEqual([5, 5])
     })
+
+    it('with surrounding whitespace', () => {
+      expect(parsePortRange('123-456 ')).toEqual([123, 456])
+      expect(parsePortRange('  1-45690')).toEqual([1, 45690])
+      expect(parsePortRange('  5-5  \n')).toEqual([5, 5])
+    })
   })
 
   describe('rejects', () => {

--- a/app/api/util.ts
+++ b/app/api/util.ts
@@ -45,7 +45,7 @@ type PortRange = [number, number]
 // null so we can annotate the failure with a reason
 export function parsePortRange(portRange: string): PortRange | null {
   // TODO: pull pattern from openapi spec (requires generator work)
-  const match = /^([0-9]{1,5})((?:-)[0-9]{1,5})?$/.exec(portRange)
+  const match = /^([0-9]{1,5})((?:-)[0-9]{1,5})?$/.exec(portRange.trim())
   if (!match) return null
 
   const p1 = parseInt(match[1], 10)

--- a/app/forms/firewall-rules-create.tsx
+++ b/app/forms/firewall-rules-create.tsx
@@ -247,7 +247,7 @@ export const CommonFields = ({ error, control }: CommonFieldsProps) => {
       <h3 className="mb-4 text-sans-2xl">Targets</h3>
       <Message
         variant="info"
-        content=" Specify instances this rule applies to. For example, target a VPC to make this rule apply to every instance in the VPC. Targets are additive: the rule applies to instances matching any of the specified targets."
+        content="Targets determine the instances to which this rule applies. You can target instances directly or specify a VPC, VPC subnet, IP, or IP subnet which will apply the rule to all matching instances. Targets are additive: the rule applies to instances matching any target."
       />
       {/* TODO: make ListboxField smarter with the values like RadioField is */}
       <ListboxField

--- a/app/forms/firewall-rules-create.tsx
+++ b/app/forms/firewall-rules-create.tsx
@@ -172,10 +172,8 @@ export const CommonFields = ({ error, control }: CommonFieldsProps) => {
   const ports = useController({ name: 'ports', control }).field
   const submitPortRange = portRangeForm.handleSubmit(({ portRange }) => {
     const portRangeValue = portRange.trim()
-    // ignore click if invalid or already in the list
-    // TODO: show error instead of ignoring the click
-    if (!parsePortRange(portRangeValue)) return
-    if (ports.value.includes(portRangeValue)) return
+    // at this point we've already validated in validate() that it parses and
+    // that it is not already in the list
     ports.onChange([...ports.value, portRangeValue])
     portRangeForm.reset()
   })
@@ -278,6 +276,8 @@ export const CommonFields = ({ error, control }: CommonFieldsProps) => {
               submitTarget(e)
             }
           }}
+          // TODO: validate here, but it's complicated because it's conditional
+          // on which type is selected
         />
 
         <div className="flex justify-end">
@@ -364,6 +364,10 @@ export const CommonFields = ({ error, control }: CommonFieldsProps) => {
                 e.preventDefault() // prevent full form submission
                 submitPortRange(e)
               }
+            }}
+            validate={(value) => {
+              if (!parsePortRange(value)) return 'Not a valid port range'
+              if (ports.value.includes(value.trim())) return 'Port range already added'
             }}
           />
         </div>
@@ -457,6 +461,8 @@ export const CommonFields = ({ error, control }: CommonFieldsProps) => {
               submitHost(e)
             }
           }}
+          // TODO: validate here, but it's complicated because it's conditional
+          // on which type is selected
         />
 
         <div className="flex justify-end">

--- a/app/forms/firewall-rules-create.tsx
+++ b/app/forms/firewall-rules-create.tsx
@@ -215,12 +215,6 @@ export const CommonFields = ({ error, control }: CommonFieldsProps) => {
       <NameField name="name" control={control} />
       <DescriptionField name="description" control={control} />
 
-      <NumberField
-        name="priority"
-        description="Must be 0&ndash;65535"
-        required
-        control={control}
-      />
       <RadioField
         name="action"
         column
@@ -239,6 +233,12 @@ export const CommonFields = ({ error, control }: CommonFieldsProps) => {
           { value: 'inbound', label: 'Inbound' },
           { value: 'outbound', label: 'Outbound' },
         ]}
+      />
+      <NumberField
+        name="priority"
+        description="Must be 0&ndash;65535. Lower-numbered rules apply first."
+        required
+        control={control}
       />
 
       <FormDivider />

--- a/test/e2e/firewall-rules.e2e.ts
+++ b/test/e2e/firewall-rules.e2e.ts
@@ -54,13 +54,27 @@ test('can create firewall rule', async ({ page }) => {
   const hosts = page.getByRole('table', { name: 'Host filters' })
   await expectRowVisible(hosts, { Type: 'instance', Value: 'host-filter-instance' })
 
-  // TODO: test invalid port range once I put an error message in there
-  await page.getByRole('textbox', { name: 'Port filters' }).fill('123-456')
-  await page.getByRole('button', { name: 'Add port filter' }).click()
+  const portRangeField = page.getByRole('textbox', { name: 'Port filters' })
+  const invalidPort = page.getByRole('dialog').getByText('Not a valid port range')
+  const addPortButton = page.getByRole('button', { name: 'Add port filter' })
+  await portRangeField.fill('abc')
+  await expect(invalidPort).toBeHidden()
+  await addPortButton.click()
+  await expect(invalidPort).toBeVisible()
+
+  await portRangeField.fill('123-456')
+  await addPortButton.click()
+  await expect(invalidPort).toBeHidden()
 
   // port range is added to port ranges table
   const ports = page.getByRole('table', { name: 'Port filters' })
   await expectRowVisible(ports, { 'Port ranges': '123-456' })
+
+  const dupePort = page.getByRole('dialog').getByText('Port range already added')
+  await expect(dupePort).toBeHidden()
+  await portRangeField.fill('123-456')
+  // don't need to click because we're already validating onChange
+  await expect(dupePort).toBeVisible()
 
   // check the UDP box
   await page.locator('text=UDP').click()

--- a/test/e2e/firewall-rules.e2e.ts
+++ b/test/e2e/firewall-rules.e2e.ts
@@ -31,7 +31,7 @@ test('can create firewall rule', async ({ page }) => {
   await expect(modal).toBeVisible()
 
   await page.fill('input[name=name]', 'my-new-rule')
-  await page.locator('text=Outbound').click()
+  await page.getByRole('radio', { name: 'Outbound' }).click()
 
   await page.fill('role=textbox[name="Priority"]', '5')
 
@@ -55,18 +55,18 @@ test('can create firewall rule', async ({ page }) => {
   await expectRowVisible(hosts, { Type: 'instance', Value: 'host-filter-instance' })
 
   // TODO: test invalid port range once I put an error message in there
-  await page.fill('role=textbox[name="Port filter"]', '123-456')
+  await page.getByRole('textbox', { name: 'Port filters' }).fill('123-456')
   await page.getByRole('button', { name: 'Add port filter' }).click()
 
   // port range is added to port ranges table
-  const ports = page.getByRole('table', { name: 'Ports' })
-  await expectRowVisible(ports, { Range: '123-456' })
+  const ports = page.getByRole('table', { name: 'Port filters' })
+  await expectRowVisible(ports, { 'Port ranges': '123-456' })
 
   // check the UDP box
   await page.locator('text=UDP').click()
 
   // submit the form
-  await page.locator('text="Add rule"').click()
+  await page.getByRole('button', { name: 'Add rule' }).click()
 
   // modal closes again
   await expect(modal).toBeHidden()


### PR DESCRIPTION
The diff is a nightmare compared to the amount of changes because it's a lot of shuffling and fiddly margin stuff. I'd focus on checking the rendered result.

https://console-git-firewall-rules-help-oxidecomputer.vercel.app/projects/mock-project/vpcs/mock-vpc

<img width="503" alt="image" src="https://github.com/oxidecomputer/console/assets/3612203/73902c8a-0a3f-4721-ad9b-715b0a00c665">

<img width="485" alt="image" src="https://github.com/oxidecomputer/console/assets/3612203/76adb7b6-1c8a-4850-b222-0ddc5cc65cf0">
﻿
<img width="487" alt="image" src="https://github.com/oxidecomputer/console/assets/3612203/eb6905ee-457b-42d1-bfd2-86321e765ecc">