### PR TITLE
Upgrade to RR 6.26 and use new `replace` helper instead of `<Navigate>`

### DIFF
--- a/app/routes.tsx
+++ b/app/routes.tsx
@@ -5,7 +5,7 @@
  *
  * Copyright Oxide Computer Company
  */
-import { createRoutesFromElements, Navigate, Route } from 'react-router-dom'
+import { createRoutesFromElements, replace, Route } from 'react-router-dom'
 
 import { RouterDataErrorBoundary } from './components/ErrorBoundary'
 import { NotFound } from './components/ErrorPage'
@@ -160,7 +160,7 @@ export const routes = createRoutesFromElements(
           loader={InventoryPage.loader}
           handle={{ crumb: 'Inventory' }}
         >
-          <Route index element={<Navigate to="sleds" replace />} loader={SledsTab.loader} />
+          <Route index element={null} loader={() => replace('sleds')} />
           <Route path="sleds" element={<SledsTab />} loader={SledsTab.loader} />
           <Route path="disks" element={<DisksTab />} loader={DisksTab.loader} />
         </Route>
@@ -170,11 +170,7 @@ export const routes = createRoutesFromElements(
           loader={SledPage.loader}
           handle={{ crumb: 'Sleds' }}
         >
-          <Route
-            index
-            element={<Navigate to="instances" replace />}
-            loader={SledInstancesTab.loader}
-          />
+          <Route index element={null} loader={() => replace('instances')} />
           <Route
             path="instances"
             element={<SledInstancesTab />}
@@ -184,7 +180,7 @@ export const routes = createRoutesFromElements(
         <Route path="health" element={null} handle={{ crumb: 'Health' }} />
         <Route path="update" element={null} handle={{ crumb: 'Update' }} />
         <Route path="networking">
-          <Route index element={<Navigate to="ip-pools" replace />} />
+          <Route index element={null} loader={() => replace('ip-pools')} />
           <Route
             element={<IpPoolsPage />}
             loader={IpPoolsPage.loader}
@@ -212,10 +208,10 @@ export const routes = createRoutesFromElements(
         </Route>
       </Route>
 
-      <Route index element={<Navigate to={pb.projects()} replace />} />
+      <Route index loader={() => replace(pb.projects())} element={null} />
 
       {/* These are done here instead of nested so we don't flash a layout on 404s */}
-      <Route path="projects/:project" element={<Navigate to="instances" replace />} />
+      <Route path="projects/:project" element={null} loader={() => replace('instances')} />
 
       <Route element={<SiloLayout />}>
         <Route
@@ -305,7 +301,7 @@ export const routes = createRoutesFromElements(
         <Route path="instances" handle={{ crumb: 'Instances' }}>
           <Route index element={<InstancesPage />} loader={InstancesPage.loader} />
           <Route path=":instance" handle={{ crumb: instanceCrumb }}>
-            <Route index element={<Navigate to="storage" replace />} />
+            <Route index element={null} loader={() => replace('storage')} />
             <Route element={<InstancePage />} loader={InstancePage.loader}>
               <Route
                 path="storage"
@@ -352,11 +348,7 @@ export const routes = createRoutesFromElements(
         <Route path="vpcs" handle={{ crumb: 'VPCs' }}>
           <Route path=":vpc" handle={{ crumb: vpcCrumb }}>
             <Route element={<VpcPage />} loader={VpcPage.loader}>
-              <Route
-                index
-                element={<Navigate to="firewall-rules" replace />}
-                loader={VpcFirewallRulesTab.loader}
-              />
+              <Route index element={null} loader={() => replace('firewall-rules')} />
               <Route element={<VpcFirewallRulesTab />} loader={VpcFirewallRulesTab.loader}>
                 <Route
                   path="firewall-rules"

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "react-hook-form": "^7.52.1",
         "react-is": "^18.3.1",
         "react-merge-refs": "^2.1.1",
-        "react-router-dom": "^6.25.1",
+        "react-router-dom": "^6.26.0",
         "react-stately": "^3.31.1",
         "recharts": "^2.12.7",
         "remeda": "^2.6.0",
@@ -5050,9 +5050,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.18.0.tgz",
-      "integrity": "sha512-L3jkqmqoSVBVKHfpGZmLrex0lxR5SucGA0sUfFzGctehw+S/ggL9L/0NnC5mw6P8HUWpFZ3nQw3cRApjjWx9Sw==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.19.0.tgz",
+      "integrity": "sha512-zDICCLKEwbVYTS6TjYaWtHXxkdoUvD/QXvyVZjGCsWz5vyH7aFeONlPffPdW+Y/t6KT0MgXb2Mfjun9YpWN1dA==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -16284,12 +16284,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.25.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.25.1.tgz",
-      "integrity": "sha512-u8ELFr5Z6g02nUtpPAggP73Jigj1mRePSwhS/2nkTrlPU5yEkH1vYzWNyvSnSzeeE2DNqWdH+P8OhIh9wuXhTw==",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.26.0.tgz",
+      "integrity": "sha512-wVQq0/iFYd3iZ9H2l3N3k4PL8EEHcb0XlU2Na8nEwmiXgIUElEH6gaJDtUQxJ+JFzmIXaQjfdpcGWaM6IoQGxg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.18.0"
+        "@remix-run/router": "1.19.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -16299,13 +16299,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.25.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.25.1.tgz",
-      "integrity": "sha512-0tUDpbFvk35iv+N89dWNrJp+afLgd+y4VtorJZuOCXK0kkCWjEvb3vTJM++SYvMEpbVwXKf3FjeVveVEb6JpDQ==",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.26.0.tgz",
+      "integrity": "sha512-RRGUIiDtLrkX3uYcFiCIxKFWMcWQGMojpYZfcstc63A1+sSnVgILGIm9gNUA6na3Fm1QuPGSBQH2EMbAZOnMsQ==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.18.0",
-        "react-router": "6.25.1"
+        "@remix-run/router": "1.19.0",
+        "react-router": "6.26.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -22617,9 +22617,9 @@
       }
     },
     "@remix-run/router": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.18.0.tgz",
-      "integrity": "sha512-L3jkqmqoSVBVKHfpGZmLrex0lxR5SucGA0sUfFzGctehw+S/ggL9L/0NnC5mw6P8HUWpFZ3nQw3cRApjjWx9Sw=="
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.19.0.tgz",
+      "integrity": "sha512-zDICCLKEwbVYTS6TjYaWtHXxkdoUvD/QXvyVZjGCsWz5vyH7aFeONlPffPdW+Y/t6KT0MgXb2Mfjun9YpWN1dA=="
     },
     "@rollup/pluginutils": {
       "version": "4.2.1",
@@ -30274,20 +30274,20 @@
       }
     },
     "react-router": {
-      "version": "6.25.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.25.1.tgz",
-      "integrity": "sha512-u8ELFr5Z6g02nUtpPAggP73Jigj1mRePSwhS/2nkTrlPU5yEkH1vYzWNyvSnSzeeE2DNqWdH+P8OhIh9wuXhTw==",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.26.0.tgz",
+      "integrity": "sha512-wVQq0/iFYd3iZ9H2l3N3k4PL8EEHcb0XlU2Na8nEwmiXgIUElEH6gaJDtUQxJ+JFzmIXaQjfdpcGWaM6IoQGxg==",
       "requires": {
-        "@remix-run/router": "1.18.0"
+        "@remix-run/router": "1.19.0"
       }
     },
     "react-router-dom": {
-      "version": "6.25.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.25.1.tgz",
-      "integrity": "sha512-0tUDpbFvk35iv+N89dWNrJp+afLgd+y4VtorJZuOCXK0kkCWjEvb3vTJM++SYvMEpbVwXKf3FjeVveVEb6JpDQ==",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.26.0.tgz",
+      "integrity": "sha512-RRGUIiDtLrkX3uYcFiCIxKFWMcWQGMojpYZfcstc63A1+sSnVgILGIm9gNUA6na3Fm1QuPGSBQH2EMbAZOnMsQ==",
       "requires": {
-        "@remix-run/router": "1.18.0",
-        "react-router": "6.25.1"
+        "@remix-run/router": "1.19.0",
+        "react-router": "6.26.0"
       }
     },
     "react-smooth": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "react-hook-form": "^7.52.1",
     "react-is": "^18.3.1",
     "react-merge-refs": "^2.1.1",
-    "react-router-dom": "^6.25.1",
+    "react-router-dom": "^6.26.0",
     "react-stately": "^3.31.1",
     "recharts": "^2.12.7",
     "remeda": "^2.6.0",


### PR DESCRIPTION
Closes #2352 

Seems to work! I like it! The nice thing about this is we can stop doing that thing where we run the loader for the target page on the starting page. That was to prevent a situation where you're sitting on a blank page while the loader for the target page runs. At least, I couldn't trigger the blank screen.