### PR TITLE
Rename "remove" -> "delete" for IP pool ranges

### DIFF
--- a/app/pages/system/networking/IpPoolPage.tsx
+++ b/app/pages/system/networking/IpPoolPage.tsx
@@ -208,7 +208,7 @@ function IpRangesTable() {
   const makeRangeActions = useCallback(
     ({ range }: IpPoolRange): MenuAction[] => [
       {
-        label: 'Remove',
+        label: 'Delete',
         className: 'destructive',
         onActivate: () =>
           confirmAction({
@@ -217,11 +217,11 @@ function IpRangesTable() {
                 path: { pool },
                 body: range,
               }),
-            errorTitle: 'Could not remove range',
-            modalTitle: 'Confirm remove range',
+            errorTitle: 'Could not delete range',
+            modalTitle: 'Confirm delete range',
             modalContent: (
               <p>
-                Are you sure you want to remove range{' '}
+                Are you sure you want to delete range{' '}
                 <HL>
                   {range.first}&ndash;{range.last}
                 </HL>{' '}

--- a/test/e2e/ip-pools.e2e.ts
+++ b/test/e2e/ip-pools.e2e.ts
@@ -258,22 +258,22 @@ test('IP range validation and add', async ({ page }) => {
   })
 })
 
-test('remove range', async ({ page }) => {
+test('delete range', async ({ page }) => {
   await page.goto('/system/networking/ip-pools/ip-pool-1')
 
   const table = page.getByRole('table')
   await expectRowVisible(table, { First: '10.0.0.20', Last: '10.0.0.22' })
   await expect(table.getByRole('row')).toHaveCount(3) // header + 2 rows
 
-  await clickRowAction(page, '10.0.0.20', 'Remove')
+  await clickRowAction(page, '10.0.0.20', 'Delete')
 
-  const confirmModal = page.getByRole('dialog', { name: 'Confirm remove range' })
+  const confirmModal = page.getByRole('dialog', { name: 'Confirm delete range' })
   await expect(confirmModal.getByText('range 10.0.0.20–10.0.0.22')).toBeVisible()
 
   await page.getByRole('button', { name: 'Cancel' }).click()
   await expect(confirmModal).toBeHidden()
 
-  await clickRowAction(page, '10.0.0.20', 'Remove')
+  await clickRowAction(page, '10.0.0.20', 'Delete')
   await confirmModal.getByRole('button', { name: 'Confirm' }).click()
 
   await expect(table.getByRole('cell', { name: '10.0.0.20' })).toBeHidden()
@@ -329,8 +329,8 @@ test('no ranges means no utilization bar', async ({ page }) => {
   await expect(page.getByText('IPv4(IPs)')).toBeVisible()
   await expect(page.getByText('IPv6(IPs)')).toBeVisible()
 
-  await clickRowAction(page, '10.0.0.50', 'Remove')
-  const confirmModal = page.getByRole('dialog', { name: 'Confirm remove range' })
+  await clickRowAction(page, '10.0.0.50', 'Delete')
+  const confirmModal = page.getByRole('dialog', { name: 'Confirm delete range' })
   await confirmModal.getByRole('button', { name: 'Confirm' }).click()
 
   await expect(page.getByText('IPv4(IPs)')).toBeHidden()


### PR DESCRIPTION
I'm not married to this, it's a random thing I had on my to-do list from a while ago. Technically the endpoint is `ip_pool_range_remove` and `.../remove`, so arguably we should match the API so people know what to look for in the docs on the off chance they're trying to do this by API or CLI. On the other hand, to me "remove" suggests that it still exists somehow but not associated with the pool, and this is not the case. I'm on the fence.

### Before

<img width="269" alt="image" src="https://github.com/user-attachments/assets/ef24578b-f86d-448e-a319-31521c376844">

### After

<img width="215" alt="image" src="https://github.com/user-attachments/assets/96dfedd2-3502-4ae6-8420-95c7d405ca74">

