### PR TITLE
Mock API: error if parent selectors present when resource is fetched by ID

### DIFF
--- a/mock-api/msw/handlers.ts
+++ b/mock-api/msw/handlers.ts
@@ -288,15 +288,17 @@ export const handlers = makeHandlers({
 
     return 204
   },
-  floatingIpAttach({ path, query, body }) {
-    const floatingIp = lookup.floatingIp({ ...path, ...query })
-    if (floatingIp.instance_id) {
+  floatingIpAttach({ path: { floatingIp }, query: { project }, body }) {
+    const dbFloatingIp = lookup.floatingIp({ floatingIp, project })
+    if (dbFloatingIp.instance_id) {
       throw 'floating IP cannot be attached to one instance while still attached to another'
     }
-    const instance = lookup.instance({ ...path, ...query, instance: body.parent })
-    floatingIp.instance_id = instance.id
+    // TODO: make sure the logic around when project is passed matches
+    // the API
+    const dbInstance = lookup.instance({ instance: body.parent })
+    dbFloatingIp.instance_id = dbInstance.id
 
-    return floatingIp
+    return dbFloatingIp
   },
   floatingIpDetach({ path, query }) {
     const floatingIp = lookup.floatingIp({ ...path, ...query })
@@ -359,13 +361,15 @@ export const handlers = makeHandlers({
 
     return json(image, { status: 202 })
   },
-  imageDemote({ path, query }) {
-    const image = lookup.image({ ...path, ...query })
-    const project = lookup.project({ ...path, ...query })
+  imageDemote({ path: { image }, query: { project } }) {
+    // TODO: change this to lookup.siloImage when I add that. or at least
+    // check API logic to make sure we match it
+    const dbImage = lookup.image({ image })
+    const dbProject = lookup.project({ project })
 
-    image.project_id = project.id
+    dbImage.project_id = dbProject.id
 
-    return json(image, { status: 202 })
+    return json(dbImage, { status: 202 })
   },
   instanceList({ query }) {
     const project = lookup.project(query)


### PR DESCRIPTION
Trying to avoid the bug fixed in https://github.com/oxidecomputer/console/pull/2394, where we accidentally include parent selectors. At first I thought we should figure out how to do this automatically, hence https://github.com/oxidecomputer/oxide.ts/issues/264, but as noted there, it's hard to do automatically, and I remembered we already have this whole manually-implemented mock DB lookup apparatus in the console. We have run into this category of bug once before, and I fixed it in precisely this way in https://github.com/oxidecomputer/console/pull/2203, but only for one resource, which is silly.

The mechanical stuff here was pretty easy. The annoying part was going through the real API and code fixing a couple of spots where we currently deviate.