### PR TITLE
Polling on instance list

### DIFF
--- a/app/pages/project/instances/InstancesPage.tsx
+++ b/app/pages/project/instances/InstancesPage.tsx
@@ -93,7 +93,7 @@ export function InstancesPage() {
       // like starting or stopping. After that, it will keep polling, but more
       // slowly. For example, if you stop an instance, its state will change to
       // `stopping`, which will cause this logic to start polling the list until
-      // it lands in `stopped`, at which point it will stop polling because
+      // it lands in `stopped`, at which point it will poll only slowly because
       // `stopped` is not considered transitional.
       refetchInterval({ state: { data } }) {
         const prevTransitioning = transitioningInstances.current

--- a/app/pages/project/instances/InstancesPage.tsx
+++ b/app/pages/project/instances/InstancesPage.tsx
@@ -61,6 +61,7 @@ InstancesPage.loader = async ({ params }: LoaderFunctionArgs) => {
 
 const sec = 1000 // ms, obviously
 const POLL_FAST_TIMEOUT = 30 * sec
+// a little slower than instance detail because this is a bigger response
 const POLL_INTERVAL_FAST = 3 * sec
 const POLL_INTERVAL_SLOW = 60 * sec
 

--- a/app/pages/project/instances/InstancesPage.tsx
+++ b/app/pages/project/instances/InstancesPage.tsx
@@ -57,7 +57,9 @@ InstancesPage.loader = async ({ params }: LoaderFunctionArgs) => {
   return null
 }
 
-const POLLING_TIMEOUT = 5_000 // 30 seconds
+const sec = 1000 // ms, obviously
+const POLL_TIMEOUT = 30 * sec
+const POLL_INTERVAL = 3 * sec
 
 export function InstancesPage() {
   const { project } = useProjectSelector()
@@ -100,7 +102,7 @@ export function InstancesPage() {
             // times out, and then you manually stop it. Without putting the state in the
             // the key, that stop action would not be registered as a change in the set
             // of transitioning instances.
-            .map((i) => i.id + '-' + i.runState)
+            .map((i) => i.id + '|' + i.runState)
         )
 
         // always update. we don't have to worry about doing this in all the branches below.
@@ -112,12 +114,12 @@ export function InstancesPage() {
         // if the set of transitioning instances hasn't changed, we only poll if we haven't hit the timeout
         if (isSetEqual(prevTransitioning, nextTransitioning)) {
           const elapsed = Date.now() - pollingStartTime.current
-          return elapsed < POLLING_TIMEOUT ? 1000 : false
+          return elapsed < POLL_TIMEOUT ? POLL_INTERVAL : false
         }
 
         // if we have new transitioning instances, always poll and restart the window
         pollingStartTime.current = Date.now()
-        return 1000
+        return POLL_INTERVAL
       },
     }
   )

--- a/app/pages/project/instances/InstancesPage.tsx
+++ b/app/pages/project/instances/InstancesPage.tsx
@@ -117,12 +117,17 @@ export function InstancesPage() {
         // then that's a change in the set, but you shouldn't start polling
         // fast because of it! What you want to look for is *new* transitioning
         // instances.
+        const anyTransitioning = nextTransitioning.size > 0
         const anyNewTransitioning = setDiff(nextTransitioning, prevTransitioning).size > 0
+
+        // if there are new instances in transitioning, restart the timeout window
         if (anyNewTransitioning) pollingStartTime.current = Date.now()
 
         // important that elapsed is calculated *after* potentially bumping start time
         const elapsed = Date.now() - pollingStartTime.current
-        return elapsed < POLL_FAST_TIMEOUT ? POLL_INTERVAL_FAST : POLL_INTERVAL_SLOW
+        return anyTransitioning && elapsed < POLL_FAST_TIMEOUT
+          ? POLL_INTERVAL_FAST
+          : POLL_INTERVAL_SLOW
       },
     }
   )

--- a/app/pages/project/instances/instance/InstancePage.tsx
+++ b/app/pages/project/instances/instance/InstancePage.tsx
@@ -172,7 +172,7 @@ export function InstancePage() {
             <div className="flex">
               <InstanceStatusBadge status={instance.runState} />
               {polling && (
-                <Tooltip content="Auto-refreshing while state changes" delay={150}>
+                <Tooltip content="Auto-refreshing while status changes" delay={150}>
                   <button type="button">
                     <Spinner className="ml-2" />
                   </button>

--- a/app/pages/project/instances/instance/InstancePage.tsx
+++ b/app/pages/project/instances/instance/InstancePage.tsx
@@ -87,6 +87,8 @@ InstancePage.loader = async ({ params }: LoaderFunctionArgs) => {
   return null
 }
 
+const POLL_INTERVAL = 1000
+
 export function InstancePage() {
   const instanceSelector = useInstanceSelector()
 
@@ -105,7 +107,7 @@ export function InstancePage() {
     },
     {
       refetchInterval: ({ state: { data: instance } }) =>
-        instance && instanceTransitioning(instance) ? 1000 : false,
+        instance && instanceTransitioning(instance) ? POLL_INTERVAL : false,
     }
   )
 

--- a/app/ui/lib/Table.tsx
+++ b/app/ui/lib/Table.tsx
@@ -115,7 +115,7 @@ Table.Cell = ({ height = 'small', className, children, ...props }: TableCellProp
  * Used _outside_ of the `Table`, this element wraps buttons that sit on top
  * of the table.
  */
-export const TableActions = classed.div`-mt-11 mb-3 flex justify-end space-x-2`
+export const TableActions = classed.div`-mt-11 mb-3 flex justify-end gap-2`
 
 export const TableEmptyBox = classed.div`flex h-full max-h-[480px] items-center justify-center rounded-lg border border-secondary p-4`
 

--- a/app/util/array.spec.tsx
+++ b/app/util/array.spec.tsx
@@ -8,7 +8,7 @@
 import { type ReactElement } from 'react'
 import { expect, test } from 'vitest'
 
-import { groupBy, intersperse, isSetEqual } from './array'
+import { groupBy, intersperse, isSetEqual, setDiff } from './array'
 
 test('groupBy', () => {
   expect(
@@ -71,4 +71,13 @@ test('isSetEqual', () => {
   expect(isSetEqual(new Set(['a', 'b']), new Set(['a']))).toBe(false)
 
   expect(isSetEqual(new Set([{}]), new Set([{}]))).toBe(false)
+})
+
+test.only('setDiff', () => {
+  expect(setDiff(new Set(), new Set())).toEqual(new Set())
+  expect(setDiff(new Set(['a']), new Set())).toEqual(new Set(['a']))
+  expect(setDiff(new Set(), new Set(['a']))).toEqual(new Set())
+  expect(setDiff(new Set(['b', 'a', 'c']), new Set(['b', 'd']))).toEqual(
+    new Set(['a', 'c'])
+  )
 })

--- a/app/util/array.spec.tsx
+++ b/app/util/array.spec.tsx
@@ -73,7 +73,7 @@ test('isSetEqual', () => {
   expect(isSetEqual(new Set([{}]), new Set([{}]))).toBe(false)
 })
 
-test.only('setDiff', () => {
+test('setDiff', () => {
   expect(setDiff(new Set(), new Set())).toEqual(new Set())
   expect(setDiff(new Set(['a']), new Set())).toEqual(new Set(['a']))
   expect(setDiff(new Set(), new Set(['a']))).toEqual(new Set())

--- a/app/util/array.spec.tsx
+++ b/app/util/array.spec.tsx
@@ -8,7 +8,7 @@
 import { type ReactElement } from 'react'
 import { expect, test } from 'vitest'
 
-import { groupBy, intersperse } from './array'
+import { groupBy, intersperse, isSetEqual } from './array'
 
 test('groupBy', () => {
   expect(
@@ -60,4 +60,15 @@ test('intersperse', () => {
   result = intersperse([a, b, c], comma, or)
   expect(result.map(getText)).toEqual(['a', ',', 'b', ',', 'or', 'c'])
   expect(result.map(getKey)).toEqual(['a', 'sep-1', 'b', 'sep-2', 'conj', 'c'])
+})
+
+test('isSetEqual', () => {
+  expect(isSetEqual(new Set(), new Set())).toBe(true)
+  expect(isSetEqual(new Set(['a', 'b', 'c']), new Set(['a', 'b', 'c']))).toBe(true)
+
+  expect(isSetEqual(new Set(['a']), new Set(['b']))).toBe(false)
+  expect(isSetEqual(new Set(['a']), new Set(['a', 'b']))).toBe(false)
+  expect(isSetEqual(new Set(['a', 'b']), new Set(['a']))).toBe(false)
+
+  expect(isSetEqual(new Set([{}]), new Set([{}]))).toBe(false)
 })

--- a/app/util/array.ts
+++ b/app/util/array.ts
@@ -38,3 +38,13 @@ export function intersperse(
     return [sep0, item]
   })
 }
+
+export function isSetEqual<T>(a: Set<T>, b: Set<T>): boolean {
+  if (a.size !== b.size) return false
+  for (const item of a) {
+    if (!b.has(item)) {
+      return false
+    }
+  }
+  return true
+}

--- a/app/util/array.ts
+++ b/app/util/array.ts
@@ -48,3 +48,8 @@ export function isSetEqual<T>(a: Set<T>, b: Set<T>): boolean {
   }
   return true
 }
+
+/** Set `a - b` */
+export function setDiff<T>(a: Set<T>, b: Set<T>): Set<T> {
+  return new Set([...a].filter((x) => !b.has(x)))
+}

--- a/test/e2e/instance.e2e.ts
+++ b/test/e2e/instance.e2e.ts
@@ -77,7 +77,7 @@ test('can stop a starting instance, then start it again', async ({ page }) => {
     status: expect.stringContaining('stopped'),
   })
 
-  await clickRowAction(page, 'not-there-yet', 'Stop')
+  await clickRowAction(page, 'not-there-yet', 'Start')
   await expectRowVisible(table, {
     name: 'not-there-yet',
     status: expect.stringContaining('starting'),

--- a/test/e2e/utils.ts
+++ b/test/e2e/utils.ts
@@ -111,13 +111,8 @@ export async function stopInstance(page: Page) {
   await page.getByRole('menuitem', { name: 'Stop' }).click()
   await page.getByRole('button', { name: 'Confirm' }).click()
   await closeToast(page)
-  await sleep(2000)
-  await refreshInstance(page)
+  // don't need to manually refresh because of polling
   await expect(page.getByText('statusstopped')).toBeVisible()
-}
-
-export async function refreshInstance(page: Page) {
-  await page.getByRole('button', { name: 'Refresh data' }).click()
 }
 
 /**


### PR DESCRIPTION
Closes #2377 

- [x] Smart logic
- [x] e2e test it
- [x] Figure out how to indicate when we're polling (don't. use "Updated" message)

### Demo

When the page loads below, it polls every 3 seconds because there is an instance in a starting state. After 30 seconds, it would switch to polling every minute, but I don't wait for that in this clip. I stop the instance, which causes it to transition to `stopping`, and the `stopped` (because of the polling). At that point, there are no instances in transitional states, so polling slows to every minute (i.e., not at all in the short time in this clip). Then when I start the instance it polls again while it's in `starting` and then stops (slows) again after it's `running`.

https://github.com/user-attachments/assets/3328ec0f-ceef-4b93-bad1-77d5b1eb5d05

