### PR TITLE
Update empty state text

### DIFF
--- a/app/components/form/fields/SshKeysField.tsx
+++ b/app/components/form/fields/SshKeysField.tsx
@@ -131,7 +131,7 @@ export function SshKeysField({
           <EmptyMessage
             icon={<Key16Icon />}
             title="No SSH keys"
-            body="You need to add a key to be able to see it here"
+            body="Add a key to see it here"
             buttonText="Add SSH Key"
             onClick={() => setShowAddSshKey(true)}
           />

--- a/app/pages/ProjectsPage.tsx
+++ b/app/pages/ProjectsPage.tsx
@@ -37,7 +37,7 @@ const EmptyState = () => (
   <EmptyMessage
     icon={<Folder24Icon />}
     title="No projects"
-    body="You need to create a project to be able to see it here"
+    body="Create a project to see it here"
     buttonText="New project"
     buttonTo={pb.projectsNew()}
   />

--- a/app/pages/project/disks/DisksPage.tsx
+++ b/app/pages/project/disks/DisksPage.tsx
@@ -41,7 +41,7 @@ const EmptyState = () => (
   <EmptyMessage
     icon={<Storage24Icon />}
     title="No disks"
-    body="You need to create a disk to be able to see it here"
+    body="Create a disk to see it here"
     buttonText="New disk"
     buttonTo={pb.disksNew(useProjectSelector())}
   />

--- a/app/pages/project/floating-ips/FloatingIpsPage.tsx
+++ b/app/pages/project/floating-ips/FloatingIpsPage.tsx
@@ -47,7 +47,7 @@ const EmptyState = () => (
   <EmptyMessage
     icon={<IpGlobal24Icon />}
     title="No floating IPs"
-    body="You need to create a floating IP to be able to see it here"
+    body="Create a floating IP to see it here"
     buttonText="New Floating IP"
     buttonTo={pb.floatingIpsNew(useProjectSelector())}
   />

--- a/app/pages/project/images/ImagesPage.tsx
+++ b/app/pages/project/images/ImagesPage.tsx
@@ -33,7 +33,7 @@ const EmptyState = () => (
   <EmptyMessage
     icon={<Images24Icon />}
     title="No images"
-    body="You need to create an image to be able to see it here"
+    body="Create an image to see it here"
     // buttonText="New image"
     // buttonTo="new"
   />

--- a/app/pages/project/instances/InstancesPage.tsx
+++ b/app/pages/project/instances/InstancesPage.tsx
@@ -39,7 +39,7 @@ const EmptyState = () => (
   <EmptyMessage
     icon={<Instances24Icon />}
     title="No instances"
-    body="You need to create an instance to be able to see it here"
+    body="Create an instance to see it here"
     buttonText="New instance"
     buttonTo={pb.instancesNew(useProjectSelector())}
   />

--- a/app/pages/project/instances/instance/tabs/StorageTab.tsx
+++ b/app/pages/project/instances/instance/tabs/StorageTab.tsx
@@ -160,7 +160,7 @@ export function StorageTab() {
     <EmptyMessage
       icon={<Storage24Icon />}
       title="No disks"
-      body="You need to attach a disk to this instance to be able to see it here"
+      body="Attach a disk to this instance to see it here"
     />
   )
 

--- a/app/pages/project/snapshots/SnapshotsPage.tsx
+++ b/app/pages/project/snapshots/SnapshotsPage.tsx
@@ -46,7 +46,7 @@ const EmptyState = () => (
   <EmptyMessage
     icon={<Snapshots24Icon />}
     title="No snapshots"
-    body="You need to create a snapshot to be able to see it here"
+    body="Create a snapshot to see it here"
     buttonText="New snapshot"
     buttonTo={pb.snapshotsNew(useProjectSelector())}
   />

--- a/app/pages/project/vpcs/VpcPage/tabs/VpcFirewallRulesTab.tsx
+++ b/app/pages/project/vpcs/VpcPage/tabs/VpcFirewallRulesTab.tsx
@@ -162,7 +162,7 @@ export function VpcFirewallRulesTab() {
     <TableEmptyBox>
       <EmptyMessage
         title="No firewall rules"
-        body="You need to create a rule to be able to see it here"
+        body="Create a rule to see it here"
         buttonText="New rule"
         buttonTo={pb.vpcFirewallRulesNew(vpcSelector)}
       />

--- a/app/pages/project/vpcs/VpcPage/tabs/VpcSubnetsTab.tsx
+++ b/app/pages/project/vpcs/VpcPage/tabs/VpcSubnetsTab.tsx
@@ -90,7 +90,7 @@ export function VpcSubnetsTab() {
   const emptyState = (
     <EmptyMessage
       title="No VPC subnets"
-      body="You need to create a subnet to be able to see it here"
+      body="Create a subnet to see it here"
       buttonText="New subnet"
       buttonTo={pb.vpcSubnetsNew(vpcSelector)}
     />

--- a/app/pages/project/vpcs/VpcsPage.tsx
+++ b/app/pages/project/vpcs/VpcsPage.tsx
@@ -38,7 +38,7 @@ const EmptyState = () => (
   <EmptyMessage
     icon={<Networking24Icon />}
     title="No VPCs"
-    body="You need to create a VPC to be able to see it here"
+    body="Create a VPC to see it here"
     buttonText="New VPC"
     buttonTo={pb.vpcsNew(useProjectSelector())}
   />

--- a/app/pages/settings/SSHKeysPage.tsx
+++ b/app/pages/settings/SSHKeysPage.tsx
@@ -67,7 +67,7 @@ export function SSHKeysPage() {
     <EmptyMessage
       icon={<Key16Icon />}
       title="No SSH keys"
-      body="You need to add a SSH key to be able to see it here"
+      body="Add a SSH key to see it here"
       buttonText="Add SSH key"
       onClick={() => navigate(pb.sshKeysNew())}
     />

--- a/app/pages/system/SiloImagesPage.tsx
+++ b/app/pages/system/SiloImagesPage.tsx
@@ -43,7 +43,7 @@ const EmptyState = () => (
   <EmptyMessage
     icon={<Images24Icon />}
     title="No images"
-    body="You need to promote an image to be able to see it here"
+    body="Promote an image to see it here"
   />
 )
 

--- a/app/pages/system/networking/IpPoolsPage.tsx
+++ b/app/pages/system/networking/IpPoolsPage.tsx
@@ -39,7 +39,7 @@ const EmptyState = () => (
   <EmptyMessage
     icon={<IpGlobal24Icon />}
     title="No IP pools"
-    body="You need to create an IP pool to be able to see it here"
+    body="Create an IP pool to see it here"
     buttonText="New IP pool"
     buttonTo={pb.ipPoolsNew()}
   />

--- a/app/pages/system/silos/SiloIpPoolsTab.tsx
+++ b/app/pages/system/silos/SiloIpPoolsTab.tsx
@@ -32,7 +32,7 @@ const EmptyState = () => (
   <EmptyMessage
     icon={<Networking24Icon />}
     title="No IP pools"
-    body="You need to create an IP pool to be able to see it here"
+    body="Create an IP pool to see it here"
     buttonText="New IP pool"
     buttonTo={pb.ipPoolsNew()}
   />

--- a/app/pages/system/silos/SilosPage.tsx
+++ b/app/pages/system/silos/SilosPage.tsx
@@ -38,7 +38,7 @@ const EmptyState = () => (
   <EmptyMessage
     icon={<Cloud24Icon />}
     title="No silos"
-    body="You need to create a silo to be able to see it here"
+    body="Create a silo to see it here"
     buttonText="New silo"
     buttonTo={pb.silosNew()}
   />

--- a/app/ui/lib/EmptyMessage.stories.tsx
+++ b/app/ui/lib/EmptyMessage.stories.tsx
@@ -13,7 +13,7 @@ export const Default = () => (
   <EmptyMessage
     icon={<Instances24Icon />}
     title="No instances"
-    body="You need to create an instance to be able to see it here"
+    body="Create an instance to see it here"
     buttonText="New instance"
     buttonTo="new"
   />

--- a/app/ui/lib/EmptyMessage.tsx
+++ b/app/ui/lib/EmptyMessage.tsx
@@ -46,7 +46,9 @@ export function EmptyMessage(props: Props) {
         </div>
       )}
       <h3 className="text-sans-semi-lg">{props.title}</h3>
-      {props.body && <p className="mt-1 text-sans-md text-secondary">{props.body}</p>}
+      {props.body && (
+        <p className="mt-1 text-balance text-sans-md text-secondary">{props.body}</p>
+      )}
       {button}
     </div>
   )


### PR DESCRIPTION
Fixes #2289 

It was quick to update the copy here, though if we decide we want to remove the text completely, that's fine, too. I think for now it makes sense to keep the text in place.

I added a `text-balance` CSS class to balance multi-line text, though I'm holding lightly to that if we aren't into it:

**Without `text-balance`:**
<img width="260" alt="Screenshot 2024-07-02 at 2 24 25 PM" src="https://github.com/oxidecomputer/console/assets/22547/49dc6b84-bd5d-46cc-90d1-23f951cb95bb">
**With `text-balance`:**
<img width="204" alt="Screenshot 2024-07-02 at 2 25 29 PM" src="https://github.com/oxidecomputer/console/assets/22547/68c088e8-adc5-4a46-b99c-78aeddf8d306">

