### PR TITLE
Add IP Pool to table of floating IPs

### DIFF
--- a/app/pages/project/floating-ips/FloatingIpsPage.tsx
+++ b/app/pages/project/floating-ips/FloatingIpsPage.tsx
@@ -95,7 +95,9 @@ const colHelper = createColumnHelper<FloatingIp>()
 const staticCols = [
   colHelper.accessor('name', {}),
   colHelper.accessor('description', Columns.description),
-  colHelper.accessor('ip', {}),
+  colHelper.accessor('ip', {
+    header: 'IP address',
+  }),
   colHelper.accessor('ipPoolId', {
     cell: (info) => <IpPoolCell ipPoolId={info.getValue()} />,
     header: 'IP pool',

--- a/app/ui/lib/Tooltip.tsx
+++ b/app/ui/lib/Tooltip.tsx
@@ -36,7 +36,8 @@ import { usePopoverZIndex } from './SideModal'
 
 export interface TooltipProps {
   delay?: number
-  children?: React.ReactNode
+  /** The target the tooltip hovers near; can not be a raw string. */
+  children?: ReactElement
   /** The text to appear on hover/focus */
   content: string | React.ReactNode
   /**

--- a/mock-api/ip-pool.ts
+++ b/mock-api/ip-pool.ts
@@ -14,7 +14,7 @@ import { defaultSilo } from './silo'
 export const ipPool1: Json<IpPool> = {
   id: '69b5c583-74a9-451a-823d-0741c1ec66e2',
   name: 'ip-pool-1',
-  description: '',
+  description: 'public IPs',
   time_created: new Date().toISOString(),
   time_modified: new Date().toISOString(),
 }
@@ -22,7 +22,7 @@ export const ipPool1: Json<IpPool> = {
 const ipPool2: Json<IpPool> = {
   id: 'af2fbe06-b21d-4364-96b7-a58220bc3242',
   name: 'ip-pool-2',
-  description: '',
+  description: 'VPN IPs',
   time_created: new Date().toISOString(),
   time_modified: new Date().toISOString(),
 }

--- a/test/e2e/floating-ip-create.e2e.ts
+++ b/test/e2e/floating-ip-create.e2e.ts
@@ -63,7 +63,7 @@ test('can detach and attach a floating IP', async ({ page }) => {
 
   await expectRowVisible(page.getByRole('table'), {
     name: 'cola-float',
-    ip: '123.4.56.5',
+    'IP address': '123.4.56.5',
     'Attached to instance': 'db1',
   })
   await clickRowAction(page, 'cola-float', 'Detach')
@@ -92,7 +92,7 @@ test('can detach and attach a floating IP', async ({ page }) => {
   await expect(page.getByRole('dialog')).toBeHidden()
   await expectRowVisible(page.getByRole('table'), {
     name: 'cola-float',
-    ip: '123.4.56.5',
+    'IP address': '123.4.56.5',
     'Attached to instance': 'db1',
   })
 })

--- a/test/e2e/floating-ip-create.e2e.ts
+++ b/test/e2e/floating-ip-create.e2e.ts
@@ -49,6 +49,7 @@ test('can create a floating IP', async ({ page }) => {
   await expectRowVisible(page.getByRole('table'), {
     name: floatingIpName,
     description: 'A description for this Floating IP',
+    'IP pool': 'ip-pool-1',
   })
 })
 


### PR DESCRIPTION
Fixes #2243 

In #2242 we added the `ip_pool_id` to the response object for each Floating IP. Using the `ipPoolView` endpoint, we can pull the name of each pool, meaning we can add the IP Pool's name to the table of Floating IPs.

Hovering over the IP Pool name gives a tooltip with the description of the IP Pool, if it exists.

<img width="1224" alt="Screenshot 2024-05-15 at 9 44 05 AM" src="https://github.com/oxidecomputer/console/assets/22547/40e12138-5a82-4276-9dae-071e0af500b6">

As there is not currently an IP Pool view at the project level (just at the system level), it doesn't make sense to set the IP Pool cell as a link (like we do with the `attached to instance` column), so we're just using a `<Badge>` component.

I made a slight tweak to the Tooltip component's prop types, as I had some confusion over why a `string` passed in as a child of the `Tooltip` wasn't working.