### PR TITLE
Use real links in dropdown menus

### DIFF
--- a/app/components/TopBar.tsx
+++ b/app/components/TopBar.tsx
@@ -6,7 +6,6 @@
  * Copyright Oxide Computer Company
  */
 import React from 'react'
-import { useNavigate } from 'react-router-dom'
 
 import { navToLogin, useApiMutation } from '@oxide/api'
 import { DirectionDownIcon, Profile16Icon } from '@oxide/design-system/icons/react'
@@ -17,7 +16,6 @@ import { DropdownMenu } from '~/ui/lib/DropdownMenu'
 import { pb } from '~/util/path-builder'
 
 export function TopBar({ children }: { children: React.ReactNode }) {
-  const navigate = useNavigate()
   const logout = useApiMutation('logout', {
     onSuccess: () => navToLogin({ includeCurrent: false }),
   })
@@ -63,9 +61,7 @@ export function TopBar({ children }: { children: React.ReactNode }) {
                 </Button>
               </DropdownMenu.Trigger>
               <DropdownMenu.Content align="end" sideOffset={8}>
-                <DropdownMenu.Item onSelect={() => navigate(pb.profile())}>
-                  Settings
-                </DropdownMenu.Item>
+                <DropdownMenu.LinkItem to={pb.profile()}>Settings</DropdownMenu.LinkItem>
                 {loggedIn ? (
                   <DropdownMenu.Item onSelect={() => logout.mutate({})}>
                     Sign out

--- a/app/ui/lib/DropdownMenu.tsx
+++ b/app/ui/lib/DropdownMenu.tsx
@@ -16,8 +16,13 @@ import {
 } from '@radix-ui/react-dropdown-menu'
 import cn from 'classnames'
 import { forwardRef, type ForwardedRef } from 'react'
+import { Link } from 'react-router-dom'
 
 type DivRef = ForwardedRef<HTMLDivElement>
+
+// remove possibility of disabling links for now. if we put it back, make sure
+// to forwardRef on LinkItem so the disabled tooltip can work
+type LinkitemProps = Omit<DropdownMenuItemProps, 'disabled'> & { to: string }
 
 export const DropdownMenu = {
   Root,
@@ -38,4 +43,9 @@ export const DropdownMenu = {
   Item: forwardRef(({ className, ...props }: DropdownMenuItemProps, ref: DivRef) => (
     <Item {...props} className={cn('DropdownMenuItem ox-menu-item', className)} ref={ref} />
   )),
+  LinkItem: ({ className, children, to, ...props }: LinkitemProps) => (
+    <Item {...props} className={cn('DropdownMenuItem ox-menu-item', className)} asChild>
+      <Link to={to}>{children}</Link>
+    </Item>
+  ),
 }

--- a/app/ui/styles/components/menu-button.css
+++ b/app/ui/styles/components/menu-button.css
@@ -10,7 +10,7 @@
   @apply z-30 min-w-36 rounded border p-0 bg-raise border-secondary;
 
   & .DropdownMenuItem {
-    @apply block cursor-pointer select-none border-b py-2 pl-3 pr-6 text-left text-sans-md text-secondary border-secondary last-of-type:border-b-0;
+    @apply block cursor-pointer select-none border-b py-2 pl-3 pr-6 text-left text-sans-md text-secondary border-secondary last:border-b-0;
 
     &.destructive {
       @apply text-destructive;


### PR DESCRIPTION
Closes #2342 

Looks like this works, but I need to make sure there's nothing weird about it. I had noticed this problem before, but for some reason when I saw #2342 I immediately had a vision of how to do it.

```[tasklist]
- [x] Add `DropdownMenu.LinkItem`
- [x] Use it for the settings link per #2342
- [x] Make sure it's not messed up in any way
- [ ] ~~Use it for other menu items that work as links!~~
```