### PR TITLE
Add `params` arg to `invalidateQueries`

### DIFF
--- a/app/api/hooks.ts
+++ b/app/api/hooks.ts
@@ -240,14 +240,12 @@ export const getUseApiMutation =
 
 export const wrapQueryClient = <A extends ApiClient>(api: A, queryClient: QueryClient) => ({
   /**
-   * Note that we only take a single argument, `method`, rather than allowing
-   * the full query key `[query, params]` to be specified. This is to avoid
-   * accidentally overspecifying and therefore failing to match the desired
-   * query. The params argument can be added back in if we ever have a use case
-   * for it.
+   * Even though it's possible to specify params, prefer invalidating by method
+   * alone to avoid accidentally overspecifying and therefore failing to match
+   * the desired query.
    */
-  invalidateQueries: <M extends keyof A>(method: M) =>
-    queryClient.invalidateQueries({ queryKey: [method] }),
+  invalidateQueries: <M extends keyof A>(method: M, params?: Params<A[M]>) =>
+    queryClient.invalidateQueries({ queryKey: params ? [method, params] : [method] }),
   setQueryData: <M extends keyof A>(method: M, params: Params<A[M]>, data: Result<A[M]>) =>
     queryClient.setQueryData([method, params], data),
   setQueryDataErrorsAllowed: <M extends keyof A>(

--- a/app/api/hooks.ts
+++ b/app/api/hooks.ts
@@ -12,7 +12,6 @@ import {
   useQueryClient,
   type DefaultError,
   type FetchQueryOptions,
-  type InvalidateQueryFilters,
   type QueryClient,
   type UndefinedInitialDataOptions,
   type UseMutationOptions,
@@ -246,11 +245,9 @@ export const wrapQueryClient = <A extends ApiClient>(api: A, queryClient: QueryC
    * accidentally overspecifying and therefore failing to match the desired
    * query. The params argument can be added back in if we ever have a use case
    * for it.
-   *
-   * Passing no arguments will invalidate all queries.
    */
-  invalidateQueries: <M extends keyof A>(method?: M, filters?: InvalidateQueryFilters) =>
-    queryClient.invalidateQueries(method ? { queryKey: [method], ...filters } : undefined),
+  invalidateQueries: <M extends keyof A>(method: M) =>
+    queryClient.invalidateQueries({ queryKey: [method] }),
   setQueryData: <M extends keyof A>(method: M, params: Params<A[M]>, data: Result<A[M]>) =>
     queryClient.setQueryData([method, params], data),
   setQueryDataErrorsAllowed: <M extends keyof A>(

--- a/app/forms/ip-pool-edit.tsx
+++ b/app/forms/ip-pool-edit.tsx
@@ -38,18 +38,13 @@ export function EditIpPoolSideModalForm() {
 
   const editPool = useApiMutation('ipPoolUpdate', {
     onSuccess(updatedPool) {
-      queryClient.invalidateQueries('ipPoolList')
       navigate(pb.ipPool({ pool: updatedPool.name }))
+      queryClient.invalidateQueries('ipPoolList')
       addToast({ content: 'Your IP pool has been updated' })
-
-      // Only invalidate if we're staying on the same page. If the name
-      // _has_ changed, invalidating ipPoolView causes an error page to flash
-      // while the loader for the target page is running because the current
-      // page's pool gets cleared out while we're still on the page. If we're
-      // navigating to a different page, its query will fetch anew regardless.
-      if (pool.name === updatedPool.name) {
-        queryClient.invalidateQueries('ipPoolView')
-      }
+      // specify params so we only invalidate the one we're navigating to,
+      // avoiding an error page flash due to clearly the current page's pool
+      // while navigating to another one
+      queryClient.invalidateQueries('ipPoolView', { path: { pool: updatedPool.name } })
     },
   })
 


### PR DESCRIPTION
This feels slightly worse somehow. I have liked not having the `params` arg on `invalidateQueries`.