### PR TITLE
All in one dogfood deploy script

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -92,7 +92,7 @@ module.exports = {
     'react/react-in-jsx-scope': 'off',
     'react/prop-types': 'off',
   },
-  ignorePatterns: ['dist/', 'node_modules/'],
+  ignorePatterns: ['dist/', 'node_modules/', 'tools/deno/'],
   overrides: [
     {
       // default export is needed in config files

--- a/tools/deno/deploy-dogfood.ts
+++ b/tools/deno/deploy-dogfood.ts
@@ -62,8 +62,10 @@ if (!go) {
   Deno.exit()
 }
 
-for (const num of gimletNums) {
+async function deploy(num: string) {
   console.log(`Deploying to gimlet ${num}...`)
   await $`./tools/dogfood/scp-assets.sh gc${num} ${TARBALL_FILE}`
-  console.log()
+  console.log(`Done with gimlet ${num}...`)
 }
+
+await Promise.all(gimletNums.map(deploy))

--- a/tools/deno/deploy-dogfood.ts
+++ b/tools/deno/deploy-dogfood.ts
@@ -1,0 +1,69 @@
+#! /usr/bin/env -S deno run --allow-run --allow-net --allow-read --allow-write --allow-env
+
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
+ */
+import $ from 'jsr:@david/dax@0.41.0'
+import { parseArgs } from 'jsr:@std/cli@0.224.7'
+
+// This script will not work unless you have the following helpful bits in your SSH config:
+//
+// Host gc*
+// StrictHostKeyChecking no
+// UserKnownHostsFile /dev/null
+// User root
+// ProxyCommand ssh jeeves.eng.oxide.computer pilot tp nc any $(echo "%h" | sed s/gc//) %p
+// ServerAliveInterval 15
+// ForwardAgent yes
+//
+// host jeeves
+// hostname %h.eng.oxide.computer
+// user <your actual username>
+// ForwardAgent yes
+
+const USAGE = `
+Usage:
+
+  tools/deno/dogfood-deploy.ts <console commit hash>
+`.trim()
+
+const args = parseArgs(Deno.args)
+const consoleCommit = args._[0]
+
+if (!consoleCommit) {
+  console.error('Error: Console commit hash is required\n')
+  console.log(USAGE)
+  Deno.exit(1)
+}
+
+console.log('Finding nexus zones...')
+const zones: string = await $`./tools/dogfood/find-zone.sh nexus`.text()
+const gimletNums = zones
+  .split('\n')
+  .filter((line) => line.includes('nexus'))
+  .map((line) => line.trim().split(' ')[0])
+
+console.log(`Found: ${JSON.stringify(gimletNums)}\n`)
+
+const TARBALL_URL = `https://dl.oxide.computer/releases/console/${consoleCommit}.tar.gz`
+const TARBALL_FILE = '/tmp/console.tar.gz'
+
+console.log(`Downloading tarball to ${TARBALL_FILE}`)
+await $`curl --show-error --fail --location --output ${TARBALL_FILE} ${TARBALL_URL}`
+console.log(`Done downloading.\n`)
+
+const go = await $.confirm(`Deploy console to gimlets ${JSON.stringify(gimletNums)}?`)
+if (!go) {
+  console.log('Deploy aborted')
+  Deno.exit()
+}
+
+for (const num of gimletNums) {
+  console.log(`Deploying to gimlet ${num}...`)
+  await $`./tools/dogfood/scp-assets.sh gc${num} ${TARBALL_FILE}`
+  console.log()
+}

--- a/tools/dogfood/scp-assets.sh
+++ b/tools/dogfood/scp-assets.sh
@@ -11,40 +11,29 @@ set -o pipefail
 
 # What this does:
 #
-# 1. Download console tarball (restricts this to use on commits pushed to console main)
-# 2. SCP tarball to gimlet
-# 3. Over SSH:
+# 1. SCP tarball to gimlet
+# 2. Over SSH:
 #    a. Extract tarball to tmp dir next to static dir
 #    b. Delete tarball
 #    c. Rename tmp dir to static dir
 #
 # Usage:
 #
-# First use `find-zone.sh nexus` to find the gimlets running nexus, then run this
-#
-#   ./scp-assets.sh gc21 1234567890abcdef1234567890abcdef12345678
-#
-# If you want to do more than one, use a loop
-#
-#    for gimlet in gc8 gc12 gc21; do
-#      .scp-assets.sh $gimlet 99173b920969e95d9d025d0038b8ffdb4c46c0ec
-#    done
+# The primary intended usage is to use tools/deno/deploy-dogfood.ts, which first
+# uses find-zone.sh to find the nexus gimlets and then downloads the tarball
+# and calls this script on each one. To use this script directly, do what that
+# script does.
+
+
+STATIC_DIR="static"
+TMP_DIR="static-tmp"
 
 GIMLET="$1"
-COMMIT="$2"
+TARBALL_FILE="$2"
 
 # kinda silly but we have to find the zone name, then we use the log file name to infer the nexus dir
 LOG_FILE=$(ssh $GIMLET 'NEXUS_ZONE=$(pfexec svcs -H -o ZONE -Z nexus); LOG_FILE=$(pfexec svcs -z $NEXUS_ZONE -L svc:/oxide/nexus:default); echo $LOG_FILE')
 NEXUS_DIR="$(echo $LOG_FILE | sed 's/\/svc\/log.*//')/nexus"
-
-STATIC_DIR="static"
-TMP_DIR="static-tmp"
-TARBALL_URL="https://dl.oxide.computer/releases/console/$COMMIT.tar.gz"
-TARBALL_FILE="/tmp/console.tar.gz"
-
-echo 'downloading console tarball...'
-curl --silent --show-error --fail --location --output $TARBALL_FILE $TARBALL_URL
-echo 'done. now scping it to the gimlet...'
 
 scp -r $TARBALL_FILE "$GIMLET:$NEXUS_DIR/"
 


### PR DESCRIPTION
Finally got tired of manually running `tools/dogfood/find-zone.sh` to confirm the gimlet numbers (which are always the same) and then running the deploy command three times or using xargs or whatever to loop over the three. This does it all in one command, with a confirmation step and without having to download the tarball three times. And it runs the three scps in parallel.

https://github.com/oxidecomputer/console/assets/3612203/c3a17e0e-2752-413d-bc2f-0c11e8604c10

