### PR TITLE
Add dropdown to instance breadcrumb

### DIFF
--- a/app/components/TopBarPicker.tsx
+++ b/app/components/TopBarPicker.tsx
@@ -326,14 +326,21 @@ export function ProjectPicker({ project }: { project?: Project }) {
 export function InstancePicker() {
   // picker only shows up when an instance is in scope
   const instanceSelector = useInstanceSelector()
-  const { instance } = instanceSelector
-
+  const { project, instance } = instanceSelector
+  const { data: instances } = useApiQuery('instanceList', {
+    query: { project, limit: PAGE_SIZE },
+  })
+  const items = (instances?.items || []).map(({ name }) => ({
+    label: name,
+    to: pb.instance({ project, instance: name }),
+  }))
   return (
     <TopBarPicker
       aria-label="Switch instance"
       category="Instance"
       current={instance}
-      to={pb.instanceStorage(instanceSelector)}
+      to={pb.instance({ project, instance })}
+      items={items}
       noItemsText="No instances found"
     />
   )

--- a/app/pages/project/instances/InstancesPage.tsx
+++ b/app/pages/project/instances/InstancesPage.tsx
@@ -10,12 +10,7 @@ import { filesize } from 'filesize'
 import { useMemo } from 'react'
 import { useNavigate, type LoaderFunctionArgs } from 'react-router-dom'
 
-import {
-  apiQueryClient,
-  useApiQueryClient,
-  usePrefetchedApiQuery,
-  type Instance,
-} from '@oxide/api'
+import { apiQueryClient, usePrefetchedApiQuery, type Instance } from '@oxide/api'
 import { Instances16Icon, Instances24Icon } from '@oxide/design-system/icons/react'
 
 import { DocsPopover } from '~/components/DocsPopover'
@@ -55,11 +50,10 @@ InstancesPage.loader = async ({ params }: LoaderFunctionArgs) => {
   return null
 }
 
+const refetchInstances = () => apiQueryClient.invalidateQueries('instanceList')
+
 export function InstancesPage() {
   const { project } = useProjectSelector()
-
-  const queryClient = useApiQueryClient()
-  const refetchInstances = () => queryClient.invalidateQueries('instanceList')
 
   const makeActions = useMakeInstanceActions(
     { project },

--- a/app/pages/project/instances/instance/InstancePage.tsx
+++ b/app/pages/project/instances/instance/InstancePage.tsx
@@ -94,7 +94,10 @@ export function InstancePage() {
   const makeActions = useMakeInstanceActions(instanceSelector, {
     onSuccess: refreshData,
     // go to project instances list since there's no more instance
-    onDelete: () => navigate(pb.instances(instanceSelector)),
+    onDelete: () => {
+      apiQueryClient.invalidateQueries('instanceList')
+      navigate(pb.instances(instanceSelector))
+    },
   })
 
   const { data: instance } = usePrefetchedApiQuery(


### PR DESCRIPTION
Closes #2380

We'll want to revisit the overall breadcrumb designs (see #2380 for a few possible directions / links to more in Figma), but in the interim, we can add the dropdown to the instance item in the breadcrumb nav.

<img width="669" alt="Screenshot 2024-08-20 at 3 00 22 PM" src="https://github.com/user-attachments/assets/7cc6ac4a-623c-4887-8c33-695aea85782d">

<img width="790" alt="Screenshot 2024-08-20 at 3 01 49 PM" src="https://github.com/user-attachments/assets/3c5a2ecb-167d-4eb6-bce2-838eca41ee13">
