### PR TITLE
chore: tweak test commands

### DIFF
--- a/.github/workflows/lintBuildTest.yml
+++ b/.github/workflows/lintBuildTest.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Lint
         run: npm run lint
       - name: Test
-        run: VITEST_MAX_THREADS=1 VITEST_MIN_THREADS=1 npm run test run
+        run: npm test run
       - name: Build
         run: npm run build
   playwright:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "vite build",
     "ci": "npm run tsc && npm run lint && npm run test run && npm run e2ec",
     "tsc": "tsc",
-    "test": "vitest",
+    "test": "NODE_OPTIONS='--no-deprecation' vitest",
     "e2e": "playwright test",
     "e2ec": "playwright test --project=chrome",
     "lint": "eslint --ext .js,.ts,.tsx app test mock-api",


### PR DESCRIPTION
Hide punycode deprecation warnings and remove min/max threads from test command in CI. The latter were added 2 1/2 years ago in https://github.com/oxidecomputer/console/pull/654. Seems to work fine without it!