### PR TITLE
Enable "reserved names" on Name field as a new, optional, validation step

### DIFF
--- a/app/components/form/fields/NameField.spec.tsx
+++ b/app/components/form/fields/NameField.spec.tsx
@@ -10,7 +10,7 @@ import { describe, expect, it } from 'vitest'
 import { validateName } from './NameField'
 
 describe('validateName', () => {
-  const validate = (name: string) => validateName(name, 'Name', true)
+  const validate = (name: string) => validateName(name, 'Name', true, ['example'])
 
   it('returns undefined for valid names', () => {
     expect(validate('abc')).toBeUndefined()
@@ -44,5 +44,11 @@ describe('validateName', () => {
 
   it('rejects names that are too long', () => {
     expect(validate('a'.repeat(64))).toEqual('Must be 63 characters or fewer')
+  })
+
+  it('rejects reserved names', () => {
+    expect(validate('example')).toEqual('Name is already in use, or is unavailable')
+    expect(validate('exam')).toBeUndefined()
+    expect(validate('example-2')).toBeUndefined()
   })
 })

--- a/app/components/form/fields/NameField.tsx
+++ b/app/components/form/fields/NameField.tsx
@@ -18,11 +18,15 @@ export function NameField<
   required = true,
   name,
   label = capitalize(name),
+  reservedNames = [],
   ...textFieldProps
-}: Omit<TextFieldProps<TFieldValues, TName>, 'validate'> & { label?: string }) {
+}: Omit<TextFieldProps<TFieldValues, TName>, 'validate'> & {
+  label?: string
+  reservedNames?: Array<string>
+}) {
   return (
     <TextField
-      validate={(name) => validateName(name, label, required)}
+      validate={(name) => validateName(name, label, required, reservedNames)}
       required={required}
       label={label}
       name={name}
@@ -32,7 +36,12 @@ export function NameField<
 }
 
 // TODO Update JSON schema to match this, add fuzz testing between this and name pattern
-export const validateName = (name: string, label: string, required: boolean) => {
+export const validateName = (
+  name: string,
+  label: string,
+  required: boolean,
+  reservedNames?: Array<string>
+) => {
   if (!required && !name) return
 
   if (name.length > 63) {
@@ -47,5 +56,9 @@ export const validateName = (name: string, label: string, required: boolean) => 
     return 'Must start with a lower-case letter'
   } else if (!/[a-z0-9]$/.test(name)) {
     return 'Must end with a letter or number'
+  }
+
+  if (reservedNames?.includes(name)) {
+    return `${label} is already in use, or is unavailable`
   }
 }

--- a/app/forms/firewall-rules-create.tsx
+++ b/app/forms/firewall-rules-create.tsx
@@ -167,7 +167,11 @@ const DocsLinkMessage = () => (
   />
 )
 
-export const CommonFields = ({ error, control }: CommonFieldsProps) => {
+export const CommonFields = ({
+  error,
+  control,
+  reservedNames,
+}: CommonFieldsProps & { reservedNames: Array<string> }) => {
   const portRangeForm = useForm({ defaultValues: portRangeDefaultValues })
   const ports = useController({ name: 'ports', control }).field
   const submitPortRange = portRangeForm.handleSubmit(({ portRange }) => {
@@ -211,7 +215,7 @@ export const CommonFields = ({ error, control }: CommonFieldsProps) => {
       <CheckboxField name="enabled" control={control}>
         Enabled
       </CheckboxField>
-      <NameField name="name" control={control} />
+      <NameField name="name" control={control} reservedNames={reservedNames} />
       <DescriptionField name="description" control={control} />
 
       <RadioField
@@ -571,7 +575,11 @@ export function CreateFirewallRuleForm({
       submitError={updateRules.error}
       submitLabel="Add rule"
     >
-      <CommonFields error={updateRules.error} control={form.control} />
+      <CommonFields
+        error={updateRules.error}
+        control={form.control}
+        reservedNames={existingRules.map((r) => r.name)}
+      />
     </SideModalForm>
   )
 }

--- a/app/forms/firewall-rules-create.tsx
+++ b/app/forms/firewall-rules-create.tsx
@@ -171,7 +171,7 @@ export const CommonFields = ({
   error,
   control,
   reservedNames,
-}: CommonFieldsProps & { reservedNames: Array<string> }) => {
+}: CommonFieldsProps & { reservedNames?: Array<string> }) => {
   const portRangeForm = useForm({ defaultValues: portRangeDefaultValues })
   const ports = useController({ name: 'ports', control }).field
   const submitPortRange = portRangeForm.handleSubmit(({ portRange }) => {


### PR DESCRIPTION
Fixes #2220 

This PR adds a validation to the NameField element, where an array of reserved names can be passed in. If the form has this optional prop, and if the user tries to pass in a name to the form that matches a string in the array, it will fail the validation check.

This does not affect the _update_ form for firewall rules.

<img width="1266" alt="Screenshot 2024-06-21 at 2 19 16 PM" src="https://github.com/oxidecomputer/console/assets/22547/6832f1ba-b332-4a22-bb7f-b8904af508f0">

