### PR TITLE
Dim plus sign on disabled button

### DIFF
--- a/app/ui/lib/CreateButton.tsx
+++ b/app/ui/lib/CreateButton.tsx
@@ -13,10 +13,12 @@ import { AddRoundel12Icon } from '@oxide/design-system/icons/react'
 
 import { Button, buttonStyle, type ButtonProps } from '~/ui/lib/Button'
 
-export const CreateButton = ({ children, disabled, ...props }: ButtonProps) => (
-  <Button size="sm" className="shrink-0" disabled={disabled} {...props}>
+export const CreateButton = ({ children, ...props }: ButtonProps) => (
+  <Button size="sm" className="shrink-0" {...props}>
     <AddRoundel12Icon
-      className={cn(disabled ? 'text-accent-disabled' : 'text-accent-secondary', 'mr-2')}
+      // dim the icon color from the default (text accent) because it looks a
+      // lot brighter than text, but default disabled color is fine
+      className={cn('mr-2', { 'text-accent-secondary': !props.disabled })}
     />
     {children}
   </Button>

--- a/app/ui/lib/CreateButton.tsx
+++ b/app/ui/lib/CreateButton.tsx
@@ -6,15 +6,18 @@
  * Copyright Oxide Computer Company
  */
 
+import cn from 'classnames'
 import { Link, type LinkProps } from 'react-router-dom'
 
 import { AddRoundel12Icon } from '@oxide/design-system/icons/react'
 
 import { Button, buttonStyle, type ButtonProps } from '~/ui/lib/Button'
 
-export const CreateButton = ({ children, ...props }: ButtonProps) => (
-  <Button size="sm" className="shrink-0" {...props}>
-    <AddRoundel12Icon className="mr-2 text-accent-secondary" />
+export const CreateButton = ({ children, disabled, ...props }: ButtonProps) => (
+  <Button size="sm" className="shrink-0" disabled={disabled} {...props}>
+    <AddRoundel12Icon
+      className={cn(disabled ? 'text-accent-disabled' : 'text-accent-secondary', 'mr-2')}
+    />
     {children}
   </Button>
 )

--- a/test/e2e/instance-networking.e2e.ts
+++ b/test/e2e/instance-networking.e2e.ts
@@ -35,14 +35,16 @@ test('Instance networking tab — NIC table', async ({ page }) => {
     '/projects/mock-project/vpcs/mock-vpc'
   )
 
+  const addNicButton = page.getByRole('button', { name: 'Add network interface' })
+
   // Ensure that the 'Add network interface' button is disabled when the instance is running
-  await expect(page.getByRole('button', { name: 'Add network interface' })).toBeDisabled()
+  await expect(addNicButton).toBeDisabled()
 
   // Have to stop instance to edit NICs
   await stopInstance(page)
 
-  await expect(page.getByRole('button', { name: 'Add network interface' })).toBeEnabled()
-  await page.click('role=button[name="Add network interface"]')
+  await expect(addNicButton).toBeEnabled()
+  await addNicButton.click()
 
   // Add network interface
   // TODO: modal title is not getting hooked up, IDs are wrong

--- a/test/e2e/instance-networking.e2e.ts
+++ b/test/e2e/instance-networking.e2e.ts
@@ -35,9 +35,13 @@ test('Instance networking tab — NIC table', async ({ page }) => {
     '/projects/mock-project/vpcs/mock-vpc'
   )
 
+  // Ensure that the 'Add network interface' button is disabled when the instance is running
+  await expect(page.getByRole('button', { name: 'Add network interface' })).toBeDisabled()
+
   // Have to stop instance to edit NICs
   await stopInstance(page)
 
+  await expect(page.getByRole('button', { name: 'Add network interface' })).toBeEnabled()
   await page.click('role=button[name="Add network interface"]')
 
   // Add network interface


### PR DESCRIPTION
Fixes #2255

With this PR, we're adding a ternary to the CSS display logic; if the button is disabled, we use the `-disabled` color; otherwise, we use the `-secondary` color.

In this screenshot, the top button is enabled; the bottom is disabled.
<img width="663" alt="Screenshot 2024-05-21 at 5 22 03 PM" src="https://github.com/oxidecomputer/console/assets/22547/f131ba38-326c-44e7-812c-c5a9f175730d">
