### PR TITLE
Add columns on SledsTab for sled Policy and State

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -45,6 +45,7 @@ module.exports = {
     '@typescript-eslint/no-empty-interface': 'off',
     '@typescript-eslint/ban-ts-comment': 'off',
     '@typescript-eslint/no-non-null-assertion': 'off',
+    '@typescript-eslint/no-duplicate-type-constituents': 'off',
     '@typescript-eslint/no-unused-vars': [
       'error',
       { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },

--- a/app/components/StatusBadge.tsx
+++ b/app/components/StatusBadge.tsx
@@ -5,7 +5,13 @@
  *
  * Copyright Oxide Computer Company
  */
-import type { DiskState, InstanceState, SnapshotState } from '@oxide/api'
+import type {
+  DiskState,
+  InstanceState,
+  PhysicalDiskState,
+  SledState,
+  SnapshotState,
+} from '@oxide/api'
 
 import { Badge, type BadgeColor, type BadgeProps } from '~/ui/lib/Badge'
 
@@ -68,4 +74,18 @@ export const SnapshotStatusBadge = (props: {
   <Badge color={SNAPSHOT_COLORS[props.status]} className={props.className}>
     {props.status}
   </Badge>
+)
+
+export const PolicyKindBadge = ({ policy }: { policy: 'in_service' | 'expunged' }) => {
+  const color = policy === 'in_service' ? 'default' : 'neutral'
+  return <Badge color={color}>{policy.replace(/_/g, ' ')}</Badge>
+}
+
+const STATE_BADGE_COLORS: Record<PhysicalDiskState | SledState, BadgeColor> = {
+  active: 'default',
+  decommissioned: 'neutral',
+}
+
+export const StateBadge = ({ state }: { state: PhysicalDiskState | SledState }) => (
+  <Badge color={STATE_BADGE_COLORS[state]}>{state}</Badge>
 )

--- a/app/components/StatusBadge.tsx
+++ b/app/components/StatusBadge.tsx
@@ -5,15 +5,7 @@
  *
  * Copyright Oxide Computer Company
  */
-import type {
-  DiskState,
-  InstanceState,
-  PhysicalDiskPolicy,
-  PhysicalDiskState,
-  SledPolicy,
-  SledState,
-  SnapshotState,
-} from '@oxide/api'
+import type { DiskState, InstanceState, SnapshotState } from '@oxide/api'
 
 import { Badge, type BadgeColor, type BadgeProps } from '~/ui/lib/Badge'
 
@@ -76,24 +68,4 @@ export const SnapshotStatusBadge = (props: {
   <Badge color={SNAPSHOT_COLORS[props.status]} className={props.className}>
     {props.status}
   </Badge>
-)
-
-type PolicyKind = PhysicalDiskPolicy['kind'] | SledPolicy['kind']
-
-const POLICY_KIND_BADGE_COLORS: Record<PolicyKind, BadgeColor> = {
-  in_service: 'default',
-  expunged: 'neutral',
-}
-
-export const PolicyKindBadge = ({ kind }: { kind: PolicyKind }) => (
-  <Badge color={POLICY_KIND_BADGE_COLORS[kind]}>{kind.replace(/_/g, ' ')}</Badge>
-)
-
-const STATE_BADGE_COLORS: Record<PhysicalDiskState | SledState, BadgeColor> = {
-  active: 'default',
-  decommissioned: 'neutral',
-}
-
-export const StateBadge = ({ state }: { state: PhysicalDiskState | SledState }) => (
-  <Badge color={STATE_BADGE_COLORS[state]}>{state}</Badge>
 )

--- a/app/components/StatusBadge.tsx
+++ b/app/components/StatusBadge.tsx
@@ -8,7 +8,9 @@
 import type {
   DiskState,
   InstanceState,
+  PhysicalDiskPolicy,
   PhysicalDiskState,
+  SledPolicy,
   SledState,
   SnapshotState,
 } from '@oxide/api'
@@ -76,10 +78,16 @@ export const SnapshotStatusBadge = (props: {
   </Badge>
 )
 
-export const PolicyKindBadge = ({ policy }: { policy: 'in_service' | 'expunged' }) => {
-  const color = policy === 'in_service' ? 'default' : 'neutral'
-  return <Badge color={color}>{policy.replace(/_/g, ' ')}</Badge>
+type PolicyKind = PhysicalDiskPolicy['kind'] | SledPolicy['kind']
+
+const POLICY_KIND_BADGE_COLORS: Record<PolicyKind, BadgeColor> = {
+  in_service: 'default',
+  expunged: 'neutral',
 }
+
+export const PolicyKindBadge = ({ kind }: { kind: PolicyKind }) => (
+  <Badge color={POLICY_KIND_BADGE_COLORS[kind]}>{kind.replace(/_/g, ' ')}</Badge>
+)
 
 const STATE_BADGE_COLORS: Record<PhysicalDiskState | SledState, BadgeColor> = {
   active: 'default',

--- a/app/pages/system/inventory/DisksTab.tsx
+++ b/app/pages/system/inventory/DisksTab.tsx
@@ -52,8 +52,11 @@ const staticCols = [
   colHelper.accessor('model', { header: 'model number' }),
   colHelper.accessor('serial', { header: 'serial number' }),
   colHelper.accessor('policy.kind', {
+    header: 'policy',
     cell: (info) => (
-      <Badge color={POLICY_KIND_BADGE_COLORS[info.getValue()]}>{info.getValue()}</Badge>
+      <Badge color={POLICY_KIND_BADGE_COLORS[info.getValue()]}>
+        {info.getValue().replace(/_/g, ' ')}
+      </Badge>
     ),
   }),
   colHelper.accessor('state', {

--- a/app/pages/system/inventory/DisksTab.tsx
+++ b/app/pages/system/inventory/DisksTab.tsx
@@ -7,13 +7,27 @@
  */
 import { createColumnHelper } from '@tanstack/react-table'
 
-import { apiQueryClient, type PhysicalDisk } from '@oxide/api'
+import {
+  apiQueryClient,
+  type PhysicalDisk,
+  type PhysicalDiskPolicy,
+  type PhysicalDiskState,
+} from '@oxide/api'
 import { Servers24Icon } from '@oxide/design-system/icons/react'
 
-import { PolicyKindBadge, StateBadge } from '~/components/StatusBadge'
 import { PAGE_SIZE, useQueryTable } from '~/table/QueryTable'
-import { Badge } from '~/ui/lib/Badge'
+import { Badge, type BadgeColor } from '~/ui/lib/Badge'
 import { EmptyMessage } from '~/ui/lib/EmptyMessage'
+
+const POLICY_KIND_BADGE_COLORS: Record<PhysicalDiskPolicy['kind'], BadgeColor> = {
+  in_service: 'default',
+  expunged: 'neutral',
+}
+
+const STATE_BADGE_COLORS: Record<PhysicalDiskState, BadgeColor> = {
+  active: 'default',
+  decommissioned: 'neutral',
+}
 
 const EmptyState = () => (
   <EmptyMessage
@@ -38,10 +52,14 @@ const staticCols = [
   colHelper.accessor('model', { header: 'model number' }),
   colHelper.accessor('serial', { header: 'serial number' }),
   colHelper.accessor('policy.kind', {
-    cell: (info) => <PolicyKindBadge kind={info.getValue()} />,
+    cell: (info) => (
+      <Badge color={POLICY_KIND_BADGE_COLORS[info.getValue()]}>{info.getValue()}</Badge>
+    ),
   }),
   colHelper.accessor('state', {
-    cell: (info) => <StateBadge state={info.getValue()} />,
+    cell: (info) => (
+      <Badge color={STATE_BADGE_COLORS[info.getValue()]}>{info.getValue()}</Badge>
+    ),
   }),
 ]
 

--- a/app/pages/system/inventory/DisksTab.tsx
+++ b/app/pages/system/inventory/DisksTab.tsx
@@ -10,6 +10,7 @@ import { createColumnHelper } from '@tanstack/react-table'
 import { apiQueryClient, type PhysicalDisk } from '@oxide/api'
 import { Servers24Icon } from '@oxide/design-system/icons/react'
 
+import { PolicyKindBadge, StateBadge } from '~/components/StatusBadge'
 import { PAGE_SIZE, useQueryTable } from '~/table/QueryTable'
 import { Badge } from '~/ui/lib/Badge'
 import { EmptyMessage } from '~/ui/lib/EmptyMessage'
@@ -37,18 +38,10 @@ const staticCols = [
   colHelper.accessor('model', { header: 'model number' }),
   colHelper.accessor('serial', { header: 'serial number' }),
   colHelper.accessor('policy', {
-    cell: (info) => {
-      const policy = info.getValue().kind
-      const color = policy === 'in_service' ? 'default' : 'neutral'
-      return <Badge color={color}>{policy.replace(/_/g, ' ')}</Badge>
-    },
+    cell: (info) => <PolicyKindBadge policy={info.getValue().kind} />,
   }),
   colHelper.accessor('state', {
-    cell: (info) => {
-      const state = info.getValue()
-      const color = state === 'active' ? 'default' : 'neutral'
-      return <Badge color={color}>{state}</Badge>
-    },
+    cell: (info) => <StateBadge state={info.getValue()} />,
   }),
 ]
 

--- a/app/pages/system/inventory/DisksTab.tsx
+++ b/app/pages/system/inventory/DisksTab.tsx
@@ -37,8 +37,8 @@ const staticCols = [
   }),
   colHelper.accessor('model', { header: 'model number' }),
   colHelper.accessor('serial', { header: 'serial number' }),
-  colHelper.accessor('policy', {
-    cell: (info) => <PolicyKindBadge policy={info.getValue().kind} />,
+  colHelper.accessor('policy.kind', {
+    cell: (info) => <PolicyKindBadge kind={info.getValue()} />,
   }),
   colHelper.accessor('state', {
     cell: (info) => <StateBadge state={info.getValue()} />,

--- a/app/pages/system/inventory/SledsTab.tsx
+++ b/app/pages/system/inventory/SledsTab.tsx
@@ -53,8 +53,11 @@ const staticCols = [
   colHelper.accessor('baseboard.serial', { header: 'serial number' }),
   colHelper.accessor('baseboard.revision', { header: 'revision' }),
   colHelper.accessor('policy.kind', {
+    header: 'policy',
     cell: (info) => (
-      <Badge color={POLICY_KIND_BADGE_COLORS[info.getValue()]}>{info.getValue()}</Badge>
+      <Badge color={POLICY_KIND_BADGE_COLORS[info.getValue()]}>
+        {info.getValue().replace(/_/g, ' ')}
+      </Badge>
     ),
   }),
   colHelper.accessor('state', {

--- a/app/pages/system/inventory/SledsTab.tsx
+++ b/app/pages/system/inventory/SledsTab.tsx
@@ -7,14 +7,24 @@
  */
 import { createColumnHelper } from '@tanstack/react-table'
 
-import { apiQueryClient, type Sled } from '@oxide/api'
+import { apiQueryClient, type Sled, type SledPolicy, type SledState } from '@oxide/api'
 import { Servers24Icon } from '@oxide/design-system/icons/react'
 
-import { PolicyKindBadge, StateBadge } from '~/components/StatusBadge'
 import { makeLinkCell } from '~/table/cells/LinkCell'
 import { PAGE_SIZE, useQueryTable } from '~/table/QueryTable'
+import { Badge, type BadgeColor } from '~/ui/lib/Badge'
 import { EmptyMessage } from '~/ui/lib/EmptyMessage'
 import { pb } from '~/util/path-builder'
+
+const POLICY_KIND_BADGE_COLORS: Record<SledPolicy['kind'], BadgeColor> = {
+  in_service: 'default',
+  expunged: 'neutral',
+}
+
+const STATE_BADGE_COLORS: Record<SledState, BadgeColor> = {
+  active: 'default',
+  decommissioned: 'neutral',
+}
 
 const EmptyState = () => {
   return (
@@ -43,10 +53,14 @@ const staticCols = [
   colHelper.accessor('baseboard.serial', { header: 'serial number' }),
   colHelper.accessor('baseboard.revision', { header: 'revision' }),
   colHelper.accessor('policy.kind', {
-    cell: (info) => <PolicyKindBadge kind={info.getValue()} />,
+    cell: (info) => (
+      <Badge color={POLICY_KIND_BADGE_COLORS[info.getValue()]}>{info.getValue()}</Badge>
+    ),
   }),
   colHelper.accessor('state', {
-    cell: (info) => <StateBadge state={info.getValue()} />,
+    cell: (info) => (
+      <Badge color={STATE_BADGE_COLORS[info.getValue()]}>{info.getValue()}</Badge>
+    ),
   }),
 ]
 

--- a/app/pages/system/inventory/SledsTab.tsx
+++ b/app/pages/system/inventory/SledsTab.tsx
@@ -42,8 +42,8 @@ const staticCols = [
   colHelper.accessor('baseboard.part', { header: 'part number' }),
   colHelper.accessor('baseboard.serial', { header: 'serial number' }),
   colHelper.accessor('baseboard.revision', { header: 'revision' }),
-  colHelper.accessor('policy', {
-    cell: (info) => <PolicyKindBadge policy={info.getValue().kind} />,
+  colHelper.accessor('policy.kind', {
+    cell: (info) => <PolicyKindBadge kind={info.getValue()} />,
   }),
   colHelper.accessor('state', {
     cell: (info) => <StateBadge state={info.getValue()} />,

--- a/app/pages/system/inventory/SledsTab.tsx
+++ b/app/pages/system/inventory/SledsTab.tsx
@@ -10,6 +10,7 @@ import { createColumnHelper } from '@tanstack/react-table'
 import { apiQueryClient, type Sled } from '@oxide/api'
 import { Servers24Icon } from '@oxide/design-system/icons/react'
 
+import { PolicyKindBadge, StateBadge } from '~/components/StatusBadge'
 import { makeLinkCell } from '~/table/cells/LinkCell'
 import { PAGE_SIZE, useQueryTable } from '~/table/QueryTable'
 import { EmptyMessage } from '~/ui/lib/EmptyMessage'
@@ -41,6 +42,12 @@ const staticCols = [
   colHelper.accessor('baseboard.part', { header: 'part number' }),
   colHelper.accessor('baseboard.serial', { header: 'serial number' }),
   colHelper.accessor('baseboard.revision', { header: 'revision' }),
+  colHelper.accessor('policy', {
+    cell: (info) => <PolicyKindBadge policy={info.getValue().kind} />,
+  }),
+  colHelper.accessor('state', {
+    cell: (info) => <StateBadge state={info.getValue()} />,
+  }),
 ]
 
 export function SledsTab() {

--- a/mock-api/sled.ts
+++ b/mock-api/sled.ts
@@ -9,23 +9,75 @@ import type { Sled } from '@oxide/api'
 
 import type { Json } from './json-type'
 
-export const sled: Json<Sled> = {
-  id: 'c2519937-44a4-493b-9b38-5c337c597d08',
-  time_created: new Date(2021, 0, 1).toISOString(),
-  time_modified: new Date(2021, 0, 2).toISOString(),
-  rack_id: '6fbafcc7-1626-4785-be65-e212f8ad66d0',
-  policy: {
-    kind: 'in_service',
-    provision_policy: 'provisionable',
+export const sleds: Json<Sled[]> = [
+  {
+    id: 'c2519937-44a4-493b-9b38-5c337c597d08',
+    time_created: new Date(2023, 0, 1).toISOString(),
+    time_modified: new Date(2023, 0, 2).toISOString(),
+    rack_id: '6fbafcc7-1626-4785-be65-e212f8ad66d0',
+    policy: {
+      kind: 'in_service',
+      provision_policy: 'provisionable',
+    },
+    state: 'active',
+    baseboard: {
+      part: '913-0000108',
+      serial: 'BRM02222869',
+      revision: 0,
+    },
+    usable_hardware_threads: 128,
+    usable_physical_ram: 1_099_511_627_776,
   },
-  state: 'active',
-  baseboard: {
-    part: '913-0000008',
-    serial: 'BRM02222867',
-    revision: 0,
+  {
+    id: '1ec7df9d-a6de-423c-8bf8-01557e8e5aea',
+    time_created: new Date(2024, 0, 1).toISOString(),
+    time_modified: new Date(2024, 0, 2).toISOString(),
+    rack_id: '759a1c80-4bff-4d0b-97ce-b482ca936724',
+    policy: {
+      kind: 'in_service',
+      provision_policy: 'provisionable',
+    },
+    state: 'active',
+    baseboard: {
+      part: '913-0001008',
+      serial: 'BRM02222870',
+      revision: 0,
+    },
+    usable_hardware_threads: 128,
+    usable_physical_ram: 1_099_511_627_776,
   },
-  usable_hardware_threads: 128,
-  usable_physical_ram: 1_099_511_627_776,
-}
-
-export const sleds: Json<Sled[]> = [sled]
+  {
+    id: 'fca81647-868a-4aa5-b8c3-84364d4b4dc9',
+    time_created: new Date(2022, 0, 1).toISOString(),
+    time_modified: new Date(2022, 0, 2).toISOString(),
+    rack_id: 'ebe9a4c0-248b-491c-9448-04ddb10ef648',
+    policy: {
+      kind: 'expunged',
+    },
+    state: 'active',
+    baseboard: {
+      part: '913-0000018',
+      serial: 'BRM02222868',
+      revision: 0,
+    },
+    usable_hardware_threads: 128,
+    usable_physical_ram: 1_099_511_627_776,
+  },
+  {
+    id: 'a4ed0c62-cb3a-48bc-a7a8-ee544a8a8869',
+    time_created: new Date(2021, 0, 1).toISOString(),
+    time_modified: new Date(2021, 0, 2).toISOString(),
+    rack_id: '64f712fe-4320-407d-835a-d63b0455d89c',
+    policy: {
+      kind: 'expunged',
+    },
+    state: 'decommissioned',
+    baseboard: {
+      part: '913-0000008',
+      serial: 'BRM02222867',
+      revision: 0,
+    },
+    usable_hardware_threads: 128,
+    usable_physical_ram: 1_099_511_627_776,
+  },
+]

--- a/test/e2e/inventory.e2e.ts
+++ b/test/e2e/inventory.e2e.ts
@@ -5,7 +5,8 @@
  *
  * Copyright Oxide Computer Company
  */
-import { physicalDisks } from '@oxide/api-mocks'
+
+import { physicalDisks, sleds } from '@oxide/api-mocks'
 
 import { expect, expectRowVisible, expectVisible, test } from './utils'
 
@@ -19,6 +20,25 @@ test('Sled inventory page', async ({ page }) => {
   await expect(sledsTab).toHaveClass(/is-selected/)
 
   const sledsTable = page.getByRole('table')
+  await expectRowVisible(sledsTable, {
+    id: sleds[1].id,
+    'serial number': sleds[1].baseboard.serial,
+    policy: 'in service',
+    state: 'active',
+  })
+  await expectRowVisible(sledsTable, {
+    id: sleds[2].id,
+    'serial number': sleds[2].baseboard.serial,
+    policy: 'expunged',
+    state: 'active',
+  })
+  await expectRowVisible(sledsTable, {
+    id: sleds[3].id,
+    'serial number': sleds[3].baseboard.serial,
+    policy: 'expunged',
+    state: 'decommissioned',
+  })
+
   // Visit the sled detail page of the first sled
   await sledsTable.getByRole('link').first().click()
 
@@ -54,11 +74,13 @@ test('Disk inventory page', async ({ page }) => {
   })
   await expectRowVisible(table, {
     id: physicalDisks[4].id,
+    'Form factor': 'M.2',
     policy: 'expunged',
     state: 'active',
   })
   await expectRowVisible(table, {
     id: physicalDisks[5].id,
+    'Form factor': 'M.2',
     policy: 'expunged',
     state: 'decommissioned',
   })


### PR DESCRIPTION
This PR adds columns for the Policy and State on the Sleds tab, as we have them on the Disks tab.

The columns on the right side are new:
<img width="1225" alt="Screenshot 2024-07-23 at 3 47 44 PM" src="https://github.com/user-attachments/assets/e92892e3-c08d-4cc2-a2d5-0def178d753d">

Same as before:
<img width="1225" alt="Screenshot 2024-07-23 at 3 47 55 PM" src="https://github.com/user-attachments/assets/d1ec19ef-0583-4829-ba42-4b6d30f91457">

Fixes #2333 