### PR TITLE
Use Remeda (lodash-like lib)

### DIFF
--- a/app/api/roles.spec.ts
+++ b/app/api/roles.spec.ts
@@ -8,6 +8,7 @@
 import { describe, expect, it, test } from 'vitest'
 
 import {
+  allRoles,
   byGroupThenName,
   deleteRole,
   getEffectiveRole,
@@ -153,4 +154,8 @@ test('byGroupThenName sorts as expected', () => {
   const e = { identityType: 'silo_user' as const, name: 'e' }
 
   expect([c, e, b, d, a].sort(byGroupThenName)).toEqual([a, b, c, d, e])
+})
+
+test('allRoles', () => {
+  expect(allRoles).toEqual(['admin', 'collaborator', 'viewer'])
 })

--- a/app/api/roles.ts
+++ b/app/api/roles.ts
@@ -12,8 +12,7 @@
  * it belongs in the API proper.
  */
 import { useMemo } from 'react'
-
-import { lowestBy, sortBy } from '~/util/array'
+import * as R from 'remeda'
 
 import type { FleetRole, IdentityType, ProjectRole, SiloRole } from './__generated__/Api'
 import { usePrefetchedApiQuery } from './client'
@@ -27,12 +26,13 @@ export type RoleKey = FleetRole | SiloRole | ProjectRole
 /** Turn a role order record into a sorted array of strings. */
 // used for displaying lists of roles, like in a <select>
 const flatRoles = (roleOrder: Record<RoleKey, number>): RoleKey[] =>
-  sortBy(Object.keys(roleOrder) as RoleKey[], (role) => roleOrder[role])
+  R.sortBy(Object.keys(roleOrder) as RoleKey[], (role) => roleOrder[role])
 
-// This is a record only to ensure that all RoleKey are covered
+// This is a record only to ensure that all RoleKey are covered. weird order
+// on purpose so allRoles test can confirm sorting works
 export const roleOrder: Record<RoleKey, number> = {
-  admin: 0,
   collaborator: 1,
+  admin: 0,
   viewer: 2,
 }
 
@@ -41,7 +41,7 @@ export const allRoles = flatRoles(roleOrder)
 
 /** Given a list of roles, get the most permissive one */
 export const getEffectiveRole = (roles: RoleKey[]): RoleKey | undefined =>
-  lowestBy(roles, (role) => roleOrder[role])
+  R.firstBy(roles, (role) => roleOrder[role])
 
 ////////////////////////////
 // Policy helpers

--- a/app/api/util.ts
+++ b/app/api/util.ts
@@ -5,9 +5,9 @@
  *
  * Copyright Oxide Computer Company
  */
-/// Helpers for working with API objects
-import { sumBy } from '~/util/array'
-import { mapValues, pick } from '~/util/object'
+
+import * as R from 'remeda'
+
 import { bytesToGiB } from '~/util/units'
 
 import type {
@@ -60,8 +60,7 @@ export function parsePortRange(portRange: string): PortRange | null {
 export const firewallRuleGetToPut = (
   rule: VpcFirewallRule
 ): NoExtraKeys<VpcFirewallRuleUpdate, VpcFirewallRule> =>
-  pick(
-    rule,
+  R.pick(rule, [
     'name',
     'action',
     'description',
@@ -69,8 +68,8 @@ export const firewallRuleGetToPut = (
     'filters',
     'priority',
     'status',
-    'targets'
-  )
+    'targets',
+  ])
 
 /**
  * Generates a valid name given a list of strings. Must be given at least
@@ -90,45 +89,44 @@ export const genName = (...parts: [string, ...string[]]) => {
   )
 }
 
-export const instanceCan = mapValues(
-  {
-    start: ['stopped'],
-    reboot: ['running'],
-    stop: ['running', 'starting'],
-    delete: ['stopped', 'failed'],
-    // https://github.com/oxidecomputer/omicron/blob/9eff6a4/nexus/db-queries/src/db/datastore/disk.rs#L310-L314
-    detachDisk: ['creating', 'stopped', 'failed'],
-    // https://github.com/oxidecomputer/omicron/blob/a7c7a67/nexus/db-queries/src/db/datastore/disk.rs#L183-L184
-    attachDisk: ['creating', 'stopped'],
-    // https://github.com/oxidecomputer/omicron/blob/8f0cbf0/nexus/db-queries/src/db/datastore/network_interface.rs#L482
-    updateNic: ['stopped'],
-  },
-  // cute way to make it ergonomic to call the test while also making the states
-  // available directly
-  (states: InstanceState[]) => {
-    const test = (i: Instance) => states.includes(i.runState)
-    test.states = states
-    return test
-  }
-)
+const instanceActions: Record<string, InstanceState[]> = {
+  start: ['stopped'],
+  reboot: ['running'],
+  stop: ['running', 'starting'],
+  delete: ['stopped', 'failed'],
+  // https://github.com/oxidecomputer/omicron/blob/9eff6a4/nexus/db-queries/src/db/datastore/disk.rs#L310-L314
+  detachDisk: ['creating', 'stopped', 'failed'],
+  // https://github.com/oxidecomputer/omicron/blob/a7c7a67/nexus/db-queries/src/db/datastore/disk.rs#L183-L184
+  attachDisk: ['creating', 'stopped'],
+  // https://github.com/oxidecomputer/omicron/blob/8f0cbf0/nexus/db-queries/src/db/datastore/network_interface.rs#L482
+  updateNic: ['stopped'],
+}
 
-export const diskCan = mapValues(
-  {
-    // https://github.com/oxidecomputer/omicron/blob/4970c71e/nexus/db-queries/src/db/datastore/disk.rs#L578-L582.
-    delete: ['detached', 'creating', 'faulted'],
-    // TODO: link to API source
-    snapshot: ['attached', 'detached'],
-    // https://github.com/oxidecomputer/omicron/blob/4970c71e/nexus/db-queries/src/db/datastore/disk.rs#L169-L172
-    attach: ['creating', 'detached'],
-  },
-  (states: DiskState['state'][]) => {
-    // only have to Pick because we want this to work for both Disk and
-    // Json<Disk>, which we pass to it in the MSW handlers
-    const test = (d: Pick<Disk, 'state'>) => states.includes(d.state.state)
-    test.states = states
-    return test
-  }
-)
+// setting .states is a cute way to make it ergonomic to call the test function
+// while also making the states available directly
+
+export const instanceCan = R.mapValues(instanceActions, (states) => {
+  const test = (i: Instance) => states.includes(i.runState)
+  test.states = states
+  return test
+})
+
+const diskActions: Record<string, DiskState['state'][]> = {
+  // https://github.com/oxidecomputer/omicron/blob/4970c71e/nexus/db-queries/src/db/datastore/disk.rs#L578-L582.
+  delete: ['detached', 'creating', 'faulted'],
+  // TODO: link to API source
+  snapshot: ['attached', 'detached'],
+  // https://github.com/oxidecomputer/omicron/blob/4970c71e/nexus/db-queries/src/db/datastore/disk.rs#L169-L172
+  attach: ['creating', 'detached'],
+}
+
+export const diskCan = R.mapValues(diskActions, (states) => {
+  // only have to Pick because we want this to work for both Disk and
+  // Json<Disk>, which we pass to it in the MSW handlers
+  const test = (d: Pick<Disk, 'state'>) => states.includes(d.state.state)
+  test.states = states
+  return test
+})
 
 /** Hard coded in the API, so we can hard code it here. */
 export const FLEET_ID = '001de000-1334-4000-8000-000000000000'
@@ -141,8 +139,8 @@ export function totalCapacity(
 ) {
   return {
     disk_tib: Math.ceil(FUDGE * sleds.length * 32 * TBtoTiB), // TODO: make more real
-    ram_gib: Math.ceil(bytesToGiB(FUDGE * sumBy(sleds, (s) => s.usablePhysicalRam))),
-    cpu: Math.ceil(FUDGE * sumBy(sleds, (s) => s.usableHardwareThreads)),
+    ram_gib: Math.ceil(bytesToGiB(FUDGE * R.sumBy(sleds, (s) => s.usablePhysicalRam))),
+    cpu: Math.ceil(FUDGE * R.sumBy(sleds, (s) => s.usableHardwareThreads)),
   }
 }
 

--- a/app/forms/instance-create.tsx
+++ b/app/forms/instance-create.tsx
@@ -9,6 +9,7 @@ import * as Accordion from '@radix-ui/react-accordion'
 import { useEffect, useMemo, useState } from 'react'
 import { useController, useWatch, type Control } from 'react-hook-form'
 import { useNavigate, type LoaderFunctionArgs } from 'react-router-dom'
+import * as R from 'remeda'
 import type { SetRequired } from 'type-fest'
 
 import {
@@ -72,7 +73,6 @@ import { Slash } from '~/ui/lib/Slash'
 import { Tabs } from '~/ui/lib/Tabs'
 import { TextInputHint } from '~/ui/lib/TextInput'
 import { TipIcon } from '~/ui/lib/TipIcon'
-import { isTruthy } from '~/util/array'
 import { readBlobAsBase64 } from '~/util/file'
 import { docLinks, links } from '~/util/links'
 import { nearest10 } from '~/util/math'
@@ -645,7 +645,7 @@ const AdvancedAccordion = ({
   )
   const attachedFloatingIpsData = attachedFloatingIps
     .map((ip) => attachableFloatingIps.find((fip) => fip.name === ip.floatingIp))
-    .filter(isTruthy)
+    .filter(R.isTruthy)
 
   const closeFloatingIpModal = () => {
     setFloatingIpModalOpen(false)

--- a/app/pages/SiloAccessPage.tsx
+++ b/app/pages/SiloAccessPage.tsx
@@ -37,7 +37,7 @@ import { EmptyMessage } from '~/ui/lib/EmptyMessage'
 import { PageHeader, PageTitle } from '~/ui/lib/PageHeader'
 import { TableActions, TableEmptyBox } from '~/ui/lib/Table'
 import { identityTypeLabel, roleColor } from '~/util/access'
-import { groupBy, isTruthy } from '~/util/array'
+import { groupBy } from '~/util/array'
 import { docLinks } from '~/util/links'
 
 const EmptyState = ({ onClick }: { onClick: () => void }) => (
@@ -84,7 +84,7 @@ export function SiloAccessPage() {
       .map(([userId, userAssignments]) => {
         const siloRole = userAssignments.find((a) => a.roleSource === 'silo')?.roleName
 
-        const roles = [siloRole].filter(isTruthy)
+        const roles = siloRole ? [siloRole] : []
 
         const { name, identityType } = userAssignments[0]
 

--- a/app/pages/project/access/ProjectAccessPage.tsx
+++ b/app/pages/project/access/ProjectAccessPage.tsx
@@ -9,6 +9,7 @@
 import { createColumnHelper, getCoreRowModel, useReactTable } from '@tanstack/react-table'
 import { useMemo, useState } from 'react'
 import type { LoaderFunctionArgs } from 'react-router-dom'
+import * as R from 'remeda'
 
 import {
   apiQueryClient,
@@ -42,7 +43,7 @@ import { PageHeader, PageTitle } from '~/ui/lib/PageHeader'
 import { TableActions, TableEmptyBox } from '~/ui/lib/Table'
 import { TipIcon } from '~/ui/lib/TipIcon'
 import { identityTypeLabel, roleColor } from '~/util/access'
-import { groupBy, isTruthy, sortBy } from '~/util/array'
+import { groupBy, sortBy } from '~/util/array'
 import { docLinks } from '~/util/links'
 
 const EmptyState = ({ onClick }: { onClick: () => void }) => (
@@ -101,7 +102,7 @@ export function ProjectAccessPage() {
         const projectAccessRow = userAssignments.find((a) => a.roleSource === 'project')
 
         const roleBadges = sortBy(
-          [siloAccessRow, projectAccessRow].filter(isTruthy),
+          [siloAccessRow, projectAccessRow].filter(R.isTruthy),
           (r) => roleOrder[r.roleName] // sorts strongest role first
         )
 

--- a/app/util/array.spec.tsx
+++ b/app/util/array.spec.tsx
@@ -8,7 +8,7 @@
 import { type ReactElement } from 'react'
 import { expect, test } from 'vitest'
 
-import { groupBy, intersperse, lowestBy, sortBy, splitOnceBy, sumBy } from './array'
+import { groupBy, intersperse, sortBy, splitOnceBy } from './array'
 
 test('sortBy', () => {
   expect(sortBy(['d', 'b', 'c', 'a'])).toEqual(['a', 'b', 'c', 'd'])
@@ -26,19 +26,6 @@ test('sortBy', () => {
       (o) => o.x.length
     )
   ).toEqual([{ x: [0] }, { x: [0, 0] }, { x: [0, 0, 0] }, { x: [0, 0, 0, 0] }])
-})
-
-test('lowestBy', () => {
-  expect(lowestBy([{ x: 'd' }, { x: 'b' }, { x: 'c' }, { x: 'a' }], (o) => o.x)).toEqual({
-    x: 'a',
-  })
-
-  expect(
-    lowestBy(
-      [{ x: [0, 0, 0, 0] }, { x: [0, 0, 0] }, { x: [0] }, { x: [0, 0] }],
-      (o) => o.x.length
-    )
-  ).toEqual({ x: [0] })
 })
 
 test('groupBy', () => {
@@ -61,11 +48,6 @@ test('groupBy', () => {
     ],
     ['b', [{ x: 'b', y: 2 }]],
   ])
-})
-
-test('sumBy', () => {
-  expect(sumBy([], (x) => x)).toEqual(0)
-  expect(sumBy([{ a: 1 }, { a: 2 }], (x) => x.a)).toEqual(3)
 })
 
 test('intersperse', () => {

--- a/app/util/array.ts
+++ b/app/util/array.ts
@@ -18,12 +18,6 @@ export function sortBy<T>(arr: T[], by: (t: T) => any = identity): T[] {
   return R.sortBy(arr, by)
 }
 
-/** Equivalent to `sortBy(...)[0]` but O(N) */
-export function lowestBy<T>(arr: T[], by: (t: T) => any = identity): T | undefined {
-  return R.firstBy(arr, by)
-}
-/* eslint-enable @typescript-eslint/no-explicit-any */
-
 type GroupKey = string | number | symbol
 
 export function groupBy<T>(arr: T[], by: (t: T) => GroupKey) {
@@ -36,21 +30,6 @@ export function groupBy<T>(arr: T[], by: (t: T) => GroupKey) {
  */
 export function partitionBy<T>(arr: T[], by: (t: T) => boolean): [T[], T[]] {
   return R.partition(arr, by)
-}
-
-type Truthy<T> = T extends false | '' | 0 | null | undefined ? never : T
-
-/**
- * TS-friendly version of `Boolean` for when you want to filter for truthy
- * values. Use `.filter(isTruthy)` instead of `.filter(Boolean)`. See
- * [StackOverflow](https://stackoverflow.com/a/58110124/604986).
- */
-export function isTruthy<T>(value: T): value is Truthy<T> {
-  return !!value
-}
-
-export function sumBy<T>(items: T[], fn: (item: T) => number): number {
-  return R.sumBy(items, fn)
 }
 
 /**

--- a/app/util/array.ts
+++ b/app/util/array.ts
@@ -7,6 +7,7 @@
  */
 
 import { cloneElement, type ReactElement } from 'react'
+import * as R from 'remeda'
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const identity = (x: any) => x
@@ -14,40 +15,19 @@ const identity = (x: any) => x
 /** Returns a new array sorted by `by`. Assumes return value of `by` is
  * comparable. Default value of `by` is the identity function. */
 export function sortBy<T>(arr: T[], by: (t: T) => any = identity): T[] {
-  const copy = [...arr]
-  copy.sort((a, b) => (by(a) < by(b) ? -1 : by(a) > by(b) ? 1 : 0))
-  return copy
+  return R.sortBy(arr, by)
 }
 
 /** Equivalent to `sortBy(...)[0]` but O(N) */
 export function lowestBy<T>(arr: T[], by: (t: T) => any = identity): T | undefined {
-  if (arr.length === 0) return undefined
-
-  let lowest = arr[0]
-  let lowestScore = by(arr[0])
-  for (let i = 1; i < arr.length; i++) {
-    const score = by(arr[i])
-    if (score < lowestScore) {
-      lowest = arr[i]
-      lowestScore = score
-    }
-  }
-  return lowest
+  return R.firstBy(arr, by)
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
 type GroupKey = string | number | symbol
 
 export function groupBy<T>(arr: T[], by: (t: T) => GroupKey) {
-  const groups: Record<GroupKey, T[]> = {}
-  for (const item of arr) {
-    const key = by(item)
-    if (!(key in groups)) {
-      groups[key] = []
-    }
-    groups[key].push(item)
-  }
-  return Object.entries(groups)
+  return Object.entries(R.groupBy(arr, by))
 }
 
 /**
@@ -55,13 +35,7 @@ export function groupBy<T>(arr: T[], by: (t: T) => GroupKey) {
  * false
  */
 export function partitionBy<T>(arr: T[], by: (t: T) => boolean): [T[], T[]] {
-  const yes: T[] = []
-  const no: T[] = []
-  for (const item of arr) {
-    const target = by(item) ? yes : no
-    target.push(item)
-  }
-  return [yes, no]
+  return R.partition(arr, by)
 }
 
 type Truthy<T> = T extends false | '' | 0 | null | undefined ? never : T
@@ -76,7 +50,7 @@ export function isTruthy<T>(value: T): value is Truthy<T> {
 }
 
 export function sumBy<T>(items: T[], fn: (item: T) => number): number {
-  return items.map(fn).reduce((a, b) => a + b, 0)
+  return R.sumBy(items, fn)
 }
 
 /**
@@ -107,6 +81,5 @@ export function intersperse(
  * Split array at first element where `by` is true. That element lands in the second array.
  */
 export function splitOnceBy<T>(array: T[], by: (t: T) => boolean) {
-  const i = array.findIndex(by)
-  return i === -1 ? [array, []] : [array.slice(0, i), array.slice(i)]
+  return R.splitWhen(array, by)
 }

--- a/app/util/object.spec.ts
+++ b/app/util/object.spec.ts
@@ -7,12 +7,8 @@
  */
 import { expect, test } from 'vitest'
 
-import { exclude, pick } from './object'
+import { pick } from './object'
 
 test('pick', () => {
   expect(pick({ a: 1, b: '2', c: { d: false } }, 'a', 'b')).toEqual({ a: 1, b: '2' })
-})
-
-test('exclude', () => {
-  expect(exclude({ a: 1, b: '2', c: { d: false } }, 'a', 'c')).toEqual({ b: '2' })
 })

--- a/app/util/object.ts
+++ b/app/util/object.ts
@@ -11,12 +11,3 @@ export const pick = <T extends Record<string, unknown>, K extends keyof T>(
   obj: T,
   ...keys: K[]
 ) => R.pick(obj, keys)
-
-export function mapValues<K extends string, V0, V>(
-  obj: Record<K, V0>,
-  fn: (value: V0, key: K) => V
-) {
-  return Object.fromEntries(
-    Object.entries<V0>(obj).map(([key, value]) => [key, fn(value, key as K)])
-  ) as Record<K, V>
-}

--- a/app/util/object.ts
+++ b/app/util/object.ts
@@ -5,22 +5,12 @@
  *
  * Copyright Oxide Computer Company
  */
+import * as R from 'remeda'
 
 export const pick = <T extends Record<string, unknown>, K extends keyof T>(
   obj: T,
   ...keys: K[]
-) =>
-  Object.fromEntries(
-    Object.entries(obj).filter(([key]) => keys.includes(key as never))
-  ) as Pick<T, K>
-
-export const exclude = <T extends Record<string, unknown>, K extends keyof T>(
-  obj: T,
-  ...keys: K[]
-) =>
-  Object.fromEntries(
-    Object.entries(obj).filter(([key]) => !keys.includes(key as never))
-  ) as Exclude<T, K>
+) => R.pick(obj, keys)
 
 export function mapValues<K extends string, V0, V>(
   obj: Record<K, V0>,

--- a/mock-api/msw/util.ts
+++ b/mock-api/msw/util.ts
@@ -9,6 +9,7 @@ import { differenceInSeconds, subHours } from 'date-fns'
 // Works without the .js for dev server and prod build in MSW mode, but
 // playwright wants the .js. No idea why, let's just add the .js.
 import { IPv4, IPv6 } from 'ip-num/IPNumber.js'
+import * as R from 'remeda'
 
 import {
   FLEET_ID,
@@ -25,7 +26,6 @@ import {
 } from '@oxide/api'
 
 import { json, type Json } from '~/api/__generated__/msw-handlers'
-import { isTruthy } from '~/util/array'
 import { validateIp } from '~/util/str'
 import { GiB, TiB } from '~/util/units'
 
@@ -343,7 +343,7 @@ export function userHasRole(
   const userGroupIds = db.groupMemberships
     .filter((gm) => gm.userId === user.id)
     .map((gm) => db.userGroups.find((g) => g.id === gm.groupId))
-    .filter(isTruthy)
+    .filter(R.isTruthy)
     .map((g) => g.id)
 
   /** All actors with *at least* the specified role on the resource */

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "react-router-dom": "^6.23.0",
         "react-stately": "^3.31.0",
         "recharts": "^2.12.6",
+        "remeda": "^2.0.3",
         "simplebar-react": "^3.2.5",
         "tslib": "^2.6.2",
         "tunnel-rat": "0.0.4",
@@ -16717,6 +16718,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remeda": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/remeda/-/remeda-2.0.3.tgz",
+      "integrity": "sha512-3OtBvbFnhPJPNDxrP4dQ+Y7ghIErMeTy7KQ2vkC6XzrQHbFdlD0tT6mYaJ2S96lUu3umNnhkqni2lhVOdL9UOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^4.18.2"
+      }
+    },
     "node_modules/remove-accents": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
@@ -18291,7 +18301,6 @@
       "version": "4.18.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.2.tgz",
       "integrity": "sha512-+suCYpfJLAe4OXS6+PPXjW3urOS4IoP9waSiLuXfLgqZODKw/aWwASvzqE886wA0kQgGy0mIWyhd87VpqIy6Xg==",
-      "dev": true,
       "engines": {
         "node": ">=16"
       },
@@ -31363,6 +31372,14 @@
         }
       }
     },
+    "remeda": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/remeda/-/remeda-2.0.3.tgz",
+      "integrity": "sha512-3OtBvbFnhPJPNDxrP4dQ+Y7ghIErMeTy7KQ2vkC6XzrQHbFdlD0tT6mYaJ2S96lUu3umNnhkqni2lhVOdL9UOQ==",
+      "requires": {
+        "type-fest": "^4.18.2"
+      }
+    },
     "remove-accents": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
@@ -32518,8 +32535,7 @@
     "type-fest": {
       "version": "4.18.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.2.tgz",
-      "integrity": "sha512-+suCYpfJLAe4OXS6+PPXjW3urOS4IoP9waSiLuXfLgqZODKw/aWwASvzqE886wA0kQgGy0mIWyhd87VpqIy6Xg==",
-      "dev": true
+      "integrity": "sha512-+suCYpfJLAe4OXS6+PPXjW3urOS4IoP9waSiLuXfLgqZODKw/aWwASvzqE886wA0kQgGy0mIWyhd87VpqIy6Xg=="
     },
     "type-is": {
       "version": "1.6.18",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "react-router-dom": "^6.23.0",
     "react-stately": "^3.31.0",
     "recharts": "^2.12.6",
+    "remeda": "^2.0.3",
     "simplebar-react": "^3.2.5",
     "tslib": "^2.6.2",
     "tunnel-rat": "0.0.4",


### PR DESCRIPTION
This is kind of a palate cleanser, nothing important. I saw this lovely library https://remedajs.com/, maintained by @tkdodo, so I tried it and it's very nice. We have some little utilities around arrays and objects and Remeda has drop-in replacements for them. The advantage of using Remeda is

1. We can delete our tests for these utils because we know remeda is legit
2. Anything else we need is just there
3. Many of remeda's functions are curried and optimized for lazy evaluation as part of a pipeline, which means a `filter().map().filter()` chain doesn't have to loop through the list three times.

This PR makes our bundle only 300 bytes bigger after gzip, and that will probably go away after we get rid of the util functions completely instead of wrapping Remeda.