### PR TITLE
instance create: focus image field on validation error

### DIFF
--- a/app/components/form/fields/ListboxField.tsx
+++ b/app/components/form/fields/ListboxField.tsx
@@ -79,7 +79,7 @@ export function ListboxField<
         name={name}
         hasError={fieldState.error !== undefined}
         isLoading={isLoading}
-        ref={field.ref}
+        buttonRef={field.ref}
       />
       <ErrorMessage error={fieldState.error} label={label} />
     </div>

--- a/app/components/form/fields/ListboxField.tsx
+++ b/app/components/form/fields/ListboxField.tsx
@@ -79,6 +79,7 @@ export function ListboxField<
         name={name}
         hasError={fieldState.error !== undefined}
         isLoading={isLoading}
+        ref={field.ref}
       />
       <ErrorMessage error={fieldState.error} label={label} />
     </div>

--- a/app/pages/project/floating-ips/FloatingIpsPage.tsx
+++ b/app/pages/project/floating-ips/FloatingIpsPage.tsx
@@ -22,6 +22,7 @@ import {
 import { IpGlobal16Icon, IpGlobal24Icon } from '@oxide/design-system/icons/react'
 
 import { DocsPopover } from '~/components/DocsPopover'
+import { ListboxField } from '~/components/form/fields/ListboxField'
 import { HL } from '~/components/HL'
 import { getProjectSelector, useProjectSelector } from '~/hooks'
 import { confirmAction } from '~/stores/confirm-action'
@@ -34,7 +35,6 @@ import { Columns } from '~/table/columns/common'
 import { PAGE_SIZE, useQueryTable } from '~/table/QueryTable'
 import { CreateLink } from '~/ui/lib/CreateButton'
 import { EmptyMessage } from '~/ui/lib/EmptyMessage'
-import { Listbox } from '~/ui/lib/Listbox'
 import { Message } from '~/ui/lib/Message'
 import { Modal } from '~/ui/lib/Modal'
 import { PageHeader, PageTitle } from '~/ui/lib/PageHeader'
@@ -268,6 +268,7 @@ const AttachFloatingIpModal = ({
     },
   })
   const form = useForm({ defaultValues: { instanceId: '' } })
+  const instanceId = form.watch('instanceId')
 
   return (
     <Modal isOpen title="Attach floating IP" onDismiss={onDismiss}>
@@ -280,30 +281,27 @@ const AttachFloatingIpModal = ({
                 The selected instance will be reachable at <HL>{address}</HL>
               </>
             }
-          ></Message>
+          />
           <form>
-            <Listbox
+            <ListboxField
+              control={form.control}
               name="instanceId"
               items={instances.map((i) => ({ value: i.id, label: i.name }))}
               label="Instance"
-              onChange={(e) => {
-                form.setValue('instanceId', e)
-              }}
               required
               placeholder="Select an instance"
-              selected={form.watch('instanceId')}
             />
           </form>
         </Modal.Section>
       </Modal.Body>
       <Modal.Footer
         actionText="Attach"
-        disabled={!form.getValues('instanceId')}
+        disabled={!instanceId}
         onAction={() =>
           floatingIpAttach.mutate({
             path: { floatingIp },
             query: { project },
-            body: { kind: 'instance', parent: form.getValues('instanceId') },
+            body: { kind: 'instance', parent: instanceId },
           })
         }
         onDismiss={onDismiss}

--- a/app/ui/lib/Listbox.tsx
+++ b/app/ui/lib/Listbox.tsx
@@ -13,7 +13,7 @@ import {
   ListboxOptions,
 } from '@headlessui/react'
 import cn from 'classnames'
-import type { ReactNode } from 'react'
+import { forwardRef, type ForwardedRef, type ReactNode } from 'react'
 
 import { SelectArrows6Icon } from '@oxide/design-system/icons/react'
 
@@ -44,117 +44,124 @@ export interface ListboxProps<Value extends string = string> {
   isLoading?: boolean
 }
 
-export const Listbox = <Value extends string = string>({
-  name,
-  selected,
-  items,
-  placeholder = 'Select an option',
-  noItemsPlaceholder = 'No items',
-  className,
-  onChange,
-  hasError = false,
-  label,
-  tooltipText,
-  description,
-  required,
-  disabled,
-  isLoading = false,
-  ...props
-}: ListboxProps<Value>) => {
-  const selectedItem = selected && items.find((i) => i.value === selected)
-  const noItems = !isLoading && items.length === 0
-  const isDisabled = disabled || noItems
-  const zIndex = usePopoverZIndex()
+export const Listbox = forwardRef(
+  <Value extends string = string>(
+    {
+      name,
+      selected,
+      items,
+      placeholder = 'Select an option',
+      noItemsPlaceholder = 'No items',
+      className,
+      onChange,
+      hasError = false,
+      label,
+      tooltipText,
+      description,
+      required,
+      disabled,
+      isLoading = false,
+      ...props
+    }: ListboxProps<Value>,
+    // needed for RHF to focus the button on validation error
+    ref: ForwardedRef<HTMLButtonElement>
+  ) => {
+    const selectedItem = selected && items.find((i) => i.value === selected)
+    const noItems = !isLoading && items.length === 0
+    const isDisabled = disabled || noItems
+    const zIndex = usePopoverZIndex()
 
-  return (
-    <div className={cn('relative', className)}>
-      <HListbox
-        value={selected}
-        // you shouldn't ever be able to select null, but we check here anyway
-        // to make TS happy so the calling code doesn't have to. note `val !==
-        // null` because '' is falsy but potentially a valid value
-        onChange={(val) => val !== null && onChange(val)}
-        disabled={isDisabled || isLoading}
-      >
-        {({ open }) => (
-          <>
-            {label && (
-              <div className="mb-2">
-                <FieldLabel id={``} as="div" tip={tooltipText} optional={!required}>
-                  <Label>{label}</Label>
-                </FieldLabel>
-                {description && <TextInputHint id={``}>{description}</TextInputHint>}
-              </div>
-            )}
-            <ListboxButton
-              name={name}
-              className={cn(
-                `flex h-10 w-full items-center justify-between rounded border text-sans-md`,
-                hasError
-                  ? 'focus-error border-error-secondary hover:border-error'
-                  : 'border-default hover:border-hover',
-                open && 'ring-2 ring-accent-secondary',
-                open && hasError && 'ring-error-secondary',
-                isDisabled
-                  ? 'cursor-not-allowed text-disabled bg-disabled !border-default'
-                  : 'bg-default',
-                isDisabled && hasError && '!border-error-secondary'
+    return (
+      <div className={cn('relative', className)}>
+        <HListbox
+          value={selected}
+          // you shouldn't ever be able to select null, but we check here anyway
+          // to make TS happy so the calling code doesn't have to. note `val !==
+          // null` because '' is falsy but potentially a valid value
+          onChange={(val) => val !== null && onChange(val)}
+          disabled={isDisabled || isLoading}
+        >
+          {({ open }) => (
+            <>
+              {label && (
+                <div className="mb-2">
+                  <FieldLabel id={``} as="div" tip={tooltipText} optional={!required}>
+                    <Label>{label}</Label>
+                  </FieldLabel>
+                  {description && <TextInputHint id={``}>{description}</TextInputHint>}
+                </div>
               )}
-              {...props}
-            >
-              <div className="w-full overflow-hidden overflow-ellipsis whitespace-pre px-3 text-left">
-                {selectedItem ? (
-                  // selectedLabel is one line, which is what we need when label is a ReactNode
-                  selectedItem.selectedLabel || selectedItem.label
-                ) : (
-                  <span className="text-quaternary">
-                    {noItems ? noItemsPlaceholder : placeholder}
-                  </span>
+              <ListboxButton
+                name={name}
+                className={cn(
+                  `flex h-10 w-full items-center justify-between rounded border text-sans-md`,
+                  hasError
+                    ? 'focus-error border-error-secondary hover:border-error'
+                    : 'border-default hover:border-hover',
+                  open && 'ring-2 ring-accent-secondary',
+                  open && hasError && 'ring-error-secondary',
+                  isDisabled
+                    ? 'cursor-not-allowed text-disabled bg-disabled !border-default'
+                    : 'bg-default',
+                  isDisabled && hasError && '!border-error-secondary'
                 )}
-              </div>
-              {!isDisabled && <SpinnerLoader isLoading={isLoading} />}
-              <div
-                className="flex h-[calc(100%-12px)] items-center border-l px-3 border-secondary"
-                aria-hidden
+                ref={ref}
+                {...props}
               >
-                <SelectArrows6Icon title="Select" className="w-2 text-tertiary" />
-              </div>
-            </ListboxButton>
-            <ListboxOptions
-              anchor={{ gap: 12 }}
-              className={`ox-menu pointer-events-auto ${zIndex} w-[var(--button-width)] overflow-y-auto !outline-none`}
-              // This is to prevent the `useOthersInert` call in ListboxOptions.
-              // Without this, when the listbox options box scrolls under the
-              // top bar (for example) you can click through the top bar to the
-              // options because the topbar (and all other elements) has been
-              // marked "inert", which means it does not catch mouse events.
-              // This would not be necessary if useScrollLock in ListboxOptions
-              // worked, but we suspect it doesn't work because the page as a
-              // whole is not the scroll container.
-              modal={false}
-            >
-              {items.map((item) => (
-                <ListboxOption
-                  key={item.value}
-                  value={item.value}
-                  className="relative border-b border-secondary last:border-0"
-                >
-                  {({ focus, selected }) => (
-                    <div
-                      className={cn('ox-menu-item', {
-                        'is-selected': selected,
-                        'is-highlighted': focus,
-                      })}
-                    >
-                      {item.label}
-                    </div>
+                <div className="w-full overflow-hidden overflow-ellipsis whitespace-pre px-3 text-left">
+                  {selectedItem ? (
+                    // selectedLabel is one line, which is what we need when label is a ReactNode
+                    selectedItem.selectedLabel || selectedItem.label
+                  ) : (
+                    <span className="text-quaternary">
+                      {noItems ? noItemsPlaceholder : placeholder}
+                    </span>
                   )}
-                </ListboxOption>
-              ))}
-            </ListboxOptions>
-          </>
-        )}
-      </HListbox>
-    </div>
-  )
-}
+                </div>
+                {!isDisabled && <SpinnerLoader isLoading={isLoading} />}
+                <div
+                  className="flex h-[calc(100%-12px)] items-center border-l px-3 border-secondary"
+                  aria-hidden
+                >
+                  <SelectArrows6Icon title="Select" className="w-2 text-tertiary" />
+                </div>
+              </ListboxButton>
+              <ListboxOptions
+                anchor={{ gap: 12 }}
+                className={`ox-menu pointer-events-auto ${zIndex} w-[var(--button-width)] overflow-y-auto !outline-none`}
+                // This is to prevent the `useOthersInert` call in ListboxOptions.
+                // Without this, when the listbox options box scrolls under the
+                // top bar (for example) you can click through the top bar to the
+                // options because the topbar (and all other elements) has been
+                // marked "inert", which means it does not catch mouse events.
+                // This would not be necessary if useScrollLock in ListboxOptions
+                // worked, but we suspect it doesn't work because the page as a
+                // whole is not the scroll container.
+                modal={false}
+              >
+                {items.map((item) => (
+                  <ListboxOption
+                    key={item.value}
+                    value={item.value}
+                    className="relative border-b border-secondary last:border-0"
+                  >
+                    {({ focus, selected }) => (
+                      <div
+                        className={cn('ox-menu-item', {
+                          'is-selected': selected,
+                          'is-highlighted': focus,
+                        })}
+                      >
+                        {item.label}
+                      </div>
+                    )}
+                  </ListboxOption>
+                ))}
+              </ListboxOptions>
+            </>
+          )}
+        </HListbox>
+      </div>
+    )
+  }
+)

--- a/app/ui/lib/Listbox.tsx
+++ b/app/ui/lib/Listbox.tsx
@@ -13,7 +13,7 @@ import {
   ListboxOptions,
 } from '@headlessui/react'
 import cn from 'classnames'
-import { forwardRef, type ForwardedRef, type ReactNode } from 'react'
+import { type ReactNode, type Ref } from 'react'
 
 import { SelectArrows6Icon } from '@oxide/design-system/icons/react'
 
@@ -42,29 +42,28 @@ export interface ListboxProps<Value extends string = string> {
   description?: React.ReactNode
   required?: boolean
   isLoading?: boolean
+  /** Necessary if you want RHF to be able to focus it on error */
+  buttonRef?: Ref<HTMLButtonElement>
 }
 
-export const ListboxInner = <Value extends string = string>(
-  {
-    name,
-    selected,
-    items,
-    placeholder = 'Select an option',
-    noItemsPlaceholder = 'No items',
-    className,
-    onChange,
-    hasError = false,
-    label,
-    tooltipText,
-    description,
-    required,
-    disabled,
-    isLoading = false,
-    ...props
-  }: ListboxProps<Value>,
-  // needed for RHF to focus the button on validation error
-  ref: ForwardedRef<HTMLButtonElement>
-) => {
+export const Listbox = <Value extends string = string>({
+  name,
+  selected,
+  items,
+  placeholder = 'Select an option',
+  noItemsPlaceholder = 'No items',
+  className,
+  onChange,
+  hasError = false,
+  label,
+  tooltipText,
+  description,
+  required,
+  disabled,
+  isLoading = false,
+  buttonRef,
+  ...props
+}: ListboxProps<Value>) => {
   const selectedItem = selected && items.find((i) => i.value === selected)
   const noItems = !isLoading && items.length === 0
   const isDisabled = disabled || noItems
@@ -104,7 +103,7 @@ export const ListboxInner = <Value extends string = string>(
                   : 'bg-default',
                 isDisabled && hasError && '!border-error-secondary'
               )}
-              ref={ref}
+              ref={buttonRef}
               {...props}
             >
               <div className="w-full overflow-hidden overflow-ellipsis whitespace-pre px-3 text-left">
@@ -163,5 +162,3 @@ export const ListboxInner = <Value extends string = string>(
     </div>
   )
 }
-
-export const Listbox = forwardRef(ListboxInner)

--- a/app/ui/lib/Listbox.tsx
+++ b/app/ui/lib/Listbox.tsx
@@ -44,124 +44,124 @@ export interface ListboxProps<Value extends string = string> {
   isLoading?: boolean
 }
 
-export const Listbox = forwardRef(
-  <Value extends string = string>(
-    {
-      name,
-      selected,
-      items,
-      placeholder = 'Select an option',
-      noItemsPlaceholder = 'No items',
-      className,
-      onChange,
-      hasError = false,
-      label,
-      tooltipText,
-      description,
-      required,
-      disabled,
-      isLoading = false,
-      ...props
-    }: ListboxProps<Value>,
-    // needed for RHF to focus the button on validation error
-    ref: ForwardedRef<HTMLButtonElement>
-  ) => {
-    const selectedItem = selected && items.find((i) => i.value === selected)
-    const noItems = !isLoading && items.length === 0
-    const isDisabled = disabled || noItems
-    const zIndex = usePopoverZIndex()
+export const ListboxInner = <Value extends string = string>(
+  {
+    name,
+    selected,
+    items,
+    placeholder = 'Select an option',
+    noItemsPlaceholder = 'No items',
+    className,
+    onChange,
+    hasError = false,
+    label,
+    tooltipText,
+    description,
+    required,
+    disabled,
+    isLoading = false,
+    ...props
+  }: ListboxProps<Value>,
+  // needed for RHF to focus the button on validation error
+  ref: ForwardedRef<HTMLButtonElement>
+) => {
+  const selectedItem = selected && items.find((i) => i.value === selected)
+  const noItems = !isLoading && items.length === 0
+  const isDisabled = disabled || noItems
+  const zIndex = usePopoverZIndex()
 
-    return (
-      <div className={cn('relative', className)}>
-        <HListbox
-          value={selected}
-          // you shouldn't ever be able to select null, but we check here anyway
-          // to make TS happy so the calling code doesn't have to. note `val !==
-          // null` because '' is falsy but potentially a valid value
-          onChange={(val) => val !== null && onChange(val)}
-          disabled={isDisabled || isLoading}
-        >
-          {({ open }) => (
-            <>
-              {label && (
-                <div className="mb-2">
-                  <FieldLabel id={``} as="div" tip={tooltipText} optional={!required}>
-                    <Label>{label}</Label>
-                  </FieldLabel>
-                  {description && <TextInputHint id={``}>{description}</TextInputHint>}
-                </div>
+  return (
+    <div className={cn('relative', className)}>
+      <HListbox
+        value={selected}
+        // you shouldn't ever be able to select null, but we check here anyway
+        // to make TS happy so the calling code doesn't have to. note `val !==
+        // null` because '' is falsy but potentially a valid value
+        onChange={(val) => val !== null && onChange(val)}
+        disabled={isDisabled || isLoading}
+      >
+        {({ open }) => (
+          <>
+            {label && (
+              <div className="mb-2">
+                <FieldLabel id={``} as="div" tip={tooltipText} optional={!required}>
+                  <Label>{label}</Label>
+                </FieldLabel>
+                {description && <TextInputHint id={``}>{description}</TextInputHint>}
+              </div>
+            )}
+            <ListboxButton
+              name={name}
+              className={cn(
+                `flex h-10 w-full items-center justify-between rounded border text-sans-md`,
+                hasError
+                  ? 'focus-error border-error-secondary hover:border-error'
+                  : 'border-default hover:border-hover',
+                open && 'ring-2 ring-accent-secondary',
+                open && hasError && 'ring-error-secondary',
+                isDisabled
+                  ? 'cursor-not-allowed text-disabled bg-disabled !border-default'
+                  : 'bg-default',
+                isDisabled && hasError && '!border-error-secondary'
               )}
-              <ListboxButton
-                name={name}
-                className={cn(
-                  `flex h-10 w-full items-center justify-between rounded border text-sans-md`,
-                  hasError
-                    ? 'focus-error border-error-secondary hover:border-error'
-                    : 'border-default hover:border-hover',
-                  open && 'ring-2 ring-accent-secondary',
-                  open && hasError && 'ring-error-secondary',
-                  isDisabled
-                    ? 'cursor-not-allowed text-disabled bg-disabled !border-default'
-                    : 'bg-default',
-                  isDisabled && hasError && '!border-error-secondary'
+              ref={ref}
+              {...props}
+            >
+              <div className="w-full overflow-hidden overflow-ellipsis whitespace-pre px-3 text-left">
+                {selectedItem ? (
+                  // selectedLabel is one line, which is what we need when label is a ReactNode
+                  selectedItem.selectedLabel || selectedItem.label
+                ) : (
+                  <span className="text-quaternary">
+                    {noItems ? noItemsPlaceholder : placeholder}
+                  </span>
                 )}
-                ref={ref}
-                {...props}
+              </div>
+              {!isDisabled && <SpinnerLoader isLoading={isLoading} />}
+              <div
+                className="flex h-[calc(100%-12px)] items-center border-l px-3 border-secondary"
+                aria-hidden
               >
-                <div className="w-full overflow-hidden overflow-ellipsis whitespace-pre px-3 text-left">
-                  {selectedItem ? (
-                    // selectedLabel is one line, which is what we need when label is a ReactNode
-                    selectedItem.selectedLabel || selectedItem.label
-                  ) : (
-                    <span className="text-quaternary">
-                      {noItems ? noItemsPlaceholder : placeholder}
-                    </span>
-                  )}
-                </div>
-                {!isDisabled && <SpinnerLoader isLoading={isLoading} />}
-                <div
-                  className="flex h-[calc(100%-12px)] items-center border-l px-3 border-secondary"
-                  aria-hidden
+                <SelectArrows6Icon title="Select" className="w-2 text-tertiary" />
+              </div>
+            </ListboxButton>
+            <ListboxOptions
+              anchor={{ gap: 12 }}
+              className={`ox-menu pointer-events-auto ${zIndex} w-[var(--button-width)] overflow-y-auto !outline-none`}
+              // This is to prevent the `useOthersInert` call in ListboxOptions.
+              // Without this, when the listbox options box scrolls under the
+              // top bar (for example) you can click through the top bar to the
+              // options because the topbar (and all other elements) has been
+              // marked "inert", which means it does not catch mouse events.
+              // This would not be necessary if useScrollLock in ListboxOptions
+              // worked, but we suspect it doesn't work because the page as a
+              // whole is not the scroll container.
+              modal={false}
+            >
+              {items.map((item) => (
+                <ListboxOption
+                  key={item.value}
+                  value={item.value}
+                  className="relative border-b border-secondary last:border-0"
                 >
-                  <SelectArrows6Icon title="Select" className="w-2 text-tertiary" />
-                </div>
-              </ListboxButton>
-              <ListboxOptions
-                anchor={{ gap: 12 }}
-                className={`ox-menu pointer-events-auto ${zIndex} w-[var(--button-width)] overflow-y-auto !outline-none`}
-                // This is to prevent the `useOthersInert` call in ListboxOptions.
-                // Without this, when the listbox options box scrolls under the
-                // top bar (for example) you can click through the top bar to the
-                // options because the topbar (and all other elements) has been
-                // marked "inert", which means it does not catch mouse events.
-                // This would not be necessary if useScrollLock in ListboxOptions
-                // worked, but we suspect it doesn't work because the page as a
-                // whole is not the scroll container.
-                modal={false}
-              >
-                {items.map((item) => (
-                  <ListboxOption
-                    key={item.value}
-                    value={item.value}
-                    className="relative border-b border-secondary last:border-0"
-                  >
-                    {({ focus, selected }) => (
-                      <div
-                        className={cn('ox-menu-item', {
-                          'is-selected': selected,
-                          'is-highlighted': focus,
-                        })}
-                      >
-                        {item.label}
-                      </div>
-                    )}
-                  </ListboxOption>
-                ))}
-              </ListboxOptions>
-            </>
-          )}
-        </HListbox>
-      </div>
-    )
-  }
-)
+                  {({ focus, selected }) => (
+                    <div
+                      className={cn('ox-menu-item', {
+                        'is-selected': selected,
+                        'is-highlighted': focus,
+                      })}
+                    >
+                      {item.label}
+                    </div>
+                  )}
+                </ListboxOption>
+              ))}
+            </ListboxOptions>
+          </>
+        )}
+      </HListbox>
+    </div>
+  )
+}
+
+export const Listbox = forwardRef(ListboxInner)


### PR DESCRIPTION
Closes #2345 

RHF automatically focuses the first field with an error, but we were not passing the `ref` for the image select listbox through to the button. And it must be the button specifically because the wrapping divs are not focusable unless they have a tabindex.

https://github.com/user-attachments/assets/cebc763c-fdfd-416d-bd4c-f0ec69501986


