### PR TITLE
Use TS client generator from npm

### DIFF
--- a/docs/update-pinned-api.md
+++ b/docs/update-pinned-api.md
@@ -1,9 +1,5 @@
 # Updating the pinned API version
 
-## Setup
-
-The API generation script assumes you have `oxide.ts` cloned under the same parent directory as the console and have run `npm install` in there.
-
 ## Instructions
 
 1. Update [`OMICRON_VERSION`](/OMICRON_VERSION) with new Omicron commit hash

--- a/tools/deno/api-diff.ts
+++ b/tools/deno/api-diff.ts
@@ -99,7 +99,7 @@ async function genForCommit(commit: string, force: boolean) {
     await $`rm -rf ${tmpDir}`
     await $`mkdir -p ${tmpDir}`
     console.log(`Generating for ${commit}...`)
-    await $`npx tsx ../oxide.ts/generator/index.ts ${specUrl(commit)} ${tmpDir}`
+    await $`npx @oxide/openapi-gen-ts@0.1.14 ${specUrl(commit)} ${tmpDir}`
     await $`npx prettier --write --log-level error ${tmpDir}`
   }
 

--- a/tools/generate_api_client.sh
+++ b/tools/generate_api_client.sh
@@ -9,19 +9,13 @@ set -o errexit # exit if anything fails
 set -o pipefail
 set -o xtrace
 
-# script assumes oxide.ts is cloned under the same parent dir as console and
-# you've run `npm install` over there
-
 OMICRON_SHA=$(head -n 1 OMICRON_VERSION)
 GEN_DIR="$PWD/app/api/__generated__"
 
 SPEC_URL="https://raw.githubusercontent.com/oxidecomputer/omicron/$OMICRON_SHA/openapi/nexus.json"
 
-npx tsx ../oxide.ts/generator/index.ts $SPEC_URL $GEN_DIR
+npx @oxide/openapi-gen-ts@0.1.14 $SPEC_URL $GEN_DIR --features msw
 npx prettier --write --log-level error "$GEN_DIR"
-
-# hack until we start pulling this from npm. we don't want this file
-rm "$GEN_DIR/type-test.ts"
 
 cat > $GEN_DIR/OMICRON_VERSION <<EOF
 # generated file. do not update manually. see docs/update-pinned-api.md


### PR DESCRIPTION
No functional changes. Now you don't have to clone `oxide.ts` to regen the client. `api-diff.ts` is also now standalone so I will probably move it out of this repo.