### PR TITLE
make routers table row shorter

### DIFF
--- a/app/pages/project/vpcs/VpcPage/tabs/VpcRoutersTab.tsx
+++ b/app/pages/project/vpcs/VpcPage/tabs/VpcRoutersTab.tsx
@@ -108,7 +108,7 @@ export function VpcRoutersTab() {
       <div className="mb-3 flex justify-end space-x-2">
         <CreateLink to={pb.vpcRoutersNew({ project, vpc })}>New router</CreateLink>
       </div>
-      <Table columns={columns} emptyState={emptyState} rowHeight="large" />
+      <Table columns={columns} emptyState={emptyState} />
       <Outlet />
     </>
   )


### PR DESCRIPTION
This just tightens up a table row that had been double-height:
![Screenshot 2024-08-19 at 11 20 14 AM](https://github.com/user-attachments/assets/c416c381-91b3-4c11-907a-5c701063d471)
