### PR TITLE
Rename Access & IAM to Access

### DIFF
--- a/app/layouts/ProjectLayout.tsx
+++ b/app/layouts/ProjectLayout.tsx
@@ -66,7 +66,7 @@ export function ProjectLayout({ overrideContentPane }: ProjectLayoutProps) {
           { value: 'Images', path: pb.projectImages(projectSelector) },
           { value: 'VPCs', path: pb.vpcs(projectSelector) },
           { value: 'Floating IPs', path: pb.floatingIps(projectSelector) },
-          { value: 'Access & IAM', path: pb.projectAccess(projectSelector) },
+          { value: 'Access', path: pb.projectAccess(projectSelector) },
         ]
           // filter out the entry for the path we're currently on
           .filter((i) => i.path !== pathname)
@@ -115,7 +115,7 @@ export function ProjectLayout({ overrideContentPane }: ProjectLayoutProps) {
             <IpGlobal16Icon /> Floating IPs
           </NavLinkItem>
           <NavLinkItem to={pb.projectAccess(projectSelector)}>
-            <Access16Icon title="Access & IAM" /> Access &amp; IAM
+            <Access16Icon title="Access" /> Access &amp; IAM
           </NavLinkItem>
         </Sidebar.Nav>
       </Sidebar>

--- a/app/layouts/SiloLayout.tsx
+++ b/app/layouts/SiloLayout.tsx
@@ -37,7 +37,7 @@ export function SiloLayout() {
           { value: 'Projects', path: pb.projects() },
           { value: 'Images', path: pb.siloImages() },
           { value: 'Utilization', path: pb.siloUtilization() },
-          { value: 'Access & IAM', path: pb.siloAccess() },
+          { value: 'Access', path: pb.siloAccess() },
         ]
           // filter out the entry for the path we're currently on
           .filter((i) => i.path !== pathname)
@@ -72,7 +72,7 @@ export function SiloLayout() {
             <Metrics16Icon /> Utilization
           </NavLinkItem>
           <NavLinkItem to={pb.siloAccess()}>
-            <Access16Icon /> Access & IAM
+            <Access16Icon /> Access
           </NavLinkItem>
         </Sidebar.Nav>
       </Sidebar>

--- a/app/routes.tsx
+++ b/app/routes.tsx
@@ -258,7 +258,7 @@ export const routes = createRoutesFromElements(
           path="access"
           element={<SiloAccessPage />}
           loader={SiloAccessPage.loader}
-          handle={{ crumb: 'Access & IAM' }}
+          handle={{ crumb: 'Access' }}
         />
       </Route>
 
@@ -413,7 +413,7 @@ export const routes = createRoutesFromElements(
           path="access"
           element={<ProjectAccessPage />}
           loader={ProjectAccessPage.loader}
-          handle={{ crumb: 'Access & IAM' }}
+          handle={{ crumb: 'Access' }}
         />
       </Route>
     </Route>

--- a/test/e2e/project-access.e2e.ts
+++ b/test/e2e/project-access.e2e.ts
@@ -11,10 +11,10 @@ import { expect, expectNotVisible, expectRowVisible, expectVisible, test } from 
 
 test('Click through project access page', async ({ page }) => {
   await page.goto('/projects/mock-project')
-  await page.click('role=link[name*="Access & IAM"]')
+  await page.click('role=link[name*="Access"]')
 
   // page is there, we see user 1 and 3 but not 2 or 4
-  await expectVisible(page, ['role=heading[name*="Access & IAM"]'])
+  await expectVisible(page, ['role=heading[name*="Access"]'])
   const table = page.locator('table')
   await expectRowVisible(table, {
     Name: 'Hannah Arendt',

--- a/test/e2e/silo-access.e2e.ts
+++ b/test/e2e/silo-access.e2e.ts
@@ -15,9 +15,9 @@ test('Click through silo access page', async ({ page }) => {
   const table = page.locator('role=table')
 
   // page is there, we see user 1 and 2 but not 3
-  await page.click('role=link[name*="Access & IAM"]')
+  await page.click('role=link[name*="Access"]')
 
-  await expectVisible(page, ['role=heading[name*="Access & IAM"]'])
+  await expectVisible(page, ['role=heading[name*="Access"]'])
   await expectRowVisible(table, {
     Name: 'real-estate-devs',
     Type: 'Group',


### PR DESCRIPTION
Closes #2196

We do call it an IAM policy in the [API endpoint descriptions](https://github.com/oxidecomputer/omicron/blob/4fda855fc48b385ad82c667dad79f835ef7f3c76/openapi/nexus.json), but I'm not sure that changes much. It would be nice to use the word policy since that's in the endpoint's path, but Access Policy might be kind of noisy. Open to any input.

<img width="511" alt="image" src="https://github.com/oxidecomputer/console/assets/3612203/7a696fc6-8c38-486d-b003-95f3446f67cc">
