### PR TITLE
Add external IP selection to instance creation form

### DIFF
--- a/app/forms/instance-create.tsx
+++ b/app/forms/instance-create.tsx
@@ -538,7 +538,6 @@ const AdvancedAccordion = ({
   // tell, inside AccordionItem, when an accordion is opened so we can scroll its
   // contents into view
   const [openItems, setOpenItems] = useState<string[]>([])
-  // TODO: move to prefetched query
   const { data: allPools } = useApiQuery('projectIpPoolList', { query: { limit: 1000 } })
   const defaultPool = useMemo(
     () => (allPools ? allPools.items.find((p) => p.isDefault)?.name : undefined),
@@ -557,10 +556,10 @@ const AdvancedAccordion = ({
   }, [assignEphemeralIp, selectedPool, control._formValues])
 
   useEffect(() => {
-    if (!selectedPool && defaultPool) {
+    if (defaultPool) {
       setSelectedPool(defaultPool)
     }
-  }, [defaultPool, selectedPool])
+  }, [defaultPool])
 
   return (
     <Accordion.Root

--- a/app/forms/instance-create.tsx
+++ b/app/forms/instance-create.tsx
@@ -551,7 +551,7 @@ const AdvancedAccordion = ({
 
   useEffect(() => {
     control._formValues.externalIps = assignEphemeralIp
-      ? [{ type: 'ephemeral' }, { pool: selectedPool }]
+      ? [{ type: 'ephemeral', pool: selectedPool }]
       : []
   }, [assignEphemeralIp, selectedPool, control._formValues])
 

--- a/app/forms/instance-create.tsx
+++ b/app/forms/instance-create.tsx
@@ -558,6 +558,7 @@ const AdvancedAccordion = ({
   const assignEphemeralIp = !!ephemeralIp
   const selectedPool = ephemeralIp && 'pool' in ephemeralIp ? ephemeralIp.pool : undefined
   const defaultPool = allPools.find((pool) => pool.isDefault)?.name
+  const defaultPoolLabel = defaultPool ? `${defaultPool} (default)` : 'No pools available'
 
   return (
     <Accordion.Root
@@ -596,13 +597,18 @@ const AdvancedAccordion = ({
                 externalIps.field.onChange(newExternalIps)
               }}
             />
-            <label htmlFor="assignEphemeralIp" className="text-sans-md">
+            <label
+              htmlFor="assignEphemeralIp"
+              className="text-sans-md"
+              aria-label="Assign an ephemeral IP address"
+            >
               Assign an ephemeral IP address
             </label>
           </div>
           <Listbox
             name="pools"
-            label="Assign ephemeral IP from pool"
+            aria-label="Assign ephemeral IP from pool"
+            placeholder={defaultPoolLabel}
             selected={`${allPools.find((pool) => pool.name === selectedPool)?.name}`}
             items={
               allPools.map((pool) => ({

--- a/app/forms/instance-create.tsx
+++ b/app/forms/instance-create.tsx
@@ -557,6 +557,7 @@ const AdvancedAccordion = ({
   const ephemeralIp = externalIps.field.value?.find((ip) => ip.type === 'ephemeral')
   const assignEphemeralIp = !!ephemeralIp
   const selectedPool = ephemeralIp && 'pool' in ephemeralIp ? ephemeralIp.pool : undefined
+  const defaultPool = allPools.find((pool) => pool.isDefault)?.name
 
   return (
     <Accordion.Root
@@ -580,7 +581,7 @@ const AdvancedAccordion = ({
         />
 
         <div className="max-w-lg space-y-2">
-          <h2>External IP</h2>
+          <h2 className="text-sans-md">External IP</h2>
           <div className="flex items-center gap-2.5">
             <Checkbox
               id="assignEphemeralIp"
@@ -590,35 +591,35 @@ const AdvancedAccordion = ({
                   ? externalIps.field.value?.filter((ip) => ip.type !== 'ephemeral')
                   : [
                       ...(externalIps.field.value || []),
-                      { type: 'ephemeral', pool: selectedPool },
+                      { type: 'ephemeral', pool: selectedPool || defaultPool },
                     ]
                 externalIps.field.onChange(newExternalIps)
               }}
             />
-            <label htmlFor="assignEphemeralIp" className="text-sans-md text-secondary">
+            <label htmlFor="assignEphemeralIp" className="text-sans-md">
               Assign an ephemeral IP address
             </label>
           </div>
+          <Listbox
+            name="pools"
+            label="Assign ephemeral IP from pool"
+            selected={`${allPools.find((pool) => pool.name === selectedPool)?.name}`}
+            items={
+              allPools.map((pool) => ({
+                label: `${pool.name}${pool.isDefault ? ' (default)' : ''}`,
+                value: pool.name,
+              })) || []
+            }
+            disabled={!assignEphemeralIp || isSubmitting}
+            required
+            onChange={(value) => {
+              const newExternalIps = externalIps.field.value?.map((ip) =>
+                ip.type === 'ephemeral' ? { ...ip, pool: value } : ip
+              )
+              externalIps.field.onChange(newExternalIps)
+            }}
+          />
         </div>
-        <Listbox
-          name="pools"
-          label="Assign ephemeral IP from pool"
-          selected={`${selectedPool}`}
-          items={
-            allPools.map((pool) => ({
-              label: `${pool.name}${pool.isDefault ? ' (default)' : ''}`,
-              value: pool.name,
-            })) || []
-          }
-          disabled={!assignEphemeralIp || isSubmitting}
-          required
-          onChange={(value) => {
-            const newExternalIps = externalIps.field.value?.map((ip) =>
-              ip.type === 'ephemeral' ? { ...ip, pool: value } : ip
-            )
-            externalIps.field.onChange(newExternalIps)
-          }}
-        />
       </AccordionItem>
       <AccordionItem
         value="configuration"

--- a/app/forms/instance-create.tsx
+++ b/app/forms/instance-create.tsx
@@ -558,7 +558,6 @@ const AdvancedAccordion = ({
   const assignEphemeralIp = !!ephemeralIp
   const selectedPool = ephemeralIp && 'pool' in ephemeralIp ? ephemeralIp.pool : undefined
   const defaultPool = allPools.find((pool) => pool.isDefault)?.name
-  const defaultPoolLabel = defaultPool ? `${defaultPool} (default)` : 'No pools available'
 
   return (
     <Accordion.Root
@@ -608,7 +607,7 @@ const AdvancedAccordion = ({
           <Listbox
             name="pools"
             aria-label="Assign ephemeral IP from pool"
-            placeholder={defaultPoolLabel}
+            placeholder={defaultPool ? `${defaultPool} (default)` : 'Select pool'}
             selected={`${allPools.find((pool) => pool.name === selectedPool)?.name}`}
             items={
               allPools.map((pool) => ({

--- a/test/e2e/instance-create.e2e.ts
+++ b/test/e2e/instance-create.e2e.ts
@@ -51,20 +51,25 @@ test('can create an instance', async ({ page }) => {
   await page.getByRole('button', { name: 'Networking' }).click()
   await page.getByRole('button', { name: 'Configuration' }).click()
 
+  const assignEphemeralIpCheckbox = page.getByRole('checkbox', {
+    name: 'Assign an ephemeral IP address',
+  })
+  const assignEphemeralIpButton = page.getByRole('button', {
+    name: 'Assign ephemeral IP from pool',
+  })
+
   // verify that the ip pool selector is visible and default is selected
-  await expect(
-    page.getByRole('checkbox', { name: 'Assign an ephemeral IP address' })
-  ).toBeChecked()
-  await page.getByRole('button', { name: 'ip-pool-1 (default)' }).click()
+  await expect(assignEphemeralIpCheckbox).toBeChecked()
+  await assignEphemeralIpButton.click()
   await expect(page.getByRole('option', { name: 'ip-pool-1 (default)' })).toBeEnabled()
 
   // unchecking the box should disable the selector
-  await page.getByRole('checkbox', { name: 'Assign an ephemeral IP address' }).uncheck()
-  await expect(page.getByRole('button', { name: 'Select an option' })).toBeDisabled()
+  await assignEphemeralIpCheckbox.uncheck()
+  await expect(assignEphemeralIpButton).toBeDisabled()
 
   // re-checking the box should re-enable the selector, and other options should be selectable
-  await page.getByRole('checkbox', { name: 'Assign an ephemeral IP address' }).check()
-  await page.getByRole('button', { name: 'ip-pool-1 (default)' }).click()
+  await assignEphemeralIpCheckbox.check()
+  await assignEphemeralIpButton.click()
   await page.getByRole('option', { name: 'ip-pool-2' }).click()
 
   // should be visible in accordion

--- a/test/e2e/instance-create.e2e.ts
+++ b/test/e2e/instance-create.e2e.ts
@@ -51,6 +51,22 @@ test('can create an instance', async ({ page }) => {
   await page.getByRole('button', { name: 'Networking' }).click()
   await page.getByRole('button', { name: 'Configuration' }).click()
 
+  // verify that the ip pool selector is visible and default is selected
+  await expect(
+    page.getByRole('checkbox', { name: 'Assign an ephemeral IP address' })
+  ).toBeChecked()
+  await page.getByRole('button', { name: 'ip-pool-1 (default)' }).click()
+  await expect(page.getByRole('option', { name: 'ip-pool-1 (default)' })).toBeEnabled()
+
+  // unchecking the box should disable the selector
+  await page.getByRole('checkbox', { name: 'Assign an ephemeral IP address' }).uncheck()
+  await expect(page.getByRole('button', { name: 'Select an option' })).toBeDisabled()
+
+  // re-checking the box should re-enable the selector, and other options should be selectable
+  await page.getByRole('checkbox', { name: 'Assign an ephemeral IP address' }).check()
+  await page.getByRole('button', { name: 'ip-pool-1 (default)' }).click()
+  await page.getByRole('option', { name: 'ip-pool-2' }).click()
+
   // should be visible in accordion
   await expectVisible(page, [
     'role=radiogroup[name="Network interface"]',


### PR DESCRIPTION
Fixes #1097
Fixes #1098

Currently, when the user creates an instance, we just create an ephemeral IP and attach it to the instance. With this PR, we give them a checkbox (default = checked) to let them opt out/in of the ephemeral IP creation step, and we give them a dropdown that lets them pick which IP pool to draw the ephemeral IP from.

We will also add the option to select a floating IP (#1099), but that'll be separate from this PR.

I'm not sure about the layout / copy I have in this PR, so would welcome design feedback from @paryhin. I was able to simplify [the designs in Figma](https://www.figma.com/file/zIBsgP7gAkhapyNvVOqsn6/Floating-IPs?type=design&node-id=427%3A22653&mode=design&t=SaUnqJRcykwBNbPD-1) a bit (we can consolidate some of the options there), but I think Eugene will have good suggestions on what I have here.

![Screenshot 2024-05-06 at 5 58 37 PM](https://github.com/oxidecomputer/console/assets/22547/7bc24d22-2dbf-4763-be6f-b4425919dcb3)