### PR TITLE
Update image 'edit' form title, as form isn't actually editable

### DIFF
--- a/app/forms/image-edit.tsx
+++ b/app/forms/image-edit.tsx
@@ -26,6 +26,7 @@ import { PropertiesTable } from '~/ui/lib/PropertiesTable'
 import { ResourceLabel } from '~/ui/lib/SideModal'
 import { Truncate } from '~/ui/lib/Truncate'
 import { pb } from '~/util/path-builder'
+import { capitalize } from '~/util/str'
 import { bytesToGiB } from '~/util/units'
 
 EditProjectImageSideModalForm.loader = async ({ params }: LoaderFunctionArgs) => {
@@ -69,12 +70,14 @@ export function EditImageSideModalForm({
 }) {
   const navigate = useNavigate()
   const form = useForm({ defaultValues: image })
+  const resourceName = type === 'Project' ? 'project image' : 'silo image'
 
   return (
     <SideModalForm
+      title={capitalize(resourceName)}
       form={form}
       formType="edit"
-      resourceName={type === 'Project' ? 'project image' : 'silo image'}
+      resourceName={resourceName}
       onDismiss={() => navigate(dismissLink)}
       subtitle={
         <ResourceLabel>
@@ -100,7 +103,6 @@ export function EditImageSideModalForm({
           <DateTime date={image.timeModified} />
         </PropertiesTable.Row>
       </PropertiesTable>
-
       <NameField name="name" control={form.control} disabled />
       <DescriptionField name="description" control={form.control} required disabled />
       <TextField name="os" label="OS" control={form.control} required disabled />


### PR DESCRIPTION
Currently, the Image "edit" form title defaults to saying "Edit {silo|project} image", which is confusing, as it isn't actually editable. This PR just updates that to make it less confusing. The URL is not changed; presumably we will be able to edit aspects of Images in time.

<img width="497" alt="Screenshot 2024-07-03 at 11 47 28 AM" src="https://github.com/oxidecomputer/console/assets/22547/ee52eb90-2e2a-4e39-b018-53b99d858745">
<img width="481" alt="Screenshot 2024-07-03 at 11 47 41 AM" src="https://github.com/oxidecomputer/console/assets/22547/4c8729a1-922f-4b30-9bdf-d4d916a22158">
