### PR TITLE
Access & IAM → Access – a few last spots

### DIFF
--- a/app/layouts/ProjectLayout.tsx
+++ b/app/layouts/ProjectLayout.tsx
@@ -115,7 +115,7 @@ export function ProjectLayout({ overrideContentPane }: ProjectLayoutProps) {
             <IpGlobal16Icon /> Floating IPs
           </NavLinkItem>
           <NavLinkItem to={pb.projectAccess(projectSelector)}>
-            <Access16Icon title="Access" /> Access &amp; IAM
+            <Access16Icon title="Access" /> Access
           </NavLinkItem>
         </Sidebar.Nav>
       </Sidebar>

--- a/app/pages/SiloAccessPage.tsx
+++ b/app/pages/SiloAccessPage.tsx
@@ -161,7 +161,7 @@ export function SiloAccessPage() {
   return (
     <>
       <PageHeader>
-        <PageTitle icon={<Access24Icon />}>Access &amp; IAM</PageTitle>
+        <PageTitle icon={<Access24Icon />}>Access</PageTitle>
       </PageHeader>
 
       <TableActions>

--- a/app/pages/project/access/ProjectAccessPage.tsx
+++ b/app/pages/project/access/ProjectAccessPage.tsx
@@ -195,7 +195,7 @@ export function ProjectAccessPage() {
   return (
     <>
       <PageHeader>
-        <PageTitle icon={<Access24Icon />}>Access &amp; IAM</PageTitle>
+        <PageTitle icon={<Access24Icon />}>Access</PageTitle>
       </PageHeader>
 
       <TableActions>


### PR DESCRIPTION
Closes #2196

We had a few spots where we were using `&amp;`, so searching for `Access & IAM` didn't catch a few `Access &amp; IAM`s.