### PR TITLE
Update system router's route IP values

### DIFF
--- a/mock-api/vpc.ts
+++ b/mock-api/vpc.ts
@@ -101,7 +101,7 @@ export const routerRoutes: Json<Array<RouterRoute>> = [
     },
     destination: {
       type: 'ip_net',
-      value: '192.168.1.0/24',
+      value: '0.0.0.0/0',
     },
   },
   {
@@ -116,7 +116,7 @@ export const routerRoutes: Json<Array<RouterRoute>> = [
     },
     destination: {
       type: 'ip_net',
-      value: '2001:db8:abcd:12::/64',
+      value: '::/0',
     },
   },
   {


### PR DESCRIPTION
This reverts the default system router route's destination values to `0.0.0.0/0` (IPv4) and `::/0` (6).

![Screenshot 2024-08-19 at 11 39 39 AM](https://github.com/user-attachments/assets/1b31b770-3a5b-4a93-adcb-90b137da6791)
