### PR TITLE
RR 6.24 and turn on v7 future flags

### DIFF
--- a/app/main.tsx
+++ b/app/main.tsx
@@ -41,8 +41,13 @@ function render() {
   // This means RR is best thought of as an external store that runs
   // independently of the React render lifecycle.
   const router = createBrowserRouter(routes, {
-    // https://reactrouter.com/en/main/guides/api-development-strategy#current-future-flags
-    future: { v7_normalizeFormMethod: true },
+    // https://reactrouter.com/en/6.24.0/upgrading/future
+    future: {
+      v7_fetcherPersist: true,
+      v7_normalizeFormMethod: true,
+      v7_partialHydration: true,
+      v7_relativeSplatPath: true,
+    },
   })
 
   root.render(
@@ -52,7 +57,13 @@ function render() {
           <ConfirmActionModal />
           <SkipLink id="skip-nav" />
           <ReduceMotion />
-          <RouterProvider router={router} />
+          <RouterProvider
+            router={router}
+            // this breaks the scroll restore test. turn it on after we change
+            // the layout so the whole page scrolls and switch back to RR's
+            // built in useScrollRestoration
+            // future={{ v7_startTransition: true }}
+          />
         </ErrorBoundary>
         {/* <ReactQueryDevtools initialIsOpen={false} /> */}
       </QueryClientProvider>

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "react-hook-form": "^7.51.4",
         "react-is": "^18.3.1",
         "react-merge-refs": "^2.1.1",
-        "react-router-dom": "^6.23.0",
+        "react-router-dom": "^6.24.0",
         "react-stately": "^3.31.0",
         "recharts": "^2.12.6",
         "remeda": "^2.0.3",
@@ -4399,9 +4399,10 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.16.0.tgz",
-      "integrity": "sha512-Quz1KOffeEf/zwkCBM3kBtH4ZoZ+pT3xIXBG4PPW/XFtDP7EGhtTiC2+gpL9GnR7+Qdet5Oa6cYSvwKYg6kN9Q==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.17.0.tgz",
+      "integrity": "sha512-2D6XaHEVvkCn682XBnipbJjgZUU7xjLtA4dGJRBVUKpEaDYOZMENZoZjAOSb7qirxt5RupjzZxz4fK2FO+EFPw==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -15670,11 +15671,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.23.0.tgz",
-      "integrity": "sha512-wPMZ8S2TuPadH0sF5irFGjkNLIcRvOSaEe7v+JER8508dyJumm6XZB1u5kztlX0RVq6AzRVndzqcUh6sFIauzA==",
+      "version": "6.24.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.24.0.tgz",
+      "integrity": "sha512-sQrgJ5bXk7vbcC4BxQxeNa5UmboFm35we1AFK0VvQaz9g0LzxEIuLOhHIoZ8rnu9BO21ishGeL9no1WB76W/eg==",
+      "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.16.0"
+        "@remix-run/router": "1.17.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -15684,12 +15686,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.23.0.tgz",
-      "integrity": "sha512-Q9YaSYvubwgbal2c9DJKfx6hTNoBp3iJDsl+Duva/DwxoJH+OTXkxGpql4iUK2sla/8z4RpjAm6EWx1qUDuopQ==",
+      "version": "6.24.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.24.0.tgz",
+      "integrity": "sha512-960sKuau6/yEwS8e+NVEidYQb1hNjAYM327gjEyXlc6r3Skf2vtwuJ2l7lssdegD2YjoKG5l8MsVyeTDlVeY8g==",
+      "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.16.0",
-        "react-router": "6.23.0"
+        "@remix-run/router": "1.17.0",
+        "react-router": "6.24.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -21742,9 +21745,9 @@
       }
     },
     "@remix-run/router": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.16.0.tgz",
-      "integrity": "sha512-Quz1KOffeEf/zwkCBM3kBtH4ZoZ+pT3xIXBG4PPW/XFtDP7EGhtTiC2+gpL9GnR7+Qdet5Oa6cYSvwKYg6kN9Q=="
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.17.0.tgz",
+      "integrity": "sha512-2D6XaHEVvkCn682XBnipbJjgZUU7xjLtA4dGJRBVUKpEaDYOZMENZoZjAOSb7qirxt5RupjzZxz4fK2FO+EFPw=="
     },
     "@rollup/pluginutils": {
       "version": "4.2.1",
@@ -29450,20 +29453,20 @@
       }
     },
     "react-router": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.23.0.tgz",
-      "integrity": "sha512-wPMZ8S2TuPadH0sF5irFGjkNLIcRvOSaEe7v+JER8508dyJumm6XZB1u5kztlX0RVq6AzRVndzqcUh6sFIauzA==",
+      "version": "6.24.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.24.0.tgz",
+      "integrity": "sha512-sQrgJ5bXk7vbcC4BxQxeNa5UmboFm35we1AFK0VvQaz9g0LzxEIuLOhHIoZ8rnu9BO21ishGeL9no1WB76W/eg==",
       "requires": {
-        "@remix-run/router": "1.16.0"
+        "@remix-run/router": "1.17.0"
       }
     },
     "react-router-dom": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.23.0.tgz",
-      "integrity": "sha512-Q9YaSYvubwgbal2c9DJKfx6hTNoBp3iJDsl+Duva/DwxoJH+OTXkxGpql4iUK2sla/8z4RpjAm6EWx1qUDuopQ==",
+      "version": "6.24.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.24.0.tgz",
+      "integrity": "sha512-960sKuau6/yEwS8e+NVEidYQb1hNjAYM327gjEyXlc6r3Skf2vtwuJ2l7lssdegD2YjoKG5l8MsVyeTDlVeY8g==",
       "requires": {
-        "@remix-run/router": "1.16.0",
-        "react-router": "6.23.0"
+        "@remix-run/router": "1.17.0",
+        "react-router": "6.24.0"
       }
     },
     "react-smooth": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "react-hook-form": "^7.51.4",
     "react-is": "^18.3.1",
     "react-merge-refs": "^2.1.1",
-    "react-router-dom": "^6.23.0",
+    "react-router-dom": "^6.24.0",
     "react-stately": "^3.31.0",
     "recharts": "^2.12.6",
     "remeda": "^2.0.3",


### PR DESCRIPTION
See comment, I couldn't get `v7_startTransition` to work because it breaks the scroll restore test in all three browsers. The really strange thing is that I could not reproduce the issue when I did the actions manually. I suspect there's something funny about how Playwright handles `goBack` and `goForward` — it seemed like (in the tests only) the navigation state was not changing to `loading` and back, which is what we rely on to tell when to save the current scroll position before the page goes away.

https://github.com/oxidecomputer/console/blob/db99a4db4eb7f17cad953b9f4d7d804f3e1bf650/app/hooks/use-scroll-restoration.ts#L27-L37