### PR TITLE
Update header on Project Images page to say "Project Images"

### DIFF
--- a/app/pages/project/images/ImagesPage.tsx
+++ b/app/pages/project/images/ImagesPage.tsx
@@ -99,7 +99,7 @@ export function ImagesPage() {
   return (
     <>
       <PageHeader>
-        <PageTitle icon={<Images24Icon />}>Images</PageTitle>
+        <PageTitle icon={<Images24Icon />}>Project Images</PageTitle>
         <DocsPopover
           heading="Images"
           icon={<Images16Icon />}


### PR DESCRIPTION
This makes the Project Images page header consistent with the Silo Images page header

Fixes #2309