### PR TITLE
bump msw to 2.3

### DIFF
--- a/mockServiceWorker.js
+++ b/mockServiceWorker.js
@@ -8,7 +8,7 @@
  * - Please do NOT serve this file on production.
  */
 
-const PACKAGE_VERSION = '2.2.14'
+const PACKAGE_VERSION = '2.3.0'
 const INTEGRITY_CHECKSUM = '26357c79639bfa20d64c0efca2a87423'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,7 @@
         "ip-num": "^1.5.1",
         "jsdom": "^24.0.0",
         "lint-staged": "^15.2.2",
-        "msw": "^2.2.14",
+        "msw": "^2.3.0",
         "patch-package": "^8.0.0",
         "postcss": "^8.4.35",
         "postcss-import": "^16.1.0",
@@ -1981,9 +1981,9 @@
       }
     },
     "node_modules/@mswjs/interceptors": {
-      "version": "0.26.15",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.26.15.tgz",
-      "integrity": "sha512-HM47Lu1YFmnYHKMBynFfjCp0U/yRskHj/8QEJW0CBEPOlw8Gkmjfll+S9b8M7V5CNDw2/ciRxjjnWeaCiblSIQ==",
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.29.1.tgz",
+      "integrity": "sha512-3rDakgJZ77+RiQUuSK69t1F0m8BQKA8Vh5DCS5V0DWvNY67zob2JhhQrhCO0AKLGINTRSFd1tBaHcJTkhefoSw==",
       "dev": true,
       "dependencies": {
         "@open-draft/deferred-promise": "^2.2.0",
@@ -14337,9 +14337,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/msw": {
-      "version": "2.2.14",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-2.2.14.tgz",
-      "integrity": "sha512-64i8rNCa1xzDK8ZYsTrVMli05D687jty8+Th+PU5VTbJ2/4P7fkQFVyDQ6ZFT5FrNR8z2BHhbY47fKNvfHrumA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.3.0.tgz",
+      "integrity": "sha512-cDr1q/QTMzaWhY8n9lpGhceY209k29UZtdTgJ3P8Bzne3TSMchX2EM/ldvn4ATLOktpCefCU2gcEgzHc31GTPw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -14347,7 +14347,7 @@
         "@bundled-es-modules/statuses": "^1.0.1",
         "@inquirer/confirm": "^3.0.0",
         "@mswjs/cookies": "^1.1.0",
-        "@mswjs/interceptors": "^0.26.14",
+        "@mswjs/interceptors": "^0.29.0",
         "@open-draft/until": "^2.1.0",
         "@types/cookie": "^0.6.0",
         "@types/statuses": "^2.0.4",
@@ -21042,9 +21042,9 @@
       }
     },
     "@mswjs/interceptors": {
-      "version": "0.26.15",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.26.15.tgz",
-      "integrity": "sha512-HM47Lu1YFmnYHKMBynFfjCp0U/yRskHj/8QEJW0CBEPOlw8Gkmjfll+S9b8M7V5CNDw2/ciRxjjnWeaCiblSIQ==",
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.29.1.tgz",
+      "integrity": "sha512-3rDakgJZ77+RiQUuSK69t1F0m8BQKA8Vh5DCS5V0DWvNY67zob2JhhQrhCO0AKLGINTRSFd1tBaHcJTkhefoSw==",
       "dev": true,
       "requires": {
         "@open-draft/deferred-promise": "^2.2.0",
@@ -29674,16 +29674,16 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "msw": {
-      "version": "2.2.14",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-2.2.14.tgz",
-      "integrity": "sha512-64i8rNCa1xzDK8ZYsTrVMli05D687jty8+Th+PU5VTbJ2/4P7fkQFVyDQ6ZFT5FrNR8z2BHhbY47fKNvfHrumA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.3.0.tgz",
+      "integrity": "sha512-cDr1q/QTMzaWhY8n9lpGhceY209k29UZtdTgJ3P8Bzne3TSMchX2EM/ldvn4ATLOktpCefCU2gcEgzHc31GTPw==",
       "dev": true,
       "requires": {
         "@bundled-es-modules/cookie": "^2.0.0",
         "@bundled-es-modules/statuses": "^1.0.1",
         "@inquirer/confirm": "^3.0.0",
         "@mswjs/cookies": "^1.1.0",
-        "@mswjs/interceptors": "^0.26.14",
+        "@mswjs/interceptors": "^0.29.0",
         "@open-draft/until": "^2.1.0",
         "@types/cookie": "^0.6.0",
         "@types/statuses": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "ip-num": "^1.5.1",
     "jsdom": "^24.0.0",
     "lint-staged": "^15.2.2",
-    "msw": "^2.2.14",
+    "msw": "^2.3.0",
     "patch-package": "^8.0.0",
     "postcss": "^8.4.35",
     "postcss-import": "^16.1.0",


### PR DESCRIPTION
The release notes mention a potential breaking change depending on whether you rely on throwing  non-response Error objects.

https://github.com/mswjs/msw/releases/tag/v2.3.0

Fortunately we already do what they say you should do, namely making sure to throw actual responses.

https://github.com/oxidecomputer/console/blob/b400ae78ac46ce7e2900607c569771accdf73e0b/app/api/__generated__/msw-handlers.ts#L1309-L1324