### PR TITLE
Refactor Router deletion process

### DIFF
--- a/app/forms/vpc-router-route/shared.tsx
+++ b/app/forms/vpc-router-route/shared.tsx
@@ -66,6 +66,8 @@ export const routeFormMessage = {
   noNewRoutesOnSystemRouter: 'User-provided routes cannot be added to a system router',
   // https://github.com/oxidecomputer/omicron/blob/914f5fd7d51f9b060dcc0382a30b607e25df49b2/nexus/src/app/vpc_router.rs#L300-L304
   noDeletingRoutesOnSystemRouter: 'System routes can not be deleted',
+  // https://github.com/oxidecomputer/omicron/blob/914f5fd7d51f9b060dcc0382a30b607e25df49b2/nexus/src/app/vpc_router.rs#L136-L138
+  noDeletingSystemRouters: 'System routers can not be deleted',
 }
 
 export const targetValueDescription = (targetType: RouteTarget['type']) =>

--- a/app/forms/vpc-router-route/shared.tsx
+++ b/app/forms/vpc-router-route/shared.tsx
@@ -65,9 +65,9 @@ export const routeFormMessage = {
   // https://github.com/oxidecomputer/omicron/blob/914f5fd7d51f9b060dcc0382a30b607e25df49b2/nexus/src/app/vpc_router.rs#L201-L204
   noNewRoutesOnSystemRouter: 'User-provided routes cannot be added to a system router',
   // https://github.com/oxidecomputer/omicron/blob/914f5fd7d51f9b060dcc0382a30b607e25df49b2/nexus/src/app/vpc_router.rs#L300-L304
-  noDeletingRoutesOnSystemRouter: 'System routes can not be deleted',
+  noDeletingRoutesOnSystemRouter: 'System routes cannot be deleted',
   // https://github.com/oxidecomputer/omicron/blob/914f5fd7d51f9b060dcc0382a30b607e25df49b2/nexus/src/app/vpc_router.rs#L136-L138
-  noDeletingSystemRouters: 'System routers can not be deleted',
+  noDeletingSystemRouters: 'System routers cannot be deleted',
 }
 
 export const targetValueDescription = (targetType: RouteTarget['type']) =>

--- a/app/pages/project/vpcs/VpcPage/tabs/VpcRoutersTab.tsx
+++ b/app/pages/project/vpcs/VpcPage/tabs/VpcRoutersTab.tsx
@@ -11,6 +11,7 @@ import { Outlet, useNavigate, type LoaderFunctionArgs } from 'react-router-dom'
 
 import { apiQueryClient, useApiMutation, type VpcRouter } from '@oxide/api'
 
+import { routeFormMessage } from '~/forms/vpc-router-route/shared'
 import { getVpcSelector, useVpcSelector } from '~/hooks'
 import { confirmDelete } from '~/stores/confirm-delete'
 import { addToast } from '~/stores/toast'
@@ -84,14 +85,17 @@ export function VpcRoutersTab() {
       },
       {
         label: 'Delete',
+        className: 'destructive',
         onActivate: confirmDelete({
           doDelete: () =>
             deleteRouter.mutateAsync({
               path: { router: router.name },
               query: { project, vpc },
             }),
+          extraContent: 'This will also delete any routes belonging to this router.',
           label: router.name,
         }),
+        disabled: router.kind === 'system' && routeFormMessage.noDeletingSystemRouters,
       },
     ],
     [deleteRouter, project, vpc, navigate]


### PR DESCRIPTION
This PR adds a warning to the router deletion confirmation box, noting that routes under that router will also be deleted.
<img width="533" alt="Screenshot 2024-08-14 at 5 58 17 PM" src="https://github.com/user-attachments/assets/e7299941-f90e-4355-b7f5-13c53927db25">


Also, as system routers should not be delete-able ([see here](https://github.com/oxidecomputer/omicron/blob/914f5fd7d51f9b060dcc0382a30b607e25df49b2/nexus/src/app/vpc_router.rs#L136-L138)), this PR also updates the UI to disable that option:
<img width="455" alt="Screenshot 2024-08-14 at 5 57 58 PM" src="https://github.com/user-attachments/assets/0f8c1f15-0088-490e-a738-377beb0f2184">

