### PR TITLE
Remove Badge from IP Pool cell

### DIFF
--- a/app/pages/project/floating-ips/FloatingIpsPage.tsx
+++ b/app/pages/project/floating-ips/FloatingIpsPage.tsx
@@ -32,7 +32,6 @@ import { InstanceLinkCell } from '~/table/cells/InstanceLinkCell'
 import { useColsWithActions, type MenuAction } from '~/table/columns/action-col'
 import { Columns } from '~/table/columns/common'
 import { PAGE_SIZE, useQueryTable } from '~/table/QueryTable'
-import { Badge } from '~/ui/lib/Badge'
 import { CreateLink } from '~/ui/lib/CreateButton'
 import { EmptyMessage } from '~/ui/lib/EmptyMessage'
 import { Listbox } from '~/ui/lib/Listbox'
@@ -81,13 +80,12 @@ FloatingIpsPage.loader = async ({ params }: LoaderFunctionArgs) => {
 const IpPoolCell = ({ ipPoolId }: { ipPoolId: string }) => {
   const pool = useApiQuery('projectIpPoolView', { path: { pool: ipPoolId } }).data
   if (!pool) return <EmptyCell />
-  const badge = <Badge color="neutral">{pool.name}</Badge>
   return pool.description ? (
     <Tooltip content={pool.description} placement="right">
-      <span>{badge}</span>
+      <span>{pool.name}</span>
     </Tooltip>
   ) : (
-    badge
+    <>{pool.name}</>
   )
 }
 


### PR DESCRIPTION
We just added this column, and I had stuck a Badge component into the new IP Pool column. Crespo pointed out that we typically use badge elements for things like states, where the instance has one of a set of predefined options.

This PR removes the badge, leaving a regular string in its place.

But!

This does create a bit of a dilemma with the tooltip, which houses the `description` of the IP pool. @paryhin, would love your thoughts on the best path forward for this. How should we show the pool's description? I'm open to any approach that makes sense to you.

<img width="1248" alt="Screenshot 2024-05-15 at 3 41 08 PM" src="https://github.com/oxidecomputer/console/assets/22547/5f8b6a3a-cd51-4489-9335-e2184eae946b">

(Note that we do not have a "view IP pool" option at the project level, just at the system level, which is why this isn't a link to a "view" page.)