### PR TITLE
Update copy regarding disk attach / detach requirements

### DIFF
--- a/app/pages/project/instances/instance/tabs/StorageTab.tsx
+++ b/app/pages/project/instances/instance/tabs/StorageTab.tsx
@@ -176,8 +176,8 @@ export function StorageTab() {
             onClick={() => setShowDiskCreate(true)}
             disabledReason={
               <>
-                Instance must be <span className="text-default">stopped</span> to create a
-                disk
+                Instance must be <span className="text-default">stopped</span> to create and
+                attach a disk
               </>
             }
             disabled={!instanceCan.attachDisk(instance)}

--- a/app/pages/project/instances/instance/tabs/StorageTab.tsx
+++ b/app/pages/project/instances/instance/tabs/StorageTab.tsx
@@ -62,9 +62,6 @@ const staticCols = [
   colHelper.accessor('timeCreated', Columns.timeCreated),
 ]
 
-const attachableStates = fancifyStates(instanceCan.attachDisk.states)
-const detachableStates = fancifyStates(instanceCan.detachDisk.states)
-
 export function StorageTab() {
   const [showDiskCreate, setShowDiskCreate] = useState(false)
   const [showDiskAttach, setShowDiskAttach] = useState(false)
@@ -128,7 +125,10 @@ export function StorageTab() {
       {
         label: 'Detach',
         disabled: !instanceCan.detachDisk(instance) && (
-          <>Instance must be in state {detachableStates} before disk can be detached</>
+          <>
+            Instance must be <span className="text-default">stopped</span> before disk can
+            be detached
+          </>
         ),
         onActivate() {
           detachDisk.mutate({ body: { disk: disk.name }, ...instancePathQuery })
@@ -174,7 +174,12 @@ export function StorageTab() {
           <Button
             size="sm"
             onClick={() => setShowDiskCreate(true)}
-            disabledReason={<>Instance must be {attachableStates} to create a disk</>}
+            disabledReason={
+              <>
+                Instance must be <span className="text-default">stopped</span> to create a
+                disk
+              </>
+            }
             disabled={!instanceCan.attachDisk(instance)}
           >
             Create new disk
@@ -183,7 +188,12 @@ export function StorageTab() {
             variant="secondary"
             size="sm"
             onClick={() => setShowDiskAttach(true)}
-            disabledReason={<>Instance must be {attachableStates} to attach a disk</>}
+            disabledReason={
+              <>
+                Instance must be <span className="text-default">stopped</span> to attach a
+                disk
+              </>
+            }
             disabled={!instanceCan.attachDisk(instance)}
           >
             Attach existing disk
@@ -191,7 +201,8 @@ export function StorageTab() {
         </div>
         {!instanceCan.attachDisk(instance) && (
           <span className="max-w-xs text-sans-md text-tertiary">
-            A disk cannot be added or attached unless the instance is {attachableStates}.
+            The instance must be <span className="text-default">stopped</span> to add or
+            attach a disk.
           </span>
         )}
       </div>

--- a/test/e2e/instance-disks.e2e.ts
+++ b/test/e2e/instance-disks.e2e.ts
@@ -18,8 +18,7 @@ import {
 test('Attach disk', async ({ page }) => {
   await page.goto('/projects/mock-project/instances/db1')
 
-  const warning =
-    'A disk cannot be added or attached unless the instance is creating or stopped.'
+  const warning = 'The instance must be stopped to add or attach a disk.'
   await expect(page.getByText(warning)).toBeVisible()
 
   const row = page.getByRole('row', { name: 'disk-1', exact: false })
@@ -30,7 +29,7 @@ test('Attach disk', async ({ page }) => {
   await expect(page.getByRole('menuitem', { name: 'Detach' })).toBeDisabled()
   await page.getByRole('menuitem', { name: 'Detach' }).hover()
   await expect(
-    page.getByText('Instance must be in state creating, stopped, or failed')
+    page.getByText('Instance must be stopped before disk can be detached')
   ).toBeVisible()
   await page.keyboard.press('Escape') // close menu
 


### PR DESCRIPTION
Currently, we have some copy on the Storage tab of the Instance page, where we tell the user that certain conditions have to be met (the instance has to be stopped) before the user can take specific actions (detaching the disk). There's some other copy that — while technically accurate (probably) — aren't things that the user really cares about in that moment.

![image](https://github.com/oxidecomputer/console/assets/22547/2df76ea3-725a-4914-bdc5-08b9999d776c)

This PR updates that view, so that the thing the user needs to know — you need to stop the instance in order to detach the disk, or add a new disk — is more clearly linked to the next step they need to take — stopping the instance.
<img width="1224" alt="Screenshot 2024-04-26 at 3 48 24 PM" src="https://github.com/oxidecomputer/console/assets/22547/ae75fcd5-510a-4512-8a9f-a1f7846ed46b">

I'm open to copy suggestions, as always, though I think what I have here is pretty clear.