### PR TITLE
Add detach button for ephemeral ip

### DIFF
--- a/app/pages/project/instances/instance/tabs/NetworkingTab.tsx
+++ b/app/pages/project/instances/instance/tabs/NetworkingTab.tsx
@@ -255,6 +255,16 @@ export function NetworkingTab() {
     }),
   ]
 
+  const ephemeralIpDetach = useApiMutation('instanceEphemeralIpDetach', {
+    onSuccess() {
+      queryClient.invalidateQueries('instanceExternalIpList')
+      addToast({ content: 'Your ephemeral IP has been detached' })
+    },
+    onError: (err) => {
+      addToast({ title: 'Error', content: err.message, variant: 'error' })
+    },
+  })
+
   const floatingIpDetach = useApiMutation('floatingIpDetach', {
     onSuccess() {
       queryClient.invalidateQueries('floatingIpList')
@@ -300,10 +310,35 @@ export function NetworkingTab() {
               }),
           },
         ]
+      } else {
+        return [
+          copyAction,
+          {
+            label: 'Detach',
+            onActivate: () =>
+              confirmAction({
+                actionType: 'danger',
+                doAction: () =>
+                  ephemeralIpDetach.mutateAsync({
+                    path: { instance: instanceName },
+                    query: { project },
+                  }),
+                modalTitle: 'Detach Ephemeral IP',
+                modalContent: (
+                  <p>
+                    Are you sure you want to detach ephemeral IP <HL>{externalIp.ip}</HL>{' '}
+                    from <HL>{instanceName}</HL>? The instance will no longer be reachable
+                    at <HL>{externalIp.ip}</HL>.
+                  </p>
+                ),
+                errorTitle: 'Error detaching ephemeral IP',
+              }),
+          },
+        ]
       }
       return [copyAction]
     },
-    [floatingIpDetach, instanceName, project]
+    [ephemeralIpDetach, floatingIpDetach, instanceName, project]
   )
 
   const ipTableInstance = useReactTable({

--- a/app/pages/project/instances/instance/tabs/NetworkingTab.tsx
+++ b/app/pages/project/instances/instance/tabs/NetworkingTab.tsx
@@ -19,7 +19,7 @@ import {
   type ExternalIp,
   type InstanceNetworkInterface,
 } from '@oxide/api'
-import { Networking24Icon } from '@oxide/design-system/icons/react'
+import { IpGlobal24Icon, Networking24Icon } from '@oxide/design-system/icons/react'
 
 import { HL } from '~/components/HL'
 import { CreateNetworkInterfaceForm } from '~/forms/network-interface-create'
@@ -359,7 +359,17 @@ export function NetworkingTab() {
           />
         )}
       </TableControls>
-      <Table aria-labelledby="attached-ips-label" table={ipTableInstance} />
+      {eips.items.length > 0 ? (
+        <Table aria-labelledby="attached-ips-label" table={ipTableInstance} />
+      ) : (
+        <TableEmptyBox>
+          <EmptyMessage
+            icon={<IpGlobal24Icon />}
+            title="No external IPs"
+            body="You need to attach an external IP to be able to see it here"
+          />
+        </TableEmptyBox>
+      )}
 
       <TableControls className="mt-8">
         <TableTitle id="nics-label">Network interfaces</TableTitle>

--- a/app/pages/project/instances/instance/tabs/NetworkingTab.tsx
+++ b/app/pages/project/instances/instance/tabs/NetworkingTab.tsx
@@ -40,6 +40,7 @@ import { EmptyMessage } from '~/ui/lib/EmptyMessage'
 import { TableControls, TableEmptyBox, TableTitle } from '~/ui/lib/Table'
 import { TipIcon } from '~/ui/lib/TipIcon'
 import { pb } from '~/util/path-builder'
+import { capitalize } from '~/util/str'
 
 import { fancifyStates } from './common'
 
@@ -306,10 +307,10 @@ export function NetworkingTab() {
             confirmAction({
               actionType: 'danger',
               doAction,
-              modalTitle: `Detach ${externalIp.kind} IP`,
+              modalTitle: `Detach ${capitalize(externalIp.kind)} IP`,
               modalContent: (
                 <p>
-                  Are you sure you want to detach ${externalIp.kind} IP{' '}
+                  Are you sure you want to detach {externalIp.kind} IP{' '}
                   <HL>
                     {externalIp.kind === 'floating' ? externalIp.name : externalIp.ip}
                   </HL>{' '}

--- a/app/pages/project/instances/instance/tabs/NetworkingTab.tsx
+++ b/app/pages/project/instances/instance/tabs/NetworkingTab.tsx
@@ -285,57 +285,43 @@ export function NetworkingTab() {
         },
       }
 
-      if (externalIp.kind === 'floating') {
-        return [
-          copyAction,
-          {
-            label: 'Detach',
-            onActivate: () =>
-              confirmAction({
-                actionType: 'danger',
-                doAction: () =>
-                  floatingIpDetach.mutateAsync({
-                    path: { floatingIp: externalIp.name },
-                    query: { project },
-                  }),
-                modalTitle: 'Detach Floating IP',
-                modalContent: (
-                  <p>
-                    Are you sure you want to detach floating IP <HL>{externalIp.name}</HL>{' '}
-                    from <HL>{instanceName}</HL>? The instance will no longer be reachable
-                    at <HL>{externalIp.ip}</HL>.
-                  </p>
-                ),
-                errorTitle: 'Error detaching floating IP',
-              }),
-          },
-        ]
-      } else {
-        return [
-          copyAction,
-          {
-            label: 'Detach',
-            onActivate: () =>
-              confirmAction({
-                actionType: 'danger',
-                doAction: () =>
-                  ephemeralIpDetach.mutateAsync({
-                    path: { instance: instanceName },
-                    query: { project },
-                  }),
-                modalTitle: 'Detach Ephemeral IP',
-                modalContent: (
-                  <p>
-                    Are you sure you want to detach ephemeral IP <HL>{externalIp.ip}</HL>{' '}
-                    from <HL>{instanceName}</HL>? The instance will no longer be reachable
-                    at <HL>{externalIp.ip}</HL>.
-                  </p>
-                ),
-                errorTitle: 'Error detaching ephemeral IP',
-              }),
-          },
-        ]
-      }
+      const doAction =
+        externalIp.kind === 'floating'
+          ? () =>
+              floatingIpDetach.mutateAsync({
+                path: { floatingIp: externalIp.name },
+                query: { project },
+              })
+          : () =>
+              ephemeralIpDetach.mutateAsync({
+                path: { instance: instanceName },
+                query: { project },
+              })
+
+      return [
+        copyAction,
+        {
+          label: 'Detach',
+          onActivate: () =>
+            confirmAction({
+              actionType: 'danger',
+              doAction,
+              modalTitle: `Detach ${externalIp.kind} IP`,
+              modalContent: (
+                <p>
+                  Are you sure you want to detach ${externalIp.kind} IP{' '}
+                  <HL>
+                    {externalIp.kind === 'floating' ? externalIp.name : externalIp.ip}
+                  </HL>{' '}
+                  from <HL>{instanceName}</HL>? The instance will no longer be reachable at{' '}
+                  <HL>{externalIp.ip}</HL>.
+                </p>
+              ),
+              errorTitle: `Error detaching ${externalIp.kind} IP`,
+            }),
+        },
+      ]
+
       return [copyAction]
     },
     [ephemeralIpDetach, floatingIpDetach, instanceName, project]

--- a/mock-api/msw/handlers.ts
+++ b/mock-api/msw/handlers.ts
@@ -561,6 +561,13 @@ export const handlers = makeHandlers({
     disk.state = { state: 'detached' }
     return disk
   },
+  instanceEphemeralIpDetach({ path, query }) {
+    const instance = lookup.instance({ ...path, ...query })
+    const ip = db.ephemeralIps.find((eip) => eip.instance_id === instance.id)
+    if (!ip) throw notFoundErr('ephemeral IP')
+    db.ephemeralIps = db.ephemeralIps.filter((eip) => eip !== ip)
+    return 204
+  },
   instanceExternalIpList({ path, query }) {
     const instance = lookup.instance({ ...path, ...query })
 
@@ -1281,7 +1288,6 @@ export const handlers = makeHandlers({
   certificateDelete: NotImplemented,
   certificateList: NotImplemented,
   certificateView: NotImplemented,
-  instanceEphemeralIpDetach: NotImplemented,
   instanceEphemeralIpAttach: NotImplemented,
   instanceMigrate: NotImplemented,
   instanceSerialConsoleStream: NotImplemented,

--- a/test/e2e/instance-networking.e2e.ts
+++ b/test/e2e/instance-networking.e2e.ts
@@ -122,4 +122,9 @@ test('Instance networking tab — External IPs', async ({ page }) => {
 
   // And that button shouldbe enabled again
   await expect(page.getByRole('button', { name: 'Attach floating IP' })).toBeEnabled()
+
+  // Detach the ephemeral IP
+  await clickRowAction(page, 'ephemeral', 'Detach')
+  await page.getByRole('button', { name: 'Confirm' }).click()
+  await expect(externalIpTable.getByRole('cell', { name: 'ephemeral' })).toBeHidden()
 })


### PR DESCRIPTION
Fixes #2205 

This adds a `Detach` button for ephemeral IPs, with a confirmation:
<img width="1223" alt="Screenshot 2024-06-21 at 5 35 23 PM" src="https://github.com/oxidecomputer/console/assets/22547/6654c3c1-8f87-4f2f-a0c2-f44025a59b82">

Now that we can detach ephemeral IPs, we also need an empty state for that table, so this PR also adds that:
<img width="1227" alt="Screenshot 2024-06-21 at 5 32 12 PM" src="https://github.com/oxidecomputer/console/assets/22547/6f65214b-4285-4b7d-9826-bc9ad94d6851">

I believe we don't currently have a way to attach an ephemeral IP to an instance in the UI, but I suspect that's something we'll tackle separately.