### PR TITLE
Don't show instance name in serial console message

### DIFF
--- a/app/pages/project/instances/instance/SerialConsolePage.tsx
+++ b/app/pages/project/instances/instance/SerialConsolePage.tsx
@@ -137,7 +137,7 @@ export function SerialConsolePage() {
       </Link>
 
       <div className="gutter relative w-full shrink grow overflow-hidden">
-        {connectionStatus === 'connecting' && <ConnectingSkeleton />}
+        {connectionStatus !== 'connecting' && <ConnectingSkeleton />}
         {connectionStatus === 'error' && <ErrorSkeleton />}
         {connectionStatus === 'closed' && !canConnect && (
           <CannotConnect instanceState={instanceData.runState} />
@@ -197,24 +197,11 @@ function SerialSkeleton({
   )
 }
 
-function InstanceLink() {
-  const { instance, project } = useInstanceSelector()
-  return (
-    <Link
-      className="text-sans-xl text-accent-secondary hover:text-accent"
-      to={pb.instance({ project, instance })}
-    >
-      {instance}
-    </Link>
-  )
-}
-
 const ConnectingSkeleton = () => (
   <SerialSkeleton connecting>
     <Spinner size="lg" />
     <div className="mt-4 text-center">
-      <p className="text-sans-xl">Connecting to</p>
-      <InstanceLink />
+      <p className="text-sans-xl">Connecting to serial console</p>
     </div>
   </SerialSkeleton>
 )
@@ -222,9 +209,7 @@ const ConnectingSkeleton = () => (
 const CannotConnect = ({ instanceState }: { instanceState: InstanceState }) => (
   <SerialSkeleton>
     <p className="flex items-center justify-center text-sans-xl">
-      <span>
-        Instance <InstanceLink /> is
-      </span>
+      <span>The instance is</span>
       <InstanceStatusBadge className="ml-1" status={instanceState} />
     </p>
     <p className="mt-2 text-center text-secondary">


### PR DESCRIPTION
Closes #2273 

Solve the problem by eliminating the problem. There's a big "Back to instance" button at the top anyway.

![Screenshot 2024-06-07 at 3 48 46 PM](https://github.com/oxidecomputer/console/assets/3612203/83d1f64e-0a00-40c5-af09-389fe73823a2)

![Screenshot 2024-06-07 at 3 50 04 PM](https://github.com/oxidecomputer/console/assets/3612203/31692754-bdba-4f02-89a1-c547ea290caa)
