### PR TITLE
update inventory sidebar link

### DIFF
--- a/app/layouts/SystemLayout.tsx
+++ b/app/layouts/SystemLayout.tsx
@@ -108,7 +108,7 @@ export function SystemLayout() {
           <NavLinkItem to={pb.systemUtilization()}>
             <Metrics16Icon /> Utilization
           </NavLinkItem>
-          <NavLinkItem to={pb.sledInventory()}>
+          <NavLinkItem to={pb.inventory()}>
             <Servers16Icon /> Inventory
           </NavLinkItem>
           <NavLinkItem to={pb.ipPools()}>


### PR DESCRIPTION
Fixes #2173

Currently, the sidebar link directs users to `/inventory/sleds`, which means that the ReactRouter magical `isActive` prop doesn't know that it should be highlighted for either `/inventory/sleds` OR `/inventory/disks`. By changing the route to just `/inventory`, it matches for both, and so it highlights the sidebar item regardless of which tab they're on.
<img width="571" alt="Screenshot 2024-05-10 at 4 01 09 PM" src="https://github.com/oxidecomputer/console/assets/22547/94e49ae2-038e-484e-87ad-c4357c0e2bd9">
<img width="634" alt="Screenshot 2024-05-10 at 4 01 18 PM" src="https://github.com/oxidecomputer/console/assets/22547/3b8f5df4-5701-489a-9b6f-308ec73856d6">

