### PR TITLE
Upgrade `xterm`, fix super-wide serial console page

### DIFF
--- a/app/components/Terminal.tsx
+++ b/app/components/Terminal.tsx
@@ -5,9 +5,9 @@
  *
  * Copyright Oxide Computer Company
  */
+import { FitAddon } from '@xterm/addon-fit'
+import { Terminal as XTerm, type ITerminalOptions } from '@xterm/xterm'
 import { useEffect, useRef, useState } from 'react'
-import { Terminal as XTerm, type ITerminalOptions } from 'xterm'
-import { FitAddon } from 'xterm-addon-fit'
 
 import { DirectionDownIcon, DirectionUpIcon } from '@oxide/design-system/icons/react'
 

--- a/app/ui/styles/index.css
+++ b/app/ui/styles/index.css
@@ -40,7 +40,7 @@
 
 @import './themes/selection.css';
 
-@import 'xterm/css/xterm.css';
+@import '@xterm/xterm/css/xterm.css';
 
 :root {
   --content-gutter: 2.5rem;

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,8 @@
         "@tanstack/react-query": "^5.35.1",
         "@tanstack/react-query-devtools": "^5.35.1",
         "@tanstack/react-table": "^8.16.0",
+        "@xterm/addon-fit": "^0.10.0",
+        "@xterm/xterm": "^5.5.0",
         "classnames": "^2.5.1",
         "date-fns": "^3.6.0",
         "filesize": "^10.1.1",
@@ -46,8 +48,6 @@
         "tslib": "^2.6.2",
         "tunnel-rat": "0.0.4",
         "uuid": "^9.0.1",
-        "xterm": "^5.3.0",
-        "xterm-addon-attach": "^0.9.0",
         "xterm-addon-fit": "^0.8.0",
         "zod": "^3.23.7",
         "zustand": "^4.5.2"
@@ -6291,6 +6291,21 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.10.0.tgz",
+      "integrity": "sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
+      }
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
+      "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
+      "license": "MIT"
     },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
@@ -19575,15 +19590,8 @@
     "node_modules/xterm": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/xterm/-/xterm-5.3.0.tgz",
-      "integrity": "sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg=="
-    },
-    "node_modules/xterm-addon-attach": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/xterm-addon-attach/-/xterm-addon-attach-0.9.0.tgz",
-      "integrity": "sha512-NykWWOsobVZPPK3P9eFkItrnBK9Lw0f94uey5zhqIVB1bhswdVBfl+uziEzSOhe2h0rT9wD0wOeAYsdSXeavPw==",
-      "peerDependencies": {
-        "xterm": "^5.0.0"
-      }
+      "integrity": "sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==",
+      "peer": true
     },
     "node_modules/xterm-addon-fit": {
       "version": "0.8.0",
@@ -23989,6 +23997,17 @@
           }
         }
       }
+    },
+    "@xterm/addon-fit": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.10.0.tgz",
+      "integrity": "sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==",
+      "requires": {}
+    },
+    "@xterm/xterm": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
+      "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A=="
     },
     "@yarnpkg/lockfile": {
       "version": "1.1.0",
@@ -33377,13 +33396,8 @@
     "xterm": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/xterm/-/xterm-5.3.0.tgz",
-      "integrity": "sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg=="
-    },
-    "xterm-addon-attach": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/xterm-addon-attach/-/xterm-addon-attach-0.9.0.tgz",
-      "integrity": "sha512-NykWWOsobVZPPK3P9eFkItrnBK9Lw0f94uey5zhqIVB1bhswdVBfl+uziEzSOhe2h0rT9wD0wOeAYsdSXeavPw==",
-      "requires": {}
+      "integrity": "sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==",
+      "peer": true
     },
     "xterm-addon-fit": {
       "version": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "@tanstack/react-query": "^5.35.1",
     "@tanstack/react-query-devtools": "^5.35.1",
     "@tanstack/react-table": "^8.16.0",
+    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/xterm": "^5.5.0",
     "classnames": "^2.5.1",
     "date-fns": "^3.6.0",
     "filesize": "^10.1.1",
@@ -69,8 +71,6 @@
     "tslib": "^2.6.2",
     "tunnel-rat": "0.0.4",
     "uuid": "^9.0.1",
-    "xterm": "^5.3.0",
-    "xterm-addon-attach": "^0.9.0",
     "xterm-addon-fit": "^0.8.0",
     "zod": "^3.23.7",
     "zustand": "^4.5.2"


### PR DESCRIPTION
We missed a couple of versions due to the `@xterm/*` namespace change, and upgrading actually fixes an [issue](https://github.com/oxidecomputer/console/issues/1447#issuecomment-2155384055) where the page gets super wide for no apparently reason.