### PR TITLE
Add missing 'VPC deleted' toast

### DIFF
--- a/app/pages/project/vpcs/VpcsPage.tsx
+++ b/app/pages/project/vpcs/VpcsPage.tsx
@@ -22,6 +22,7 @@ import { Networking16Icon, Networking24Icon } from '@oxide/design-system/icons/r
 import { DocsPopover } from '~/components/DocsPopover'
 import { getProjectSelector, useProjectSelector, useQuickActions } from '~/hooks'
 import { confirmDelete } from '~/stores/confirm-delete'
+import { addToast } from '~/stores/toast'
 import { SkeletonCell } from '~/table/cells/EmptyCell'
 import { LinkCell, makeLinkCell } from '~/table/cells/LinkCell'
 import { getActionsCol, type MenuAction } from '~/table/columns/action-col'
@@ -83,6 +84,7 @@ export function VpcsPage() {
   const { mutateAsync: deleteVpc } = useApiMutation('vpcDelete', {
     onSuccess() {
       queryClient.invalidateQueries('vpcList')
+      addToast({ content: 'Your VPC has been deleted' })
     },
   })
 


### PR DESCRIPTION
We were missing a toast to confirm when a VPC was successfully deleted.

<img width="576" alt="Screenshot 2024-09-09 at 5 13 19 PM" src="https://github.com/user-attachments/assets/1320829f-154a-44a5-98fe-ca0388786409">
