### PR TITLE
Link-side approach for sidebar link active highlight

### DIFF
--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -88,9 +88,16 @@ export const NavLinkItem = (props: {
   children: React.ReactNode
   end?: boolean
   disabled?: boolean
+  /**
+   * Used for making sure the link highlights for all sub-routes even if it
+   * links to the first sub-route directly, e.g., for route tabs
+   */
+  activePrefix?: string
 }) => {
+  const { pathname } = useLocation()
   // If the current page is the create form for this NavLinkItem's resource, highlight the NavLink in the sidebar
-  const currentPathIsCreateForm = useLocation().pathname.startsWith(`${props.to}-new`)
+  const onCreateFormForPath = pathname.startsWith(`${props.to}-new`)
+  const altActive = props.activePrefix && pathname.startsWith(props.activePrefix)
   return (
     <li>
       <NavLink
@@ -98,7 +105,7 @@ export const NavLinkItem = (props: {
         className={({ isActive }) =>
           cn(linkStyles, {
             'text-accent !bg-accent-secondary hover:!bg-accent-secondary-hover svg:!text-accent-tertiary':
-              isActive || currentPathIsCreateForm,
+              isActive || onCreateFormForPath || altActive,
             'pointer-events-none text-disabled': props.disabled,
           })
         }

--- a/app/layouts/SystemLayout.tsx
+++ b/app/layouts/SystemLayout.tsx
@@ -108,7 +108,7 @@ export function SystemLayout() {
           <NavLinkItem to={pb.systemUtilization()}>
             <Metrics16Icon /> Utilization
           </NavLinkItem>
-          <NavLinkItem to={pb.sledInventory()}>
+          <NavLinkItem to={pb.sledInventory()} activePrefix={pb.inventory()}>
             <Servers16Icon /> Inventory
           </NavLinkItem>
           <NavLinkItem to={pb.ipPools()}>


### PR DESCRIPTION
Closes #2173

This is an alternative to #2238 that avoids changing the paths. We had some issues with loader and back button behavior in the past that we fixed by having the sidebar link go directly to the first tab on the page (in this case `/system/inventory/sleds`) instead of linking to the parent (`/system/inventory`), which is then responsible for doing a replace nav to get to the first tab path.

As part of reviewing #2238 I reviewed the past conversations I could find about this problem

* https://github.com/oxidecomputer/console/pull/1267
* https://github.com/oxidecomputer/console/pull/1267#discussion_r1016766205

and I could **not** reproduce the issue with the solution #2238, but something still makes me nervous about it. So here is the other way to do it. I'm still sort of on the fence (not sure why I can't shake the worry about #2238), but seeing the two approaches side by side will help us think about it.

Clearly this is more complicated, adding logic where the other just goes along with how React Router works by default, so I'd rather do #2238 if we can.