### PR TITLE
tools: try to reduce flake in image upload e2e tests

### DIFF
--- a/app/forms/image-upload.tsx
+++ b/app/forms/image-upload.tsx
@@ -101,7 +101,11 @@ function Step({ children, state, label, className }: StepProps) {
   /* eslint-enable react/jsx-key */
   return (
     // data-status used only for e2e testing
-    <div className={cn('items-top flex gap-2 px-4 py-3', className)} data-status={status}>
+    <div
+      className={cn('items-top flex gap-2 px-4 py-3', className)}
+      data-testid="upload-step"
+      data-status={status}
+    >
       {/* padding on icon to align it with text since everything is aligned to top */}
       <div className="pt-px">{icon}</div>
       <div

--- a/test/e2e/image-upload.e2e.ts
+++ b/test/e2e/image-upload.e2e.ts
@@ -19,16 +19,14 @@ import {
 // to complete in time, so we just assert that they all start out ready and end
 // up complete
 async function expectUploadProcess(page: Page) {
-  const steps = page.locator('div[data-status]')
-
-  for (const step of await steps.all()) {
-    await expect(step).toHaveAttribute('data-status', 'ready', { timeout: 10000 })
-  }
-
   // check these here instead of first because if we don't look for the ready
   // states right away we won't catch them in time
   const progressModal = page.getByRole('dialog', { name: 'Image upload progress' })
   await expect(progressModal).toBeVisible()
+
+  const steps = page.getByTestId('upload-step')
+  await expect(steps).toHaveCount(8)
+
   const done = progressModal.getByRole('button', { name: 'Done' })
 
   for (const step of await steps.all()) {
@@ -233,12 +231,6 @@ test.describe('Image upload', () => {
       await fillForm(page, imageName)
 
       await page.click('role=button[name="Upload image"]')
-
-      const steps = page.locator('div[data-status]')
-
-      for (const step of await steps.all()) {
-        await expect(step).toHaveAttribute('data-status', 'ready')
-      }
 
       const step = page.locator('[data-status]').filter({ hasText: stepText }).first()
       await expect(step).toHaveAttribute('data-status', 'error', { timeout: 15000 })


### PR DESCRIPTION
Test flakes pretty much always look like this. The assert about them all being ready is sort of ill-conceived anyway.

<img width="771" alt="image" src="https://github.com/user-attachments/assets/b916e038-df57-4320-978e-edd53fcdda29">
