### PR TITLE
Move IP Pools edit form to view page

### DIFF
--- a/app/forms/ip-pool-edit.tsx
+++ b/app/forms/ip-pool-edit.tsx
@@ -40,10 +40,11 @@ export function EditIpPoolSideModalForm() {
     onSuccess(_pool) {
       if (pool.name !== _pool.name) {
         queryClient.invalidateQueries('ipPoolList')
+        // as the pool's name has changed, we need to navigate to an updated URL
         navigate(pb.ipPool({ pool: _pool.name }))
       } else {
         queryClient.invalidateQueries('ipPoolView')
-        navigate(pb.ipPool({ pool: pool.name }))
+        onDismiss()
       }
       addToast({ content: 'Your IP pool has been updated' })
     },

--- a/app/forms/ip-pool-edit.tsx
+++ b/app/forms/ip-pool-edit.tsx
@@ -35,6 +35,7 @@ export function EditIpPoolSideModalForm() {
   const { data: pool } = usePrefetchedApiQuery('ipPoolView', { path: poolSelector })
 
   const form = useForm({ defaultValues: pool })
+  const onDismiss = () => navigate(pb.ipPool({ pool: poolSelector.pool }))
 
   const editPool = useApiMutation('ipPoolUpdate', {
     onSuccess(_pool) {
@@ -43,13 +44,11 @@ export function EditIpPoolSideModalForm() {
         // as the pool's name has changed, we need to navigate to an updated URL
         navigate(pb.ipPool({ pool: _pool.name }))
       } else {
-        queryClient.invalidateQueries('ipPoolView')
         onDismiss()
       }
       addToast({ content: 'Your IP pool has been updated' })
     },
   })
-  const onDismiss = () => navigate(pb.ipPool({ pool: poolSelector.pool }))
 
   return (
     <SideModalForm

--- a/app/forms/ip-pool-edit.tsx
+++ b/app/forms/ip-pool-edit.tsx
@@ -39,11 +39,12 @@ export function EditIpPoolSideModalForm() {
 
   const editPool = useApiMutation('ipPoolUpdate', {
     onSuccess(_pool) {
+      queryClient.invalidateQueries('ipPoolList')
       if (pool.name !== _pool.name) {
-        queryClient.invalidateQueries('ipPoolList')
         // as the pool's name has changed, we need to navigate to an updated URL
         navigate(pb.ipPool({ pool: _pool.name }))
       } else {
+        queryClient.invalidateQueries('ipPoolView')
         onDismiss()
       }
       addToast({ content: 'Your IP pool has been updated' })

--- a/app/forms/ip-pool-edit.tsx
+++ b/app/forms/ip-pool-edit.tsx
@@ -30,22 +30,24 @@ EditIpPoolSideModalForm.loader = async ({ params }: LoaderFunctionArgs) => {
 export function EditIpPoolSideModalForm() {
   const queryClient = useApiQueryClient()
   const navigate = useNavigate()
-
   const poolSelector = useIpPoolSelector()
-
-  const onDismiss = () => navigate(pb.ipPools())
 
   const { data: pool } = usePrefetchedApiQuery('ipPoolView', { path: poolSelector })
 
+  const form = useForm({ defaultValues: pool })
+
   const editPool = useApiMutation('ipPoolUpdate', {
     onSuccess(_pool) {
-      queryClient.invalidateQueries('ipPoolList')
+      if (pool.name !== _pool.name) {
+        navigate(pb.ipPool({ pool: _pool.name }))
+      } else {
+        queryClient.invalidateQueries('ipPoolView')
+        navigate(pb.ipPool({ pool: pool.name }))
+      }
       addToast({ content: 'Your IP pool has been updated' })
-      onDismiss()
     },
   })
-
-  const form = useForm({ defaultValues: pool })
+  const onDismiss = () => navigate(pb.ipPool({ pool: poolSelector.pool }))
 
   return (
     <SideModalForm

--- a/app/forms/ip-pool-edit.tsx
+++ b/app/forms/ip-pool-edit.tsx
@@ -39,6 +39,7 @@ export function EditIpPoolSideModalForm() {
   const editPool = useApiMutation('ipPoolUpdate', {
     onSuccess(_pool) {
       if (pool.name !== _pool.name) {
+        queryClient.invalidateQueries('ipPoolList')
         navigate(pb.ipPool({ pool: _pool.name }))
       } else {
         queryClient.invalidateQueries('ipPoolView')

--- a/app/pages/system/networking/IpPoolPage.tsx
+++ b/app/pages/system/networking/IpPoolPage.tsx
@@ -78,7 +78,7 @@ export function IpPoolPage() {
     query,
   })
   const navigate = useNavigate()
-  const deletePool = useApiMutation('ipPoolDelete', {
+  const { mutateAsync: deletePool } = useApiMutation('ipPoolDelete', {
     onSuccess() {
       apiQueryClient.invalidateQueries('ipPoolList')
       navigate(pb.ipPools())
@@ -97,7 +97,7 @@ export function IpPoolPage() {
       {
         label: 'Delete',
         onActivate: confirmDelete({
-          doDelete: () => deletePool.mutateAsync({ path: { pool: pool.name } }),
+          doDelete: () => deletePool({ path: { pool: pool.name } }),
           label: pool.name,
         }),
         disabled:

--- a/app/pages/system/networking/IpPoolsPage.tsx
+++ b/app/pages/system/networking/IpPoolsPage.tsx
@@ -23,6 +23,7 @@ import { DocsPopover } from '~/components/DocsPopover'
 import { IpUtilCell } from '~/components/IpPoolUtilization'
 import { useQuickActions } from '~/hooks'
 import { confirmDelete } from '~/stores/confirm-delete'
+import { addToast } from '~/stores/toast'
 import { SkeletonCell } from '~/table/cells/EmptyCell'
 import { makeLinkCell } from '~/table/cells/LinkCell'
 import { useColsWithActions, type MenuAction } from '~/table/columns/action-col'
@@ -79,6 +80,7 @@ export function IpPoolsPage() {
   const deletePool = useApiMutation('ipPoolDelete', {
     onSuccess() {
       apiQueryClient.invalidateQueries('ipPoolList')
+      addToast({ content: 'IP pool deleted' })
     },
   })
 

--- a/app/routes.tsx
+++ b/app/routes.tsx
@@ -198,12 +198,6 @@ export const routes = createRoutesFromElements(
           >
             <Route path="ip-pools" element={null} />
             <Route path="ip-pools-new" element={<CreateIpPoolSideModalForm />} />
-            <Route
-              path="ip-pools/:pool/edit"
-              element={<EditIpPoolSideModalForm />}
-              loader={EditIpPoolSideModalForm.loader}
-              handle={{ crumb: 'Edit IP pool' }}
-            />
           </Route>
         </Route>
         <Route path="networking/ip-pools" handle={{ crumb: 'IP pools' }}>
@@ -213,6 +207,12 @@ export const routes = createRoutesFromElements(
             loader={IpPoolPage.loader}
             handle={{ crumb: poolCrumb }}
           >
+            <Route
+              path="edit"
+              element={<EditIpPoolSideModalForm />}
+              loader={EditIpPoolSideModalForm.loader}
+              handle={{ crumb: 'Edit IP pool' }}
+            />
             <Route path="ranges-add" element={<IpPoolAddRangeSideModalForm />} />
           </Route>
         </Route>

--- a/test/e2e/ip-pools.e2e.ts
+++ b/test/e2e/ip-pools.e2e.ts
@@ -110,7 +110,7 @@ test('IP pool link silo', async ({ page }) => {
   await expectRowVisible(table, { Silo: 'myriad', 'Pool is silo default': '' })
 })
 
-test('IP pool delete', async ({ page }) => {
+test('IP pool delete from IP Pools list page', async ({ page }) => {
   await page.goto('/system/networking/ip-pools')
 
   // can't delete a pool containing ranges
@@ -130,6 +130,24 @@ test('IP pool delete', async ({ page }) => {
   await expect(page.getByRole('dialog', { name: 'Confirm delete' })).toBeVisible()
   await page.getByRole('button', { name: 'Confirm' }).click()
 
+  await expect(page.getByRole('cell', { name: 'ip-pool-3' })).toBeHidden()
+})
+
+test('IP pool delete from IP Pool view page', async ({ page }) => {
+  // can't delete a pool containing ranges
+  await page.goto('/system/networking/ip-pools/ip-pool-1')
+  await page.getByRole('button', { name: 'IP pool actions' }).click()
+  await expect(page.getByRole('menuitem', { name: 'Delete' })).toBeDisabled()
+
+  // can delete a pool with no ranges
+  await page.goto('/system/networking/ip-pools/ip-pool-3')
+  await page.getByRole('button', { name: 'IP pool actions' }).click()
+  await page.getByRole('menuitem', { name: 'Delete' }).click()
+  await expect(page.getByRole('dialog', { name: 'Confirm delete' })).toBeVisible()
+  await page.getByRole('button', { name: 'Confirm' }).click()
+
+  // get redirected back to the list after successful delete
+  await expect(page).toHaveURL('/system/networking/ip-pools')
   await expect(page.getByRole('cell', { name: 'ip-pool-3' })).toBeHidden()
 })
 

--- a/test/e2e/ip-pools.e2e.ts
+++ b/test/e2e/ip-pools.e2e.ts
@@ -173,6 +173,23 @@ test('IP pool create', async ({ page }) => {
   })
 })
 
+test('IP pool edit', async ({ page }) => {
+  await page.goto('/system/networking/ip-pools/ip-pool-3')
+  await page.getByRole('button', { name: 'IP pool actions' }).click()
+  await page.getByRole('menuitem', { name: 'Edit' }).click()
+
+  const modal = page.getByRole('dialog', { name: 'Edit IP pool' })
+  await expect(modal).toBeVisible()
+
+  await page.getByRole('textbox', { name: 'Name' }).fill('updated-pool')
+  await page.getByRole('textbox', { name: 'Description' }).fill('an updated description')
+  await page.getByRole('button', { name: 'Update IP pool' }).click()
+
+  await expect(modal).toBeHidden()
+  await expect(page).toHaveURL('/system/networking/ip-pools/updated-pool')
+  await expect(page.getByRole('heading', { name: 'updated-pool' })).toBeVisible()
+})
+
 test('IP range validation and add', async ({ page }) => {
   await page.goto('/system/networking/ip-pools/ip-pool-2')
 


### PR DESCRIPTION
This PR moves the "Edit IP pool" side modal from the IP Pools list page to the individual IP Pool view page. In some ways, this makes more sense with our existing URL schema, as the edit URL is `http://localhost:4000/system/networking/ip-pools/:pool/edit`, so is conceptually already a child of the pool itself, rather than the list.

We start with an additional actions button in the header …
<img width="999" alt="Screenshot 2024-08-30 at 11 07 07 AM" src="https://github.com/user-attachments/assets/5430f41c-ee1c-4d20-87ef-5f6d976144b3">
… which leads to the side modal on the view page …
<img width="1001" alt="Screenshot 2024-08-30 at 11 07 30 AM" src="https://github.com/user-attachments/assets/2b91ea19-e2ff-4b43-a643-fc296e239df5">

The `delete` button is disabled for IP Pools with existing ranges …
<img width="1002" alt="Screenshot 2024-08-30 at 11 07 20 AM" src="https://github.com/user-attachments/assets/3c7a8631-a2d2-4540-955d-a4851d0eb2c8">
… but is enabled for IP Pools that can, in fact, be deleted:
<img width="1001" alt="Screenshot 2024-08-30 at 11 07 56 AM" src="https://github.com/user-attachments/assets/36d6e661-b929-48fe-afe5-dcaf5e905d1b">

Closes #2353, and if we feel this is a good pattern to replicate, we can roll it out to other resources as well. 