### PR TITLE
Filter out already-attached disks from instance create and edit views

### DIFF
--- a/app/components/form/fields/DisksTableField.tsx
+++ b/app/components/form/fields/DisksTableField.tsx
@@ -116,6 +116,7 @@ export function DisksTableField({
       )}
       {showDiskAttach && (
         <AttachDiskSideModalForm
+          attachedDisks={items.filter((i) => i.type === 'attach').map((i) => i.name)}
           onDismiss={() => setShowDiskAttach(false)}
           onSubmit={(values) => {
             onChange([...items, { type: 'attach', ...values }])

--- a/app/forms/disk-attach.tsx
+++ b/app/forms/disk-attach.tsx
@@ -14,6 +14,7 @@ import { useForm, useProjectSelector } from '~/hooks'
 const defaultValues = { name: '' }
 
 type AttachDiskProps = {
+  attachedDisks: string[]
   /** If defined, this overrides the usual mutation */
   onSubmit: (diskAttach: { name: string }) => void
   onDismiss: () => void
@@ -26,6 +27,7 @@ type AttachDiskProps = {
  * the optional `loading` and `submitError`
  */
 export function AttachDiskSideModalForm({
+  attachedDisks,
   onSubmit,
   onDismiss,
   loading,
@@ -39,7 +41,7 @@ export function AttachDiskSideModalForm({
   // TODO: error handling
   const detachedDisks =
     useApiQuery('diskList', { query: projectSelector }).data?.items.filter(
-      (d) => d.state.state === 'detached'
+      (d) => d.state.state === 'detached' && !attachedDisks.includes(d.name)
     ) || []
 
   const form = useForm({ defaultValues })

--- a/app/pages/project/instances/instance/tabs/StorageTab.tsx
+++ b/app/pages/project/instances/instance/tabs/StorageTab.tsx
@@ -101,6 +101,10 @@ export function StorageTab() {
   })
 
   const { data: instance } = usePrefetchedApiQuery('instanceView', instancePathQuery)
+  const { data: disks } = usePrefetchedApiQuery('instanceDiskList', {
+    path: { instance: instanceName },
+    query: { project, limit: PAGE_SIZE },
+  })
 
   const makeActions = useCallback(
     (disk: Disk): MenuAction[] => [
@@ -218,6 +222,7 @@ export function StorageTab() {
       )}
       {showDiskAttach && (
         <AttachDiskSideModalForm
+          attachedDisks={disks.items.map((d) => d.name)}
           onDismiss={() => setShowDiskAttach(false)}
           onSubmit={({ name }) => {
             attachDisk.mutate({ ...instancePathQuery, body: { disk: name } })

--- a/test/e2e/instance-disks.e2e.ts
+++ b/test/e2e/instance-disks.e2e.ts
@@ -58,6 +58,9 @@ test('Attach disk', async ({ page }) => {
   await expectVisible(page, ['role=dialog >> text="Disk name is required"'])
 
   await page.click('role=button[name*="Disk name"]')
+
+  // disk-1 is already attached, so should not be visible in the list
+  await expectNotVisible(page, ['role=option[name="disk-1"]'])
   await expectVisible(page, ['role=option[name="disk-3"]', 'role=option[name="disk-4"]'])
   await page.click('role=option[name="disk-3"]')
 


### PR DESCRIPTION
Not ready for review yet; just saving this as a draft PR so I can write down some notes and come back to it.

An enhancement I haven't made here yet is that we can disable the "attach existing disk" button, but to do that we'll need to move the API query higher in the stack, and then pass in the detached-and-available disks to the list component. If the detached-and-available count is 0, we'll disable the button. I'll take a look at that in a little bit.