### PR TITLE
Add slashes to cliCmd for serial console

### DIFF
--- a/app/util/cli-cmd.ts
+++ b/app/util/cli-cmd.ts
@@ -8,5 +8,5 @@
 
 export const cliCmd = {
   serialConsole: ({ project, instance }: { project: string; instance: string }) =>
-    `oxide instance serial console\n--project ${project}\n--instance ${instance}`,
+    `oxide instance serial console \\\n--project ${project} \\\n--instance ${instance}`,
 }


### PR DESCRIPTION
Fixes #2234

This adds slashes to the "equivalent console command" view, so copying and pasting works into a terminal works as expected.

<img width="461" alt="Screenshot 2024-05-10 at 11 44 54 AM" src="https://github.com/oxidecomputer/console/assets/22547/184426f6-bbc9-449d-bcc2-ce73ceb91300">

copied output:
```
oxide instance serial console \
--project mock-project \
--instance db1
```