### PR TITLE
Start `.git-blame-ignore-revs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# get rid of hooks barrel file
+a0c29a535d17b0f57fa5fa9bee7cca05631885fc
+
+# get rid of useForm wrapper
+a8fcdab9e906f8ff37bb106c20e8364f371c9997
+
+# standardize on ~/ instead of app/
+269c2c82018d09d442a932474d84366a54837068


### PR DESCRIPTION
By adding this file with a0c29a535d17b0f57fa5fa9bee7cca05631885fc and a8fcdab9e906f8ff37bb106c20e8364f371c9997, uninteresting refactors are left out of the blame. I did this before in #1972 but the commit in question included something I didn't want to exclude. This feature adds some pressure to do totally mechanical refactors in their own PR so they can be excluded from the blame without excluding anything interesting. Inspired by https://github.com/oxidecomputer/omicron/pull/6461.

### Before

![Screenshot 2024-09-10 at 3 25 11 PM](https://github.com/user-attachments/assets/f38a18a9-2dac-435c-b6a0-cd701ebe3240)

### After

![Screenshot 2024-09-10 at 3 24 58 PM](https://github.com/user-attachments/assets/051a3b72-a47e-4186-987b-5f5a4117ea6b)
