### PR TITLE
Focus confirm button instead of cancel in modals

### DIFF
--- a/app/ui/lib/Modal.tsx
+++ b/app/ui/lib/Modal.tsx
@@ -135,10 +135,9 @@ Modal.Footer = ({
 }) => (
   <footer className="flex items-center justify-between border-t px-3 py-3 border-secondary">
     <div className="mr-4">{children}</div>
-    <div className="space-x-2">
-      <Button variant="secondary" size="sm" onClick={onDismiss}>
-        {cancelText || 'Cancel'}
-      </Button>
+    <div className="flex flex-row-reverse gap-2">
+      {/* Note the confirm button is first so it autofocuses when the modal opens,
+          but it displays in the right order because of flex-row-reverse */}
       <Button
         size="sm"
         variant={actionType}
@@ -147,6 +146,9 @@ Modal.Footer = ({
         loading={actionLoading}
       >
         {actionText}
+      </Button>
+      <Button variant="secondary" size="sm" onClick={onDismiss}>
+        {cancelText || 'Cancel'}
       </Button>
     </div>
   </footer>


### PR DESCRIPTION
We fixed this once in #1714, though maybe it was only for side modals. In any case, here I swap the order in the HTML so the confirm button autofocuses and use `flex-row-reverse` to get them to display visually in the right order. This has the downside that tabbing through goes in a funny order, but that seems less bad on net than the status quo.

### Before

<img width="484" alt="image" src="https://github.com/user-attachments/assets/11982d5b-fa44-4d59-ac80-8368e63eba00">

### After

<img width="490" alt="image" src="https://github.com/user-attachments/assets/1977bb7b-c500-4cbe-aa6b-9e5d2f455ee0">
