### PR TITLE
Add docs popover button to instance create

### DIFF
--- a/app/components/form/FullPageForm.tsx
+++ b/app/components/form/FullPageForm.tsx
@@ -44,6 +44,7 @@ interface FullPageFormProps<TFieldValues extends FieldValues> {
    * constrain the `name` prop to paths in the values object.
    */
   children: ReactNode
+  docsPopover?: ReactNode
 }
 
 const PageActionsContainer = classed.div`flex h-20 items-center gutter`
@@ -59,6 +60,7 @@ export function FullPageForm<TFieldValues extends FieldValues>({
   form,
   onSubmit,
   submitError,
+  docsPopover,
 }: FullPageFormProps<TFieldValues>) {
   const { isSubmitting, isDirty, isSubmitSuccessful } = form.formState
 
@@ -87,6 +89,7 @@ export function FullPageForm<TFieldValues extends FieldValues>({
     <>
       <PageHeader>
         <PageTitle icon={icon}>{title}</PageTitle>
+        {docsPopover}
       </PageHeader>
       <form
         className="ox-form pb-20"

--- a/app/components/form/FullPageForm.tsx
+++ b/app/components/form/FullPageForm.tsx
@@ -5,14 +5,13 @@
  *
  * Copyright Oxide Computer Company
  */
-import { cloneElement, useEffect, type ReactElement, type ReactNode } from 'react'
+import { cloneElement, useEffect, type ReactNode } from 'react'
 import type { FieldValues, UseFormReturn } from 'react-hook-form'
 import { useBlocker, type Blocker } from 'react-router-dom'
 
 import type { ApiError } from '@oxide/api'
 
 import { Modal } from '~/ui/lib/Modal'
-import { PageHeader, PageTitle } from '~/ui/lib/PageHeader'
 import { flattenChildren, pluckFirstOfType } from '~/util/children'
 import { classed } from '~/util/classed'
 
@@ -21,8 +20,6 @@ import { PageActions } from '../PageActions'
 
 interface FullPageFormProps<TFieldValues extends FieldValues> {
   id: string
-  title: string
-  icon: ReactElement
   /** Must provide a reason for submit being disabled */
   submitDisabled?: string
   error?: Error
@@ -44,23 +41,19 @@ interface FullPageFormProps<TFieldValues extends FieldValues> {
    * constrain the `name` prop to paths in the values object.
    */
   children: ReactNode
-  docsPopover?: ReactNode
 }
 
 const PageActionsContainer = classed.div`flex h-20 items-center gutter`
 
 export function FullPageForm<TFieldValues extends FieldValues>({
   id,
-  title,
   children,
   submitDisabled,
   error,
-  icon,
   loading,
   form,
   onSubmit,
   submitError,
-  docsPopover,
 }: FullPageFormProps<TFieldValues>) {
   const { isSubmitting, isDirty, isSubmitSuccessful } = form.formState
 
@@ -87,10 +80,6 @@ export function FullPageForm<TFieldValues extends FieldValues>({
 
   return (
     <>
-      <PageHeader>
-        <PageTitle icon={icon}>{title}</PageTitle>
-        {docsPopover}
-      </PageHeader>
       <form
         className="ox-form pb-20"
         id={id}

--- a/app/forms/instance-create.tsx
+++ b/app/forms/instance-create.tsx
@@ -25,11 +25,13 @@ import {
 } from '@oxide/api'
 import {
   Images16Icon,
+  Instances16Icon,
   Instances24Icon,
   Storage16Icon,
 } from '@oxide/design-system/icons/react'
 
 import { AccordionItem } from '~/components/AccordionItem'
+import { DocsPopover } from '~/components/DocsPopover'
 import { CheckboxField } from '~/components/form/fields/CheckboxField'
 import { DescriptionField } from '~/components/form/fields/DescriptionField'
 import { DiskSizeField } from '~/components/form/fields/DiskSizeField'
@@ -61,7 +63,7 @@ import { Tabs } from '~/ui/lib/Tabs'
 import { TextInputHint } from '~/ui/lib/TextInput'
 import { TipIcon } from '~/ui/lib/TipIcon'
 import { readBlobAsBase64 } from '~/util/file'
-import { links } from '~/util/links'
+import { docLinks, links } from '~/util/links'
 import { nearest10 } from '~/util/math'
 import { pb } from '~/util/path-builder'
 import { GiB } from '~/util/units'
@@ -309,6 +311,14 @@ export function CreateInstanceForm() {
       }}
       loading={createInstance.isPending}
       submitError={createInstance.error}
+      docsPopover={
+        <DocsPopover
+          heading="instances"
+          icon={<Instances16Icon />}
+          summary="Instances are virtual machines that run on the Oxide platform."
+          links={[docLinks.instances, docLinks.vms]}
+        />
+      }
     >
       <NameField name="name" control={control} disabled={isSubmitting} />
       <DescriptionField name="description" control={control} disabled={isSubmitting} />

--- a/app/forms/instance-create.tsx
+++ b/app/forms/instance-create.tsx
@@ -279,7 +279,7 @@ export function CreateInstanceForm() {
           heading="instances"
           icon={<Instances16Icon />}
           summary="Instances are virtual machines that run on the Oxide platform."
-          links={[docLinks.instances, docLinks.vms]}
+          links={[docLinks.instances, docLinks.vms, docLinks.quickStart]}
         />
       </PageHeader>
       <FullPageForm

--- a/app/pages/project/floating-ips/FloatingIpsPage.tsx
+++ b/app/pages/project/floating-ips/FloatingIpsPage.tsx
@@ -59,6 +59,9 @@ FloatingIpsPage.loader = async ({ params }: LoaderFunctionArgs) => {
     apiQueryClient.prefetchQuery('instanceList', {
       query: { project },
     }),
+    apiQueryClient.prefetchQuery('projectIpPoolList', {
+      query: { limit: 1000 },
+    }),
   ])
   return null
 }

--- a/app/pages/project/floating-ips/FloatingIpsPage.tsx
+++ b/app/pages/project/floating-ips/FloatingIpsPage.tsx
@@ -59,9 +59,6 @@ FloatingIpsPage.loader = async ({ params }: LoaderFunctionArgs) => {
     apiQueryClient.prefetchQuery('instanceList', {
       query: { project },
     }),
-    apiQueryClient.prefetchQuery('projectIpPoolList', {
-      query: { limit: 1000 },
-    }),
   ])
   return null
 }

--- a/app/util/links.ts
+++ b/app/util/links.ts
@@ -22,6 +22,7 @@ export const links: Record<string, string> = {
   keyConceptsProjectsDocs:
     'https://docs.oxide.computer/guides/key-entities-and-concepts#_projects',
   projectsDocs: 'https://docs.oxide.computer/guides/onboarding-projects',
+  quickStart: 'https://docs.oxide.computer/guides/quickstart',
   sledDocs:
     'https://docs.oxide.computer/guides/architecture/service-processors#_server_sled',
   snapshotsDocs:
@@ -73,6 +74,10 @@ export const docLinks = {
   projects: {
     href: links.projectsDocs,
     linkText: 'Managing Projects',
+  },
+  quickStart: {
+    href: links.quickStart,
+    linkText: 'Quick Start',
   },
   sleds: {
     href: links.sledDocs,


### PR DESCRIPTION
Fixes #2221 

The full-page form has a custom header, so we'll need to pass the DocsPopover component in as an optional prop.

Currently, `instance-create` is the only place where we call `FullPageForm`, so there aren't other places we need to add this in for now.

<img width="1234" alt="Screenshot 2024-05-10 at 3 12 39 PM" src="https://github.com/oxidecomputer/console/assets/22547/0e551249-8ffe-483f-8cde-578a992ea1a7">
