### PR TITLE
Truncate truncated descriptions even more

### DIFF
--- a/app/ui/lib/Truncate.tsx
+++ b/app/ui/lib/Truncate.tsx
@@ -32,9 +32,12 @@ export const Truncate = ({
 
   // Only use the tooltip if the text is longer than maxLength
   return (
-    <div className="flex items-center space-x-2">
+    // overflow-hidden required to make inner truncate work
+    <div className="flex items-center space-x-2 overflow-hidden">
       <Tooltip content={text} delay={tooltipDelay}>
-        <div aria-label={text}>{truncate(text, maxLength, position)}</div>
+        <div aria-label={text} className="truncate">
+          {truncate(text, maxLength, position)}
+        </div>
       </Tooltip>
       {hasCopyButton && <CopyToClipboard text={text} />}
     </div>

--- a/mock-api/vpc.ts
+++ b/mock-api/vpc.ts
@@ -48,7 +48,7 @@ export const vpcs: Json<Vpc[]> = [vpc, vpc2]
 export const defaultRouter: Json<VpcRouter> = {
   id: 'fc59fb4d-baad-44a8-b152-9a3c27ae8aa1',
   name: 'mock-system-router',
-  description: 'a fake router',
+  description: 'Routes are automatically added to this router as VPC subnets are created',
   time_created: new Date(2024, 0, 1).toISOString(),
   time_modified: new Date(2024, 0, 2).toISOString(),
   vpc_id: vpc.id,


### PR DESCRIPTION
In the draft v10 release notes, description was cut off in my routes screenshot, but I was pretending I didn't notice. @benjaminleonard, however, could not so pretend. He said it was "bad." Touché.

![rel-9-vpc-routes](https://github.com/user-attachments/assets/c48f4da7-ff99-43fc-921e-fb0794d69b4a)

So I thought, let's try using CSS's built in truncation on top of ours. The only reason we do that to begin with is so we can detect when we're truncating and add a tooltip on hover showing the full text. But combining the two works shockingly well. The reason it's a draft is I want to go and look at all the places we call `Truncate` and make sure they look good.

https://github.com/user-attachments/assets/bbdcd452-5009-452d-9819-ecf9614fdc20

