### PR TITLE
Remove cmd+k quick actions from instance detail page

### DIFF
--- a/app/pages/project/instances/instance/InstancePage.tsx
+++ b/app/pages/project/instances/instance/InstancePage.tsx
@@ -23,7 +23,7 @@ import { MoreActionsMenu } from '~/components/MoreActionsMenu'
 import { RefreshButton } from '~/components/RefreshButton'
 import { RouteTabs, Tab } from '~/components/RouteTabs'
 import { InstanceStatusBadge } from '~/components/StatusBadge'
-import { getInstanceSelector, useInstanceSelector, useQuickActions } from '~/hooks'
+import { getInstanceSelector, useInstanceSelector } from '~/hooks'
 import { EmptyCell } from '~/table/cells/EmptyCell'
 import { DateTime } from '~/ui/lib/DateTime'
 import { PageHeader, PageTitle } from '~/ui/lib/PageHeader'
@@ -128,18 +128,6 @@ export function InstancePage() {
     ],
     [instance, makeActions]
   )
-  const quickActions = useMemo(
-    () =>
-      actions
-        // in the quick menu we do not show disabled actions
-        .filter((a) => !a.disabled)
-        // append "instance" to labels
-        // TODO: if these were in an "Instance actions" subsection they might not
-        // need the suffix for clarity
-        .map((a) => ({ onSelect: a.onActivate, value: a.label })),
-    [actions]
-  )
-  useQuickActions(quickActions)
 
   const memory = filesize(instance.memory, { output: 'object', base: 2 })
 


### PR DESCRIPTION
Closes #2276 

Fixing them is too complicated and doesn't seem worth it. Bye!

<img width="905" alt="image" src="https://github.com/oxidecomputer/console/assets/3612203/fc9fb8d5-6d64-4f74-962a-eafe60e72b7c">
