### PR TITLE
Remove truncation on topbar dropdown

### DIFF
--- a/app/components/TopBarPicker.tsx
+++ b/app/components/TopBarPicker.tsx
@@ -21,7 +21,6 @@ import { PAGE_SIZE } from '~/table/QueryTable'
 import { Button } from '~/ui/lib/Button'
 import { DropdownMenu } from '~/ui/lib/DropdownMenu'
 import { Identicon } from '~/ui/lib/Identicon'
-import { Truncate } from '~/ui/lib/Truncate'
 import { Wrap } from '~/ui/util/wrap'
 import { pb } from '~/util/path-builder'
 
@@ -118,8 +117,8 @@ const TopBarPicker = (props: TopBarPickerProps) => {
                 return (
                   <DropdownMenu.Item asChild key={label}>
                     <Link to={to} className={cn({ 'is-selected': isSelected })}>
-                      <span className="flex w-full items-center justify-between">
-                        <Truncate text={label} maxLength={24} />
+                      <span className="flex w-full items-center gap-2">
+                        {label}
                         {isSelected && <Success12Icon className="-mr-3 block" />}
                       </span>
                     </Link>


### PR DESCRIPTION
This removes the truncation in the topbar dropdown, just in case that's the direction we want to go with it. If not, no worries.

Fixes #2327 if we go with it.

<img width="516" alt="Screenshot 2024-07-17 at 11 45 03 AM" src="https://github.com/user-attachments/assets/4350e657-baab-41c6-94bc-580484e8c991">
