### PR TITLE
Remove unnecessary invalidateQueries command

### DIFF
--- a/app/forms/ip-pool-edit.tsx
+++ b/app/forms/ip-pool-edit.tsx
@@ -41,15 +41,6 @@ export function EditIpPoolSideModalForm() {
       queryClient.invalidateQueries('ipPoolList')
       navigate(pb.ipPool({ pool: updatedPool.name }))
       addToast({ content: 'Your IP pool has been updated' })
-
-      // Only invalidate if we're staying on the same page. If the name
-      // _has_ changed, invalidating ipPoolView causes an error page to flash
-      // while the loader for the target page is running because the current
-      // page's pool gets cleared out while we're still on the page. If we're
-      // navigating to a different page, its query will fetch anew regardless.
-      if (pool.name === updatedPool.name) {
-        queryClient.invalidateQueries('ipPoolView')
-      }
     },
   })
 


### PR DESCRIPTION
I went back to look at this a bit more, and couldn't replicate the error message flash that I was seeing earlier, regardless of the presence or absence of this block of code. I tried both while updating the IP Pool's name and when updating the description (without the name changing).

Seeing as it's a bit confusing, and likely unnecessary, I figured we could clean it out.