### PR TITLE
Improve combobox implementations in preparation for v9

### DIFF
--- a/app/components/AttachEphemeralIpModal.tsx
+++ b/app/components/AttachEphemeralIpModal.tsx
@@ -50,7 +50,7 @@ export const AttachEphemeralIpModal = ({ onDismiss }: { onDismiss: () => void })
               label="IP pool"
               placeholder={
                 siloPools?.items && siloPools.items.length > 0
-                  ? 'Select pool'
+                  ? 'Select a pool'
                   : 'No pools available'
               }
               items={

--- a/app/components/AttachFloatingIpModal.tsx
+++ b/app/components/AttachFloatingIpModal.tsx
@@ -71,7 +71,7 @@ export const AttachFloatingIpModal = ({
               control={form.control}
               name="floatingIp"
               label="Floating IP"
-              placeholder="Select floating IP"
+              placeholder="Select a floating IP"
               items={floatingIps.map((ip) => ({
                 value: ip.id,
                 label: <FloatingIpLabel fip={ip} />,

--- a/app/components/form/fields/ListboxField.tsx
+++ b/app/components/form/fields/ListboxField.tsx
@@ -34,6 +34,7 @@ export type ListboxFieldProps<
   items: ListboxItem[]
   onChange?: (value: string | null | undefined) => void
   isLoading?: boolean
+  noItemsPlaceholder?: string
 }
 
 export function ListboxField<
@@ -52,6 +53,7 @@ export function ListboxField<
   control,
   onChange,
   isLoading,
+  noItemsPlaceholder,
 }: ListboxFieldProps<TFieldValues, TName>) {
   // TODO: recreate this logic
   //   validate: (v) => (required && !v ? `${name} is required` : undefined),
@@ -64,6 +66,7 @@ export function ListboxField<
         tooltipText={tooltipText}
         required={required}
         placeholder={placeholder}
+        noItemsPlaceholder={noItemsPlaceholder}
         selected={field.value || null}
         items={items}
         onChange={(value) => {

--- a/app/components/form/fields/SubnetListbox.tsx
+++ b/app/components/form/fields/SubnetListbox.tsx
@@ -18,7 +18,6 @@ type SubnetListboxProps<
   TName extends FieldPath<TFieldValues>,
 > = Omit<ListboxFieldProps<TFieldValues, TName>, 'items'> & {
   vpcNameField: FieldPath<TFieldValues>
-  noItemsPlaceholder?: string
 }
 
 /**
@@ -31,12 +30,7 @@ type SubnetListboxProps<
 export function SubnetListbox<
   TFieldValues extends FieldValues,
   TName extends FieldPath<TFieldValues>,
->({
-  vpcNameField,
-  control,
-  noItemsPlaceholder,
-  ...fieldProps
-}: SubnetListboxProps<TFieldValues, TName>) {
+>({ vpcNameField, control, ...fieldProps }: SubnetListboxProps<TFieldValues, TName>) {
   const projectSelector = useProjectSelector()
 
   const [vpcName] = useWatch({ control, name: [vpcNameField] })
@@ -59,7 +53,7 @@ export function SubnetListbox<
       disabled={!vpcExists}
       control={control}
       placeholder="Select a subnet"
-      noItemsPlaceholder={noItemsPlaceholder}
+      noItemsPlaceholder={vpcName ? 'No subnets found' : 'Select a VPC to see subnets'}
     />
   )
 }

--- a/app/components/form/fields/SubnetListbox.tsx
+++ b/app/components/form/fields/SubnetListbox.tsx
@@ -18,6 +18,7 @@ type SubnetListboxProps<
   TName extends FieldPath<TFieldValues>,
 > = Omit<ListboxFieldProps<TFieldValues, TName>, 'items'> & {
   vpcNameField: FieldPath<TFieldValues>
+  noItemsPlaceholder?: string
 }
 
 /**
@@ -30,7 +31,12 @@ type SubnetListboxProps<
 export function SubnetListbox<
   TFieldValues extends FieldValues,
   TName extends FieldPath<TFieldValues>,
->({ vpcNameField, control, ...fieldProps }: SubnetListboxProps<TFieldValues, TName>) {
+>({
+  vpcNameField,
+  control,
+  noItemsPlaceholder,
+  ...fieldProps
+}: SubnetListboxProps<TFieldValues, TName>) {
   const projectSelector = useProjectSelector()
 
   const [vpcName] = useWatch({ control, name: [vpcNameField] })
@@ -53,7 +59,7 @@ export function SubnetListbox<
       disabled={!vpcExists}
       control={control}
       placeholder="Select a subnet"
-      noItemsPlaceholder="Select a VPC to see subnets"
+      noItemsPlaceholder={noItemsPlaceholder}
     />
   )
 }

--- a/app/components/form/fields/SubnetListbox.tsx
+++ b/app/components/form/fields/SubnetListbox.tsx
@@ -11,12 +11,12 @@ import { useApiQuery } from '@oxide/api'
 
 import { useProjectSelector } from '~/hooks'
 
-import { ComboboxField, type ComboboxFieldProps } from './ComboboxField'
+import { ListboxField, type ListboxFieldProps } from './ListboxField'
 
 type SubnetListboxProps<
   TFieldValues extends FieldValues,
   TName extends FieldPath<TFieldValues>,
-> = Omit<ComboboxFieldProps<TFieldValues, TName>, 'items'> & {
+> = Omit<ListboxFieldProps<TFieldValues, TName>, 'items'> & {
   vpcNameField: FieldPath<TFieldValues>
 }
 
@@ -47,11 +47,13 @@ export function SubnetListbox<
     ).data?.items || []
 
   return (
-    <ComboboxField
+    <ListboxField
       {...fieldProps}
       items={subnets.map(({ name }) => ({ value: name, label: name }))}
       disabled={!vpcExists}
       control={control}
+      placeholder="Select a subnet"
+      noItemsPlaceholder="Select a VPC to see subnets"
     />
   )
 }

--- a/app/forms/floating-ip-create.tsx
+++ b/app/forms/floating-ip-create.tsx
@@ -111,7 +111,7 @@ export function CreateFloatingIpSideModalForm() {
             items={(allPools?.items || []).map((p) => toListboxItem(p))}
             label="IP pool"
             control={form.control}
-            placeholder="Select pool"
+            placeholder="Select a pool"
           />
         </AccordionItem>
       </Accordion.Root>

--- a/app/forms/instance-create.tsx
+++ b/app/forms/instance-create.tsx
@@ -729,7 +729,7 @@ const AdvancedAccordion = ({
             <Listbox
               name="pools"
               label="IP pool for ephemeral IP"
-              placeholder={defaultPool ? `${defaultPool} (default)` : 'Select pool'}
+              placeholder={defaultPool ? `${defaultPool} (default)` : 'Select a pool'}
               selected={`${siloPools.find((pool) => pool.name === selectedPool)?.name}`}
               items={
                 siloPools.map((pool) => ({
@@ -838,7 +838,7 @@ const AdvancedAccordion = ({
                       )
                     }}
                     required
-                    placeholder="Select floating IP"
+                    placeholder="Select a floating IP"
                     selected={selectedFloatingIp?.name || ''}
                   />
                 </form>

--- a/app/forms/instance-create.tsx
+++ b/app/forms/instance-create.tsx
@@ -771,25 +771,21 @@ const AdvancedAccordion = ({
                 <MiniTable.HeadCell className="w-12" />
               </MiniTable.Header>
               <MiniTable.Body>
-                {attachedFloatingIpsData.map((item, index) =>
-                  item ? (
-                    <MiniTable.Row
-                      tabIndex={0}
-                      aria-rowindex={index + 1}
-                      aria-label={`Name: ${item.name}, IP: ${item.ip}`}
-                      key={item.name}
-                    >
-                      <MiniTable.Cell>{item.name}</MiniTable.Cell>
-                      <MiniTable.Cell>{item.ip}</MiniTable.Cell>
-                      <MiniTable.RemoveCell
-                        onClick={() => detachFloatingIp(item.name)}
-                        label={`remove floating IP ${item.name}`}
-                      />
-                    </MiniTable.Row>
-                  ) : (
-                    <></>
-                  )
-                )}
+                {attachedFloatingIpsData.map((item, index) => (
+                  <MiniTable.Row
+                    tabIndex={0}
+                    aria-rowindex={index + 1}
+                    aria-label={`Name: ${item.name}, IP: ${item.ip}`}
+                    key={item.name}
+                  >
+                    <MiniTable.Cell>{item.name}</MiniTable.Cell>
+                    <MiniTable.Cell>{item.ip}</MiniTable.Cell>
+                    <MiniTable.RemoveCell
+                      onClick={() => detachFloatingIp(item.name)}
+                      label={`remove floating IP ${item.name}`}
+                    />
+                  </MiniTable.Row>
+                ))}
               </MiniTable.Body>
             </MiniTable.Table>
           )}

--- a/app/forms/instance-create.tsx
+++ b/app/forms/instance-create.tsx
@@ -37,7 +37,6 @@ import {
 import { AccordionItem } from '~/components/AccordionItem'
 import { DocsPopover } from '~/components/DocsPopover'
 import { CheckboxField } from '~/components/form/fields/CheckboxField'
-import { ComboboxField } from '~/components/form/fields/ComboboxField'
 import { DescriptionField } from '~/components/form/fields/DescriptionField'
 import { DiskSizeField } from '~/components/form/fields/DiskSizeField'
 import {
@@ -46,6 +45,7 @@ import {
 } from '~/components/form/fields/DisksTableField'
 import { FileField } from '~/components/form/fields/FileField'
 import { BootDiskImageSelectField as ImageSelectField } from '~/components/form/fields/ImageSelectField'
+import { ListboxField } from '~/components/form/fields/ListboxField'
 import { NameField } from '~/components/form/fields/NameField'
 import { NetworkInterfaceField } from '~/components/form/fields/NetworkInterfaceField'
 import { NumberField } from '~/components/form/fields/NumberField'
@@ -547,7 +547,7 @@ export function CreateInstanceForm() {
                 />
               </div>
             ) : (
-              <ComboboxField
+              <ListboxField
                 label="Disk"
                 name="diskSource"
                 description="Existing disks that are not attached to an instance"
@@ -771,21 +771,25 @@ const AdvancedAccordion = ({
                 <MiniTable.HeadCell className="w-12" />
               </MiniTable.Header>
               <MiniTable.Body>
-                {attachedFloatingIpsData.map((item, index) => (
-                  <MiniTable.Row
-                    tabIndex={0}
-                    aria-rowindex={index + 1}
-                    aria-label={`Name: ${item.name}, IP: ${item.ip}`}
-                    key={item.name}
-                  >
-                    <MiniTable.Cell>{item.name}</MiniTable.Cell>
-                    <MiniTable.Cell>{item.ip}</MiniTable.Cell>
-                    <MiniTable.RemoveCell
-                      onClick={() => detachFloatingIp(item.name)}
-                      label={`remove floating IP ${item.name}`}
-                    />
-                  </MiniTable.Row>
-                ))}
+                {attachedFloatingIpsData.map((item, index) =>
+                  item ? (
+                    <MiniTable.Row
+                      tabIndex={0}
+                      aria-rowindex={index + 1}
+                      aria-label={`Name: ${item.name}, IP: ${item.ip}`}
+                      key={item.name}
+                    >
+                      <MiniTable.Cell>{item.name}</MiniTable.Cell>
+                      <MiniTable.Cell>{item.ip}</MiniTable.Cell>
+                      <MiniTable.RemoveCell
+                        onClick={() => detachFloatingIp(item.name)}
+                        label={`remove floating IP ${item.name}`}
+                      />
+                    </MiniTable.Row>
+                  ) : (
+                    <></>
+                  )
+                )}
               </MiniTable.Body>
             </MiniTable.Table>
           )}

--- a/app/forms/instance-create.tsx
+++ b/app/forms/instance-create.tsx
@@ -221,9 +221,6 @@ export function CreateInstanceForm() {
   const defaultValues: InstanceCreateInput = {
     ...baseDefaultValues,
     bootDiskSourceType: defaultSource,
-    siloImageSource: siloImages?.[0]?.id || '',
-    projectImageSource: projectImages?.[0]?.id || '',
-    diskSource: disks?.[0]?.value || '',
     sshPublicKeys: allKeys,
     bootDiskSize: nearest10(defaultImage?.size / GiB),
     externalIps: [{ type: 'ephemeral', pool: defaultPool }],

--- a/app/forms/network-interface-create.tsx
+++ b/app/forms/network-interface-create.tsx
@@ -9,8 +9,8 @@ import { useMemo } from 'react'
 
 import { useApiQuery, type ApiError, type InstanceNetworkInterfaceCreate } from '@oxide/api'
 
-import { ComboboxField } from '~/components/form/fields/ComboboxField'
 import { DescriptionField } from '~/components/form/fields/DescriptionField'
+import { ListboxField } from '~/components/form/fields/ListboxField'
 import { NameField } from '~/components/form/fields/NameField'
 import { SubnetListbox } from '~/components/form/fields/SubnetListbox'
 import { TextField } from '~/components/form/fields/TextField'
@@ -65,12 +65,13 @@ export function CreateNetworkInterfaceForm({
       <DescriptionField name="description" control={form.control} />
       <FormDivider />
 
-      <ComboboxField
+      <ListboxField
         name="vpcName"
         label="VPC"
         items={vpcs.map(({ name }) => ({ label: name, value: name }))}
         required
         control={form.control}
+        placeholder="Select a VPC"
       />
       <SubnetListbox
         name="subnetName"

--- a/app/forms/network-interface-create.tsx
+++ b/app/forms/network-interface-create.tsx
@@ -79,6 +79,9 @@ export function CreateNetworkInterfaceForm({
         vpcNameField="vpcName"
         required
         control={form.control}
+        noItemsPlaceholder={
+          form.watch('vpcName') ? 'No subnets found' : 'Select a VPC to see subnets'
+        }
       />
       <TextField
         name="ip"

--- a/app/forms/network-interface-create.tsx
+++ b/app/forms/network-interface-create.tsx
@@ -79,9 +79,6 @@ export function CreateNetworkInterfaceForm({
         vpcNameField="vpcName"
         required
         control={form.control}
-        noItemsPlaceholder={
-          form.watch('vpcName') ? 'No subnets found' : 'Select a VPC to see subnets'
-        }
       />
       <TextField
         name="ip"

--- a/app/forms/snapshot-create.tsx
+++ b/app/forms/snapshot-create.tsx
@@ -76,6 +76,7 @@ export function CreateSnapshotSideModalForm() {
       <ComboboxField
         label="Disk"
         name="disk"
+        placeholder="Select a disk"
         items={diskItems}
         required
         control={form.control}

--- a/app/pages/project/floating-ips/FloatingIpsPage.tsx
+++ b/app/pages/project/floating-ips/FloatingIpsPage.tsx
@@ -290,7 +290,7 @@ const AttachFloatingIpModal = ({
                 form.setValue('instanceId', e)
               }}
               required
-              placeholder="Select instance"
+              placeholder="Select an instance"
               selected={form.watch('instanceId')}
             />
           </form>

--- a/app/pages/system/SiloImagesPage.tsx
+++ b/app/pages/system/SiloImagesPage.tsx
@@ -169,7 +169,7 @@ const PromoteImageModal = ({ onDismiss }: { onDismiss: () => void }) => {
         <Modal.Section>
           <form autoComplete="off" onSubmit={handleSubmit(onSubmit)} className="space-y-4">
             <ComboboxField
-              placeholder="Filter images by project"
+              placeholder="Select a project"
               name="project"
               label="Project"
               items={projectItems}

--- a/app/pages/system/networking/IpPoolPage.tsx
+++ b/app/pages/system/networking/IpPoolPage.tsx
@@ -369,7 +369,7 @@ function LinkSiloModal({ onDismiss }: { onDismiss: () => void }) {
             />
 
             <ComboboxField
-              placeholder="Select silo"
+              placeholder="Select a silo"
               name="silo"
               label="Silo"
               items={unlinkedSiloItems}

--- a/app/pages/system/silos/SiloIpPoolsTab.tsx
+++ b/app/pages/system/silos/SiloIpPoolsTab.tsx
@@ -236,7 +236,7 @@ function LinkPoolModal({ onDismiss }: { onDismiss: () => void }) {
             />
 
             <ComboboxField
-              placeholder="Select pool"
+              placeholder="Select a pool"
               name="pool"
               label="IP pool"
               items={unlinkedPoolItems}

--- a/test/e2e/floating-ip-create.e2e.ts
+++ b/test/e2e/floating-ip-create.e2e.ts
@@ -83,7 +83,7 @@ test('can detach and attach a floating IP', async ({ page }) => {
   // Now click back to floating IPs and reattach it to db1
   await page.getByRole('link', { name: 'Floating IPs' }).click()
   await clickRowAction(page, 'cola-float', 'Attach')
-  await page.getByRole('button', { name: 'Select instance' }).click()
+  await page.getByRole('button', { name: 'Select an instance' }).click()
   await page.getByRole('option', { name: 'db1' }).click()
 
   await page.getByRole('button', { name: 'Attach' }).click()

--- a/test/e2e/images.e2e.ts
+++ b/test/e2e/images.e2e.ts
@@ -24,7 +24,7 @@ test('can promote an image from silo', async ({ page }) => {
   await expectNotVisible(page, ['role=cell[name="image-1"]'])
 
   // Listboxes are visible
-  await expect(page.getByPlaceholder('Filter images by project')).toBeVisible()
+  await expect(page.getByPlaceholder('Select a project')).toBeVisible()
   await expect(page.locator(`text="Select an image"`)).toBeVisible()
 
   // Notice is visible

--- a/test/e2e/instance-create.e2e.ts
+++ b/test/e2e/instance-create.e2e.ts
@@ -22,10 +22,10 @@ const selectASiloImage = async (page: Page, name: string) => {
   await page.getByRole('option', { name }).click()
 }
 
-const selectAProjectImage = async (page: Page, index: number) => {
+const selectAProjectImage = async (page: Page, name: string) => {
   await page.getByRole('tab', { name: 'Project images' }).click()
-  await page.getByRole('button', { name: 'Image' }).click()
-  await page.getByRole('option', { name: images[index].name }).click()
+  await page.getByRole('button', { name: 'Select an image' }).click()
+  await page.getByRole('option', { name }).click()
 }
 
 const selectAnExistingDisk = async (page: Page, name: string) => {
@@ -61,7 +61,7 @@ test('can create an instance', async ({ page }) => {
   await diskSizeInput.fill('20')
 
   // pick a project image just to show we can
-  await selectAProjectImage(page, 2)
+  await selectAProjectImage(page, 'image-3')
 
   // should be hidden in accordion
   await expectNotVisible(page, [
@@ -127,7 +127,7 @@ test('can create an instance', async ({ page }) => {
 test('duplicate instance name produces visible error', async ({ page }) => {
   await page.goto('/projects/mock-project/instances-new')
   await page.fill('input[name=name]', 'db1')
-  await selectAProjectImage(page, 0)
+  await selectAProjectImage(page, 'image-1')
   await page.locator('button:has-text("Create instance")').click()
   await expect(page.getByText('Instance name already exists')).toBeVisible()
 })
@@ -168,7 +168,7 @@ test('can create an instance with custom hardware', async ({ page }) => {
   await page.keyboard.press('Tab')
 
   // pick a project image just to show we can
-  await selectAProjectImage(page, 2)
+  await selectAProjectImage(page, 'image-3')
   // the disk size should bot have been changed from what was entered earlier
   await expect(diskSizeInput).toHaveValue('20')
 
@@ -204,13 +204,13 @@ test('automatically updates disk size when larger image selected', async ({ page
   await page.keyboard.press('Tab')
 
   // pick a disk image that's smaller than 5GiB (the first project image works [4GiB])
-  await selectAProjectImage(page, 0)
+  await selectAProjectImage(page, 'image-1')
 
   // test that it still says 5, as that's larger than the given image
   await expect(diskSizeInput).toHaveValue('5')
 
   // pick a disk image that's larger than 5GiB (the third project image works [6GiB])
-  await selectAProjectImage(page, 2)
+  await selectAProjectImage(page, 'image-3')
 
   // test that it has been automatically increased to next-largest incremement of 10
   await expect(diskSizeInput).toHaveValue('10')
@@ -230,7 +230,7 @@ test('automatically updates disk size when larger image selected', async ({ page
 test('with disk name already taken', async ({ page }) => {
   await page.goto('/projects/mock-project/instances-new')
   await page.fill('input[name=name]', 'my-instance')
-  await selectAProjectImage(page, 0)
+  await selectAProjectImage(page, 'image-1')
   await page.fill('input[name=bootDiskName]', 'disk-1')
 
   await page.getByRole('button', { name: 'Create instance' }).click()
@@ -268,7 +268,7 @@ test('add ssh key from instance create form', async ({ page }) => {
 test('shows object not found error on no default pool', async ({ page }) => {
   await page.goto('/projects/mock-project/instances-new')
   await page.getByRole('textbox', { name: 'Name', exact: true }).fill('no-default-pool')
-  await selectAProjectImage(page, 0)
+  await selectAProjectImage(page, 'image-1')
   await page.getByRole('button', { name: 'Create instance' }).click()
   await expect(page.getByText('Not found: default IP pool for current silo')).toBeVisible()
 })
@@ -366,7 +366,7 @@ test('maintains selected values even when changing tabs', async ({ page }) => {
 test('does not attach an ephemeral IP when the checkbox is unchecked', async ({ page }) => {
   await page.goto('/projects/mock-project/instances-new')
   await page.getByRole('textbox', { name: 'Name', exact: true }).fill('no-ephemeral-ip')
-  await selectAProjectImage(page, 0)
+  await selectAProjectImage(page, 'image-1')
   await page.getByRole('button', { name: 'Networking' }).click()
   await page
     .getByRole('checkbox', { name: 'Allocate and attach an ephemeral IP address' })
@@ -385,7 +385,7 @@ test('attaches a floating IP; disables button when no IPs available', async ({ p
   const instanceName = 'with-floating-ip'
   await page.goto('/projects/mock-project/instances-new')
   await page.getByRole('textbox', { name: 'Name', exact: true }).fill(instanceName)
-  await selectAProjectImage(page, 0)
+  await selectAProjectImage(page, 'image-1')
   await page.getByRole('button', { name: 'Networking' }).click()
 
   await attachFloatingIpButton.click()

--- a/test/e2e/instance-create.e2e.ts
+++ b/test/e2e/instance-create.e2e.ts
@@ -16,19 +16,19 @@ import {
   type Page,
 } from './utils'
 
-const pickASiloImage = async (page: Page, name: string) => {
+const selectASiloImage = async (page: Page, name: string) => {
   await page.getByRole('tab', { name: 'Silo images' }).click()
   await page.getByRole('button', { name: 'Select an image' }).click()
   await page.getByRole('option', { name }).click()
 }
 
-const pickAProjectImage = async (page: Page, index: number) => {
+const selectAProjectImage = async (page: Page, index: number) => {
   await page.getByRole('tab', { name: 'Project images' }).click()
   await page.getByRole('button', { name: 'Image' }).click()
   await page.getByRole('option', { name: images[index].name }).click()
 }
 
-const pickAnExistingDisk = async (page: Page, diskName: string) => {
+const selectAnExistingDisk = async (page: Page, diskName: string) => {
   await page.getByRole('tab', { name: 'Existing disks' }).click()
   await page.getByRole('button', { name: 'Select a disk' }).click()
   await page.getByRole('option', { name: diskName }).click()
@@ -61,7 +61,7 @@ test('can create an instance', async ({ page }) => {
   await diskSizeInput.fill('20')
 
   // pick a project image just to show we can
-  await pickAProjectImage(page, 2)
+  await selectAProjectImage(page, 2)
 
   // should be hidden in accordion
   await expectNotVisible(page, [
@@ -127,7 +127,7 @@ test('can create an instance', async ({ page }) => {
 test('duplicate instance name produces visible error', async ({ page }) => {
   await page.goto('/projects/mock-project/instances-new')
   await page.fill('input[name=name]', 'db1')
-  await pickAProjectImage(page, 0)
+  await selectAProjectImage(page, 0)
   await page.locator('button:has-text("Create instance")').click()
   await expect(page.getByText('Instance name already exists')).toBeVisible()
 })
@@ -168,7 +168,7 @@ test('can create an instance with custom hardware', async ({ page }) => {
   await page.keyboard.press('Tab')
 
   // pick a project image just to show we can
-  await pickAProjectImage(page, 2)
+  await selectAProjectImage(page, 2)
   // the disk size should bot have been changed from what was entered earlier
   await expect(diskSizeInput).toHaveValue('20')
 
@@ -204,13 +204,13 @@ test('automatically updates disk size when larger image selected', async ({ page
   await page.keyboard.press('Tab')
 
   // pick a disk image that's smaller than 5GiB (the first project image works [4GiB])
-  await pickAProjectImage(page, 0)
+  await selectAProjectImage(page, 0)
 
   // test that it still says 5, as that's larger than the given image
   await expect(diskSizeInput).toHaveValue('5')
 
   // pick a disk image that's larger than 5GiB (the third project image works [6GiB])
-  await pickAProjectImage(page, 2)
+  await selectAProjectImage(page, 2)
 
   // test that it has been automatically increased to next-largest incremement of 10
   await expect(diskSizeInput).toHaveValue('10')
@@ -230,7 +230,7 @@ test('automatically updates disk size when larger image selected', async ({ page
 test('with disk name already taken', async ({ page }) => {
   await page.goto('/projects/mock-project/instances-new')
   await page.fill('input[name=name]', 'my-instance')
-  await pickAProjectImage(page, 0)
+  await selectAProjectImage(page, 0)
   await page.fill('input[name=bootDiskName]', 'disk-1')
 
   await page.getByRole('button', { name: 'Create instance' }).click()
@@ -268,7 +268,7 @@ test('add ssh key from instance create form', async ({ page }) => {
 test('shows object not found error on no default pool', async ({ page }) => {
   await page.goto('/projects/mock-project/instances-new')
   await page.getByRole('textbox', { name: 'Name', exact: true }).fill('no-default-pool')
-  await pickAProjectImage(page, 0)
+  await selectAProjectImage(page, 0)
   await page.getByRole('button', { name: 'Create instance' }).click()
   await expect(page.getByText('Not found: default IP pool for current silo')).toBeVisible()
 })
@@ -277,7 +277,7 @@ test('create instance with existing disk', async ({ page }) => {
   const instanceName = 'my-existing-disk-instance'
   await page.goto('/projects/mock-project/instances-new')
   await page.getByRole('textbox', { name: 'Name', exact: true }).fill(instanceName)
-  await pickAnExistingDisk(page, 'disk-3')
+  await selectAnExistingDisk(page, 'disk-3')
   await page.getByRole('button', { name: 'Create instance' }).click()
   await expect(page).toHaveURL(`/projects/mock-project/instances/${instanceName}/storage`)
   await expectVisible(page, [`h1:has-text("${instanceName}")`, 'text=8 GiB'])
@@ -288,7 +288,7 @@ test('create instance with a silo image', async ({ page }) => {
   const instanceName = 'my-existing-disk-2'
   await page.goto('/projects/mock-project/instances-new')
   await page.getByRole('textbox', { name: 'Name', exact: true }).fill(instanceName)
-  await pickASiloImage(page, 'ubuntu-22-04')
+  await selectASiloImage(page, 'ubuntu-22-04')
   await page.getByRole('button', { name: 'Create instance' }).click()
   await expect(page).toHaveURL(`/projects/mock-project/instances/${instanceName}/storage`)
   await expectVisible(page, [`h1:has-text("${instanceName}")`, 'text=10 GiB'])
@@ -298,8 +298,8 @@ test('start with an existing disk, but then switch to a silo image', async ({ pa
   const instanceName = 'silo-image-instance'
   await page.goto('/projects/mock-project/instances-new')
   await page.getByRole('textbox', { name: 'Name', exact: true }).fill(instanceName)
-  await pickAnExistingDisk(page, 'disk-7')
-  await pickASiloImage(page, 'ubuntu-22-04')
+  await selectAnExistingDisk(page, 'disk-7')
+  await selectASiloImage(page, 'ubuntu-22-04')
   await page.getByRole('button', { name: 'Create instance' }).click()
   await expect(page).toHaveURL(`/projects/mock-project/instances/${instanceName}/storage`)
   await expectVisible(page, [`h1:has-text("${instanceName}")`, 'text=8 GiB'])
@@ -366,7 +366,7 @@ test('maintains selected values even when changing tabs', async ({ page }) => {
 test('does not attach an ephemeral IP when the checkbox is unchecked', async ({ page }) => {
   await page.goto('/projects/mock-project/instances-new')
   await page.getByRole('textbox', { name: 'Name', exact: true }).fill('no-ephemeral-ip')
-  await pickAProjectImage(page, 0)
+  await selectAProjectImage(page, 0)
   await page.getByRole('button', { name: 'Networking' }).click()
   await page
     .getByRole('checkbox', { name: 'Allocate and attach an ephemeral IP address' })
@@ -385,7 +385,7 @@ test('attaches a floating IP; disables button when no IPs available', async ({ p
   const instanceName = 'with-floating-ip'
   await page.goto('/projects/mock-project/instances-new')
   await page.getByRole('textbox', { name: 'Name', exact: true }).fill(instanceName)
-  await pickAProjectImage(page, 0)
+  await selectAProjectImage(page, 0)
   await page.getByRole('button', { name: 'Networking' }).click()
 
   await attachFloatingIpButton.click()

--- a/test/e2e/instance-create.e2e.ts
+++ b/test/e2e/instance-create.e2e.ts
@@ -378,7 +378,7 @@ test('does not attach an ephemeral IP when the checkbox is unchecked', async ({ 
 
 test('attaches a floating IP; disables button when no IPs available', async ({ page }) => {
   const attachFloatingIpButton = page.getByRole('button', { name: 'Attach floating IP' })
-  const selectFloatingIpButton = page.getByRole('button', { name: 'Select floating ip' })
+  const selectFloatingIpButton = page.getByRole('button', { name: 'Select a floating ip' })
   const rootbeerFloatOption = page.getByRole('option', { name: 'rootbeer-float' })
   const attachButton = page.getByRole('button', { name: 'Attach', exact: true })
 

--- a/test/e2e/instance-create.e2e.ts
+++ b/test/e2e/instance-create.e2e.ts
@@ -115,6 +115,7 @@ test('can create an instance', async ({ page }) => {
 test('duplicate instance name produces visible error', async ({ page }) => {
   await page.goto('/projects/mock-project/instances-new')
   await page.fill('input[name=name]', 'db1')
+  await pickAProjectImage(page, 0)
   await page.locator('button:has-text("Create instance")').click()
   await expect(page.getByText('Instance name already exists')).toBeVisible()
 })
@@ -217,6 +218,7 @@ test('automatically updates disk size when larger image selected', async ({ page
 test('with disk name already taken', async ({ page }) => {
   await page.goto('/projects/mock-project/instances-new')
   await page.fill('input[name=name]', 'my-instance')
+  await pickAProjectImage(page, 0)
   await page.fill('input[name=bootDiskName]', 'disk-1')
 
   await page.getByRole('button', { name: 'Create instance' }).click()

--- a/test/e2e/instance-create.e2e.ts
+++ b/test/e2e/instance-create.e2e.ts
@@ -7,7 +7,20 @@
  */
 import { floatingIp, images } from '@oxide/api-mocks'
 
-import { expect, expectNotVisible, expectRowVisible, expectVisible, test } from './utils'
+import {
+  expect,
+  expectNotVisible,
+  expectRowVisible,
+  expectVisible,
+  test,
+  type Page,
+} from './utils'
+
+const pickAProjectImage = async (page: Page, index = 0) => {
+  await page.getByRole('tab', { name: 'Project images' }).click()
+  await page.getByRole('button', { name: 'Image' }).click()
+  await page.getByRole('option', { name: images[index].name }).click()
+}
 
 test('can create an instance', async ({ page }) => {
   await page.goto('/projects/mock-project/instances')
@@ -36,9 +49,7 @@ test('can create an instance', async ({ page }) => {
   await diskSizeInput.fill('20')
 
   // pick a project image just to show we can
-  await page.getByRole('tab', { name: 'Project images' }).click()
-  await page.getByRole('button', { name: 'Image' }).click()
-  await page.getByRole('option', { name: images[2].name }).click()
+  await pickAProjectImage(page, 2)
 
   // should be hidden in accordion
   await expectNotVisible(page, [
@@ -144,9 +155,7 @@ test('can create an instance with custom hardware', async ({ page }) => {
   await page.keyboard.press('Tab')
 
   // pick a project image just to show we can
-  await page.getByRole('tab', { name: 'Project images' }).click()
-  await page.getByRole('button', { name: 'Image' }).click()
-  await page.getByRole('option', { name: images[2].name }).click()
+  await pickAProjectImage(page, 2)
   // the disk size should bot have been changed from what was entered earlier
   await expect(diskSizeInput).toHaveValue('20')
 
@@ -182,16 +191,13 @@ test('automatically updates disk size when larger image selected', async ({ page
   await page.keyboard.press('Tab')
 
   // pick a disk image that's smaller than 5GiB (the first project image works [4GiB])
-  await page.getByRole('tab', { name: 'Project images' }).click()
-  await page.getByRole('button', { name: 'Image' }).click()
-  await page.getByRole('option', { name: images[0].name }).click()
+  await pickAProjectImage(page, 0)
 
   // test that it still says 5, as that's larger than the given image
   await expect(diskSizeInput).toHaveValue('5')
 
   // pick a disk image that's larger than 5GiB (the third project image works [6GiB])
-  await page.getByRole('button', { name: 'Image' }).click()
-  await page.getByRole('option', { name: images[2].name }).click()
+  await pickAProjectImage(page, 2)
 
   // test that it has been automatically increased to next-largest incremement of 10
   await expect(diskSizeInput).toHaveValue('10')

--- a/test/e2e/instance-create.e2e.ts
+++ b/test/e2e/instance-create.e2e.ts
@@ -5,7 +5,7 @@
  *
  * Copyright Oxide Computer Company
  */
-import { floatingIp, images } from '@oxide/api-mocks'
+import { floatingIp } from '@oxide/api-mocks'
 
 import {
   expect,
@@ -18,13 +18,13 @@ import {
 
 const selectASiloImage = async (page: Page, name: string) => {
   await page.getByRole('tab', { name: 'Silo images' }).click()
-  await page.getByRole('button', { name: 'Select an image' }).click()
+  await page.getByLabel('Image', { exact: true }).click()
   await page.getByRole('option', { name }).click()
 }
 
 const selectAProjectImage = async (page: Page, name: string) => {
   await page.getByRole('tab', { name: 'Project images' }).click()
-  await page.getByRole('button', { name: 'Select an image' }).click()
+  await page.getByLabel('Image', { exact: true }).click()
   await page.getByRole('option', { name }).click()
 }
 
@@ -216,8 +216,7 @@ test('automatically updates disk size when larger image selected', async ({ page
   await expect(diskSizeInput).toHaveValue('10')
 
   // pick another image, just to verify that the diskSizeInput stays as it was
-  await page.getByRole('button', { name: 'Image' }).click()
-  await page.getByRole('option', { name: images[1].name }).click()
+  await selectAProjectImage(page, 'image-2')
   await expect(diskSizeInput).toHaveValue('10')
 
   const submitButton = page.getByRole('button', { name: 'Create instance' })

--- a/test/e2e/instance-create.e2e.ts
+++ b/test/e2e/instance-create.e2e.ts
@@ -28,10 +28,10 @@ const selectAProjectImage = async (page: Page, index: number) => {
   await page.getByRole('option', { name: images[index].name }).click()
 }
 
-const selectAnExistingDisk = async (page: Page, diskName: string) => {
+const selectAnExistingDisk = async (page: Page, name: string) => {
   await page.getByRole('tab', { name: 'Existing disks' }).click()
   await page.getByRole('button', { name: 'Select a disk' }).click()
-  await page.getByRole('option', { name: diskName }).click()
+  await page.getByRole('option', { name }).click()
 }
 
 test('can create an instance', async ({ page }) => {

--- a/test/e2e/instance-networking.e2e.ts
+++ b/test/e2e/instance-networking.e2e.ts
@@ -129,7 +129,7 @@ test('Instance networking tab — floating IPs', async ({ page }) => {
   // Select the 'rootbeer-float' option
   const dialog = page.getByRole('dialog')
   // TODO: this "select the option" syntax is awkward; it's working, but I suspect there's a better way
-  await dialog.getByRole('button', { name: 'Select floating IP' }).click()
+  await dialog.getByRole('button', { name: 'Select a floating IP' }).click()
   await page.keyboard.press('ArrowDown')
   await page.keyboard.press('Enter')
   // await dialog.getByRole('button', { name: 'rootbeer-float' }).click()

--- a/test/e2e/instance-networking.e2e.ts
+++ b/test/e2e/instance-networking.e2e.ts
@@ -17,7 +17,7 @@ test('Instance networking tab — NIC table', async ({ page }) => {
   await expect(page.getByRole('link', { name: '123.4.56.0' })).toBeVisible()
 
   // Instance networking tab
-  await page.click('role=tab[name="Networking"]')
+  await page.getByRole('tab', { name: 'Networking' }).click()
 
   const nicTable = page.getByRole('table', { name: 'Network interfaces' })
 
@@ -44,20 +44,20 @@ test('Instance networking tab — NIC table', async ({ page }) => {
   // TODO: modal title is not getting hooked up, IDs are wrong
   await expectVisible(page, [
     'role=heading[name="Add network interface"]',
-    'role=textbox[name="Name"]',
     'role=textbox[name="Description"]',
-    'role=button[name*="VPC"]', // listbox
-    'role=button[name*="Subnet"]', // listbox
     'role=textbox[name="IP Address"]',
   ])
 
-  await page.fill('role=textbox[name="Name"]', 'nic-2')
-  await page.click('role=button[name*="VPC"]')
-  await page.click('role=option[name="mock-vpc"]')
-  await page.click('role=button[name*="Subnet"]')
-  await page.click('role=option[name="mock-subnet"]')
-  await page.click('role=dialog >> role=button[name="Add network interface"]')
-  await expectVisible(page, ['role=cell[name="nic-2"]'])
+  await page.getByRole('textbox', { name: 'Name' }).fill('nic-2')
+  await page.getByLabel('VPC', { exact: true }).click()
+  await page.getByRole('option', { name: 'mock-vpc' }).click()
+  await page.getByLabel('Subnet').click()
+  await page.getByRole('option', { name: 'mock-subnet' }).click()
+  await page
+    .getByRole('dialog')
+    .getByRole('button', { name: 'Add network interface' })
+    .click()
+  await expect(page.getByRole('cell', { name: 'nic-2' })).toBeVisible()
 
   // Make this interface primary
   await clickRowAction(page, 'nic-2', 'Make primary')
@@ -66,8 +66,8 @@ test('Instance networking tab — NIC table', async ({ page }) => {
 
   // Make an edit to the network interface
   await clickRowAction(page, 'nic-2', 'Edit')
-  await page.fill('role=textbox[name="Name"]', 'nic-3')
-  await page.click('role=button[name="Update network interface"]')
+  await page.getByRole('textbox', { name: 'Name' }).fill('nic-3')
+  await page.getByRole('button', { name: 'Update network interface' }).click()
   await expect(page.getByRole('cell', { name: 'nic-2' })).toBeHidden()
   const nic3 = page.getByRole('cell', { name: 'nic-3' })
   await expect(nic3).toBeVisible()

--- a/test/e2e/ip-pools.e2e.ts
+++ b/test/e2e/ip-pools.e2e.ts
@@ -101,7 +101,7 @@ test('IP pool link silo', async ({ page }) => {
   await expect(modal).toBeVisible()
 
   // select silo in combobox and click link
-  await page.getByPlaceholder('Select silo').fill('m')
+  await page.getByPlaceholder('Select a silo').fill('m')
   await page.getByRole('option', { name: 'myriad' }).click()
   await modal.getByRole('button', { name: 'Link' }).click()
 

--- a/test/e2e/network-interface-create.e2e.ts
+++ b/test/e2e/network-interface-create.e2e.ts
@@ -47,7 +47,7 @@ test('can create a NIC with a blank IP address', async ({ page }) => {
 
   // fill out the form
   await page.getByLabel('Name').fill('nic-2')
-  await page.getByRole('button', { name: 'VPC' }).click()
+  await page.getByLabel('VPC', { exact: true }).click()
   await page.getByRole('option', { name: 'mock-vpc' }).click()
   await page.getByRole('button', { name: 'Subnet' }).click()
   await page.getByRole('option', { name: 'mock-subnet' }).click()

--- a/test/e2e/network-interface-create.e2e.ts
+++ b/test/e2e/network-interface-create.e2e.ts
@@ -20,7 +20,7 @@ test('can create a NIC with a specified IP address', async ({ page }) => {
 
   // fill out the form
   await page.getByLabel('Name').fill('nic-1')
-  await page.getByRole('button', { name: 'VPC' }).first().click()
+  await page.getByLabel('VPC', { exact: true }).click()
   await page.getByRole('option', { name: 'mock-vpc' }).click()
   await page.getByRole('button', { name: 'Subnet' }).click()
   await page.getByRole('option', { name: 'mock-subnet' }).click()

--- a/test/e2e/network-interface-create.e2e.ts
+++ b/test/e2e/network-interface-create.e2e.ts
@@ -20,7 +20,7 @@ test('can create a NIC with a specified IP address', async ({ page }) => {
 
   // fill out the form
   await page.getByLabel('Name').fill('nic-1')
-  await page.getByRole('button', { name: 'VPC' }).click()
+  await page.getByRole('button', { name: 'VPC' }).first().click()
   await page.getByRole('option', { name: 'mock-vpc' }).click()
   await page.getByRole('button', { name: 'Subnet' }).click()
   await page.getByRole('option', { name: 'mock-subnet' }).click()

--- a/test/e2e/silos.e2e.ts
+++ b/test/e2e/silos.e2e.ts
@@ -243,7 +243,7 @@ test('Silo IP pools link pool', async ({ page }) => {
   await expect(modal).toBeVisible()
 
   // select silo in combobox and click link
-  await page.getByPlaceholder('Select pool').fill('ip-pool')
+  await page.getByPlaceholder('Select a pool').fill('ip-pool')
   await page.getByRole('option', { name: 'ip-pool-3' }).click()
   await modal.getByRole('button', { name: 'Link' }).click()
 

--- a/test/e2e/z-index.e2e.ts
+++ b/test/e2e/z-index.e2e.ts
@@ -55,7 +55,7 @@ test('Dropdown content in SidebarModal shows on screen', async ({ page }) => {
 
   // select the VPC and subnet via the dropdowns. The fact that the options are
   // clickable means they are not obscured due to having a too-low z-index
-  await page.getByRole('button', { name: 'VPC' }).click()
+  await page.getByLabel('VPC', { exact: true }).click()
   await page.getByRole('option', { name: 'mock-vpc' }).click()
   await page.getByRole('button', { name: 'Subnet' }).click()
   await page.getByRole('option', { name: 'mock-subnet' }).click()


### PR DESCRIPTION
This PR makes a few general improvements to the combobox component and a few forms that use either comboboxes or listboxes.

- All placeholders should now have a consistent phrasing — `Select a disk`, `Select a pool`, etc., rather than `Select pool`, etc.
- On the instance create form, we had been pre-filling the dropdown on the Boot Disk section with the first item in each dropdown. This made things easier for users, but removed some intentionality. We have removed the default filling of that field, meaning the user will now need to select the appropriate disk for their new instance.
- Updated tests.