### PR TITLE
Add table row action to copy silo ID from system utilization page

### DIFF
--- a/app/pages/system/UtilizationPage.tsx
+++ b/app/pages/system/UtilizationPage.tsx
@@ -229,7 +229,7 @@ function UsageTab() {
               />
             </Table.Cell>
             <Table.Cell className="action-col w-10 children:p-0" height="large">
-              <RowActions id={silo.siloId} copyIdText="Copy Silo ID" />
+              <RowActions id={silo.siloId} copyIdLabel="Copy Silo ID" />
             </Table.Cell>
           </Table.Row>
         ))}

--- a/app/pages/system/UtilizationPage.tsx
+++ b/app/pages/system/UtilizationPage.tsx
@@ -229,7 +229,7 @@ function UsageTab() {
               />
             </Table.Cell>
             <Table.Cell className="action-col w-10 children:p-0" height="large">
-              <RowActions id={silo.siloId} copyIdLabel="Copy Silo ID" />
+              <RowActions id={silo.siloId} copyIdLabel="Copy silo ID" />
             </Table.Cell>
           </Table.Row>
         ))}

--- a/app/pages/system/UtilizationPage.tsx
+++ b/app/pages/system/UtilizationPage.tsx
@@ -24,6 +24,7 @@ import { QueryParamTabs } from '~/components/QueryParamTabs'
 import { useIntervalPicker } from '~/components/RefetchIntervalPicker'
 import { SystemMetric } from '~/components/SystemMetric'
 import { LinkCell } from '~/table/cells/LinkCell'
+import { RowActions } from '~/table/columns/action-col'
 import { Listbox } from '~/ui/lib/Listbox'
 import { PageHeader, PageTitle } from '~/ui/lib/PageHeader'
 import { ResourceMeter } from '~/ui/lib/ResourceMeter'
@@ -168,6 +169,7 @@ function UsageTab() {
           <Table.HeadCell colSpan={3} data-test-ignore>
             Available
           </Table.HeadCell>
+          <Table.HeadCell data-test-ignore></Table.HeadCell>
         </Table.HeaderRow>
         <Table.HeaderRow>
           <Table.HeadCell data-test-ignore></Table.HeadCell>
@@ -177,6 +179,7 @@ function UsageTab() {
           <Table.HeadCell>CPU</Table.HeadCell>
           <Table.HeadCell>Memory</Table.HeadCell>
           <Table.HeadCell>Storage</Table.HeadCell>
+          <Table.HeadCell data-test-ignore></Table.HeadCell>
         </Table.HeaderRow>
       </Table.Header>
       <Table.Body>
@@ -224,6 +227,9 @@ function UsageTab() {
                 allocated={bytesToTiB(silo.allocated.storage)}
                 unit="TiB"
               />
+            </Table.Cell>
+            <Table.Cell className="action-col w-10 children:p-0" height="large">
+              <RowActions id={silo.siloId} copyIdText="Copy Silo ID" />
             </Table.Cell>
           </Table.Row>
         ))}

--- a/app/table/columns/action-col.tsx
+++ b/app/table/columns/action-col.tsx
@@ -50,54 +50,60 @@ export const getActionsCol = <TData extends Record<string, unknown>>(
       // TODO: control flow here has always confused me, would like to straighten it out
       const actions = makeActions(row.original)
       const id = typeof row.original.id === 'string' ? row.original.id : null
-      return (
-        <DropdownMenu.Root>
-          {/* TODO: This name should not suck; future us, make it so! */}
-          {/* stopPropagation prevents clicks from toggling row select in a single select table */}
-          <DropdownMenu.Trigger
-            className="flex h-full w-10 items-center justify-center"
-            aria-label="Row actions"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <More12Icon className="text-tertiary" />
-          </DropdownMenu.Trigger>
-          {/* portal fixes mysterious z-index issue where menu is behind button */}
-          <DropdownMenu.Portal>
-            <DropdownMenu.Content align="end" className="-mt-3 mr-2">
-              {id && (
-                <DropdownMenu.Item
-                  onSelect={() => {
-                    window.navigator.clipboard.writeText(id)
-                  }}
-                >
-                  Copy ID
-                </DropdownMenu.Item>
-              )}
-              {actions.map((action) => {
-                // TODO: Tooltip on disabled button broke, probably due to portal
-                return (
-                  <Wrap
-                    when={!!action.disabled}
-                    with={<Tooltip content={action.disabled} />}
-                    key={kebabCase(`action-${action.label}`)}
-                  >
-                    <DropdownMenu.Item
-                      className={cn(action.className, {
-                        destructive:
-                          action.label.toLowerCase() === 'delete' && !action.disabled,
-                      })}
-                      onSelect={action.onActivate}
-                      disabled={!!action.disabled}
-                    >
-                      {action.label}
-                    </DropdownMenu.Item>
-                  </Wrap>
-                )
-              })}
-            </DropdownMenu.Content>
-          </DropdownMenu.Portal>
-        </DropdownMenu.Root>
-      )
+      return <RowActions id={id} actions={actions} />
     },
   }
+}
+
+type RowActionsProps = { id?: string | null; copyIdText?: string; actions?: MenuAction[] }
+
+export const RowActions = ({ id, copyIdText, actions }: RowActionsProps) => {
+  return (
+    <DropdownMenu.Root>
+      {/* TODO: This name should not suck; future us, make it so! */}
+      {/* stopPropagation prevents clicks from toggling row select in a single select table */}
+      <DropdownMenu.Trigger
+        className="flex h-full w-10 items-center justify-center"
+        aria-label="Row actions"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <More12Icon className="text-tertiary" />
+      </DropdownMenu.Trigger>
+      {/* portal fixes mysterious z-index issue where menu is behind button */}
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content align="end" className="-mt-3 mr-2">
+          {id && (
+            <DropdownMenu.Item
+              onSelect={() => {
+                window.navigator.clipboard.writeText(id)
+              }}
+            >
+              {copyIdText || 'Copy ID'}
+            </DropdownMenu.Item>
+          )}
+          {actions?.map((action) => {
+            // TODO: Tooltip on disabled button broke, probably due to portal
+            return (
+              <Wrap
+                when={!!action.disabled}
+                with={<Tooltip content={action.disabled} />}
+                key={kebabCase(`action-${action.label}`)}
+              >
+                <DropdownMenu.Item
+                  className={cn(action.className, {
+                    destructive:
+                      action.label.toLowerCase() === 'delete' && !action.disabled,
+                  })}
+                  onSelect={action.onActivate}
+                  disabled={!!action.disabled}
+                >
+                  {action.label}
+                </DropdownMenu.Item>
+              </Wrap>
+            )
+          })}
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  )
 }

--- a/app/table/columns/action-col.tsx
+++ b/app/table/columns/action-col.tsx
@@ -56,9 +56,9 @@ export const getActionsCol = <TData extends Record<string, unknown>>(
 }
 
 type RowActionsProps = {
-  /** If id is provided, a `Copy ID` menu item will be automatically included. */
+  /** If `id` is provided, a `Copy ID` menu item will be automatically included. */
   id?: string | null
-  /** Use copyIdLabel to override the default label. */
+  /** Use `copyIdLabel` to override the default label (`Copy ID`). */
   copyIdLabel?: string
   actions?: MenuAction[]
 }

--- a/app/table/columns/action-col.tsx
+++ b/app/table/columns/action-col.tsx
@@ -55,9 +55,15 @@ export const getActionsCol = <TData extends Record<string, unknown>>(
   }
 }
 
-type RowActionsProps = { id?: string | null; copyIdLabel?: string; actions?: MenuAction[] }
+type RowActionsProps = {
+  /** If id is provided, a `Copy ID` menu item will be automatically included. */
+  id?: string | null
+  /** Use copyIdLabel to override the default label. */
+  copyIdLabel?: string
+  actions?: MenuAction[]
+}
 
-export const RowActions = ({ id, copyIdLabel, actions }: RowActionsProps) => {
+export const RowActions = ({ id, copyIdLabel = 'Copy ID', actions }: RowActionsProps) => {
   return (
     <DropdownMenu.Root>
       {/* TODO: This name should not suck; future us, make it so! */}
@@ -78,7 +84,7 @@ export const RowActions = ({ id, copyIdLabel, actions }: RowActionsProps) => {
                 window.navigator.clipboard.writeText(id)
               }}
             >
-              {copyIdLabel || 'Copy ID'}
+              {copyIdLabel}
             </DropdownMenu.Item>
           )}
           {actions?.map((action) => {

--- a/app/table/columns/action-col.tsx
+++ b/app/table/columns/action-col.tsx
@@ -55,9 +55,9 @@ export const getActionsCol = <TData extends Record<string, unknown>>(
   }
 }
 
-type RowActionsProps = { id?: string | null; copyIdText?: string; actions?: MenuAction[] }
+type RowActionsProps = { id?: string | null; copyIdLabel?: string; actions?: MenuAction[] }
 
-export const RowActions = ({ id, copyIdText, actions }: RowActionsProps) => {
+export const RowActions = ({ id, copyIdLabel, actions }: RowActionsProps) => {
   return (
     <DropdownMenu.Root>
       {/* TODO: This name should not suck; future us, make it so! */}
@@ -78,7 +78,7 @@ export const RowActions = ({ id, copyIdText, actions }: RowActionsProps) => {
                 window.navigator.clipboard.writeText(id)
               }}
             >
-              {copyIdText || 'Copy ID'}
+              {copyIdLabel || 'Copy ID'}
             </DropdownMenu.Item>
           )}
           {actions?.map((action) => {

--- a/test/e2e/images.e2e.ts
+++ b/test/e2e/images.e2e.ts
@@ -76,7 +76,10 @@ test('can promote an image from project', async ({ page }) => {
 
 test('can copy an image ID to clipboard', async ({ page, browserName }) => {
   // eslint-disable-next-line playwright/no-skipped-test
-  test.skip(browserName === 'webkit', 'Works locally in Safari but not in CI.')
+  test.skip(
+    browserName === 'webkit',
+    'navigator.clipboard.readText() works locally in Safari but not in CI.'
+  )
 
   await page.goto('/images')
   await clickRowAction(page, 'ubuntu-22-04', 'Copy ID')

--- a/test/e2e/images.e2e.ts
+++ b/test/e2e/images.e2e.ts
@@ -76,10 +76,7 @@ test('can promote an image from project', async ({ page }) => {
 
 test('can copy an image ID to clipboard', async ({ page, browserName }) => {
   // eslint-disable-next-line playwright/no-skipped-test
-  test.skip(
-    browserName === 'firefox' || browserName === 'webkit',
-    'navigator.clipboard.readText() not supported in FF. Works locally in Safari but not in CI.'
-  )
+  test.skip(browserName === 'webkit', 'Works locally in Safari but not in CI.')
 
   await page.goto('/images')
   await clickRowAction(page, 'ubuntu-22-04', 'Copy ID')

--- a/test/e2e/utilization.e2e.ts
+++ b/test/e2e/utilization.e2e.ts
@@ -46,7 +46,10 @@ test.describe('System utilization', () => {
 
   test('can copy silo ID', async ({ page, browserName }) => {
     // eslint-disable-next-line playwright/no-skipped-test
-    test.skip(browserName === 'webkit', 'Works locally in Safari but not in CI.')
+    test.skip(
+      browserName === 'webkit',
+      'navigator.clipboard.readText() works locally in Safari but not in CI.'
+    )
     await page.goto('/system/utilization')
     await clickRowAction(page, 'maze-war', 'Copy Silo ID')
     expect(await clipboardText(page)).toEqual('6d3a9c06-475e-4f75-b272-c0d0e3f980fa')

--- a/test/e2e/utilization.e2e.ts
+++ b/test/e2e/utilization.e2e.ts
@@ -51,7 +51,7 @@ test.describe('System utilization', () => {
       'navigator.clipboard.readText() works locally in Safari but not in CI.'
     )
     await page.goto('/system/utilization')
-    await clickRowAction(page, 'maze-war', 'Copy Silo ID')
+    await clickRowAction(page, 'maze-war', 'Copy silo ID')
     expect(await clipboardText(page)).toEqual('6d3a9c06-475e-4f75-b272-c0d0e3f980fa')
   })
 

--- a/test/e2e/utilization.e2e.ts
+++ b/test/e2e/utilization.e2e.ts
@@ -40,10 +40,16 @@ test.describe('System utilization', () => {
       Memory: '350 GiB',
       Silo: 'myriad',
     })
-    await clickRowAction(page, 'maze-war', 'Copy Silo ID')
-    expect(await clipboardText(page)).toEqual('6d3a9c06-475e-4f75-b272-c0d0e3f980fa')
 
     await page.getByRole('tab', { name: 'Metrics' }).click()
+  })
+
+  test('can copy silo ID', async ({ page, browserName }) => {
+    // eslint-disable-next-line playwright/no-skipped-test
+    test.skip(browserName === 'webkit', 'Works locally in Safari but not in CI.')
+    await page.goto('/system/utilization')
+    await clickRowAction(page, 'maze-war', 'Copy Silo ID')
+    expect(await clipboardText(page)).toEqual('6d3a9c06-475e-4f75-b272-c0d0e3f980fa')
   })
 
   test('does not appear for dev user', async ({ browser }) => {

--- a/test/e2e/utilization.e2e.ts
+++ b/test/e2e/utilization.e2e.ts
@@ -7,6 +7,7 @@
  */
 import {
   clickRowAction,
+  clipboardText,
   closeToast,
   expect,
   expectRowVisible,
@@ -39,6 +40,8 @@ test.describe('System utilization', () => {
       Memory: '350 GiB',
       Silo: 'myriad',
     })
+    await clickRowAction(page, 'maze-war', 'Copy Silo ID')
+    expect(await clipboardText(page)).toEqual('6d3a9c06-475e-4f75-b272-c0d0e3f980fa')
 
     await page.getByRole('tab', { name: 'Metrics' }).click()
   })


### PR DESCRIPTION
This adds a column to the `system/utilization` page, allowing users to copy the ID of the silo on each row. As this table is constructed a bit differently than our other tables where we pass the columns in, I extracted some existing code into a RowActions component that we can call independently (as we do in this PR). The new component also has an optional prop for `copyIdLabel`, in case we want to use more specific copy than "Copy ID" (as we do in this PR).

<img width="1216" alt="Screenshot 2024-09-04 at 4 17 15 PM" src="https://github.com/user-attachments/assets/7eccd796-6ffb-4345-b08c-0849b1d23a61">

Closes #2344

Minor sidenote: We had an existing "did it copy to the clipboard?" test that was skipping for Safari and Firefox. It's still uncooperative for CI contexts, but Firefox is now working, [as of June 2024,](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/readText#browser_compatibility) so we aren't skipping that one any more.