### PR TITLE
Bump mock API generator to improve error handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "@ianvs/prettier-plugin-sort-imports": "^4.3.0",
         "@ladle/react": "^4.1.0",
         "@mswjs/http-middleware": "^0.10.1",
-        "@oxide/openapi-gen-ts": "~0.2.2",
+        "@oxide/openapi-gen-ts": "~0.3.0",
         "@playwright/test": "^1.45.0",
         "@testing-library/dom": "^10.2.0",
         "@testing-library/jest-dom": "^6.4.6",
@@ -1979,10 +1979,11 @@
       }
     },
     "node_modules/@oxide/openapi-gen-ts": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@oxide/openapi-gen-ts/-/openapi-gen-ts-0.2.2.tgz",
-      "integrity": "sha512-PHJS2Gk98DfeMN0kMLGlL8Hy3SNkF4RGnPxMs/q8FJsmAFHtJu7hqoPpFIhfpjFYdFOP7gEKbWilstheBYdTUA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@oxide/openapi-gen-ts/-/openapi-gen-ts-0.3.0.tgz",
+      "integrity": "sha512-BiblEUJd+E3HgCmL3xZRtWXQ8AgaFVJ9KDm63nNt8pCg+HFpsTiEIJrlN1vaHx37gPkWk/Oi7tXGJOmPrpHfZg==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "minimist": "^1.2.8",
         "prettier": "2.7.1",
@@ -20081,9 +20082,9 @@
       }
     },
     "@oxide/openapi-gen-ts": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@oxide/openapi-gen-ts/-/openapi-gen-ts-0.2.2.tgz",
-      "integrity": "sha512-PHJS2Gk98DfeMN0kMLGlL8Hy3SNkF4RGnPxMs/q8FJsmAFHtJu7hqoPpFIhfpjFYdFOP7gEKbWilstheBYdTUA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@oxide/openapi-gen-ts/-/openapi-gen-ts-0.3.0.tgz",
+      "integrity": "sha512-BiblEUJd+E3HgCmL3xZRtWXQ8AgaFVJ9KDm63nNt8pCg+HFpsTiEIJrlN1vaHx37gPkWk/Oi7tXGJOmPrpHfZg==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.8",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@ianvs/prettier-plugin-sort-imports": "^4.3.0",
     "@ladle/react": "^4.1.0",
     "@mswjs/http-middleware": "^0.10.1",
-    "@oxide/openapi-gen-ts": "~0.2.2",
+    "@oxide/openapi-gen-ts": "~0.3.0",
     "@playwright/test": "^1.45.0",
     "@testing-library/dom": "^10.2.0",
     "@testing-library/jest-dom": "^6.4.6",


### PR DESCRIPTION
See https://github.com/oxidecomputer/oxide.ts/pull/259, which removes the ability to throw function from a handler (an antipattern) and makes zod parse errors look like regular API 400s.