### PR TITLE
Extract common fields and refactor VPC router route forms

### DIFF
--- a/app/forms/vpc-router-route-common.tsx
+++ b/app/forms/vpc-router-route-common.tsx
@@ -6,9 +6,9 @@
  * Copyright Oxide Computer Company
  */
 
-import type { Control } from 'react-hook-form'
+import type { UseFormReturn } from 'react-hook-form'
 
-import type { RouterRouteCreate, RouterRouteUpdate, RouteTarget } from '~/api'
+import type { RouterRouteCreate, RouterRouteUpdate } from '~/api'
 import { DescriptionField } from '~/components/form/fields/DescriptionField'
 import { ListboxField } from '~/components/form/fields/ListboxField'
 import { NameField } from '~/components/form/fields/NameField'
@@ -31,73 +31,75 @@ export const routeFormMessage = {
 }
 
 type RouteFormFieldsProps = {
-  control: Control<RouteFormValues>
-  targetType: RouteTarget['type']
+  form: UseFormReturn<RouteFormValues>
   isDisabled?: boolean
 }
-export const RouteFormFields = ({
-  control,
-  targetType,
-  isDisabled,
-}: RouteFormFieldsProps) => (
-  <>
-    {isDisabled && (
-      <Message variant="info" content={routeFormMessage.vpcSubnetNotModifiable} />
-    )}
-    <NameField name="name" control={control} disabled={isDisabled} />
-    <DescriptionField name="description" control={control} disabled={isDisabled} />
-    <ListboxField
-      name="destination.type"
-      label="Destination type"
-      control={control}
-      items={[
-        // VPCs can not be specified as a destination in custom routers
-        // https://github.com/oxidecomputer/omicron/blob/4f27433d1bca57eb02073a4ea1cd14557f70b8c7/nexus/src/app/vpc_router.rs#L363
-        { value: 'ip', label: 'IP' },
-        { value: 'ip_net', label: 'IP network' },
-        { value: 'subnet', label: 'Subnet' },
-      ]}
-      placeholder="Select a destination type"
-      required
-      disabled={isDisabled}
-    />
-    <TextField
-      name="destination.value"
-      label="Destination value"
-      control={control}
-      placeholder="Enter a destination value"
-      required
-      disabled={isDisabled}
-    />
-    <ListboxField
-      name="target.type"
-      label="Target type"
-      control={control}
-      items={[
-        // Subnets and VPCs cannot be used as a target in custom routers
-        // https://github.com/oxidecomputer/omicron/blob/4f27433d1bca57eb02073a4ea1cd14557f70b8c7/nexus/src/app/vpc_router.rs#L362-L368
-        { value: 'ip', label: 'IP' },
-        { value: 'instance', label: 'Instance' },
-        { value: 'internet_gateway', label: 'Internet gateway' },
-        { value: 'drop', label: 'Drop' },
-      ]}
-      placeholder="Select a target type"
-      required
-      disabled={isDisabled}
-    />
-    {targetType !== 'drop' && (
-      <TextField
-        name="target.value"
-        label="Target value"
+export const RouteFormFields = ({ form, isDisabled }: RouteFormFieldsProps) => {
+  const { control } = form
+  const targetType = form.watch('target.type')
+  return (
+    <>
+      {isDisabled && (
+        <Message variant="info" content={routeFormMessage.vpcSubnetNotModifiable} />
+      )}
+      <NameField name="name" control={control} disabled={isDisabled} />
+      <DescriptionField name="description" control={control} disabled={isDisabled} />
+      <ListboxField
+        name="destination.type"
+        label="Destination type"
         control={control}
-        placeholder="Enter a target value"
+        items={[
+          // VPCs can not be specified as a destination in custom routers
+          // https://github.com/oxidecomputer/omicron/blob/4f27433d1bca57eb02073a4ea1cd14557f70b8c7/nexus/src/app/vpc_router.rs#L363
+          { value: 'ip', label: 'IP' },
+          { value: 'ip_net', label: 'IP network' },
+          { value: 'subnet', label: 'Subnet' },
+        ]}
+        placeholder="Select a destination type"
         required
-        // 'internet_gateway' targetTypes can only have the value 'outbound', so we disable the field
-        disabled={isDisabled || targetType === 'internet_gateway'}
-        description={
-          targetType === 'internet_gateway' && routeFormMessage.internetGatewayTargetValue
-        }
+        disabled={isDisabled}
       />
-    )}
-  </>
-)
+      <TextField
+        name="destination.value"
+        label="Destination value"
+        control={control}
+        placeholder="Enter a destination value"
+        required
+        disabled={isDisabled}
+      />
+      <ListboxField
+        name="target.type"
+        label="Target type"
+        control={control}
+        items={[
+          // Subnets and VPCs cannot be used as a target in custom routers
+          // https://github.com/oxidecomputer/omicron/blob/4f27433d1bca57eb02073a4ea1cd14557f70b8c7/nexus/src/app/vpc_router.rs#L362-L368
+          { value: 'ip', label: 'IP' },
+          { value: 'instance', label: 'Instance' },
+          { value: 'internet_gateway', label: 'Internet gateway' },
+          { value: 'drop', label: 'Drop' },
+        ]}
+        placeholder="Select a target type"
+        required
+        onChange={(value) => {
+          form.setValue('target.value', value === 'internet_gateway' ? 'outbound' : '')
+        }}
+        disabled={isDisabled}
+      />
+      {targetType !== 'drop' && (
+        <TextField
+          name="target.value"
+          label="Target value"
+          control={control}
+          placeholder="Enter a target value"
+          required
+          // 'internet_gateway' targetTypes can only have the value 'outbound', so we disable the field
+          disabled={isDisabled || targetType === 'internet_gateway'}
+          description={
+            targetType === 'internet_gateway' && routeFormMessage.internetGatewayTargetValue
+          }
+        />
+      )}
+    </>
+  )
+}

--- a/app/forms/vpc-router-route-common.tsx
+++ b/app/forms/vpc-router-route-common.tsx
@@ -98,26 +98,24 @@ export const RouteFormFields = ({
   control,
   targetType,
   isDisabled,
-}: RouteFormFieldsProps) => {
-  return (
-    <>
-      {isDisabled && (
-        <Message variant="info" content={routeFormMessage.vpcSubnetNotModifiable} />
-      )}
-      <NameField name="name" control={control} disabled={isDisabled} />
-      <DescriptionField name="description" control={control} disabled={isDisabled} />
-      <ListboxField {...fields.destType} control={control} disabled={isDisabled} />
-      <TextField {...fields.destValue} control={control} disabled={isDisabled} />
-      <ListboxField {...fields.targetType} control={control} disabled={isDisabled} />
-      {targetType !== 'drop' && (
-        <TextField
-          {...fields.targetValue}
-          control={control}
-          // when targetType is 'internet_gateway', we set it to `outbound` and make it non-editable
-          disabled={isDisabled || targetType === 'internet_gateway'}
-          description={targetValueDescription(targetType)}
-        />
-      )}
-    </>
-  )
-}
+}: RouteFormFieldsProps) => (
+  <>
+    {isDisabled && (
+      <Message variant="info" content={routeFormMessage.vpcSubnetNotModifiable} />
+    )}
+    <NameField name="name" control={control} disabled={isDisabled} />
+    <DescriptionField name="description" control={control} disabled={isDisabled} />
+    <ListboxField {...fields.destType} control={control} disabled={isDisabled} />
+    <TextField {...fields.destValue} control={control} disabled={isDisabled} />
+    <ListboxField {...fields.targetType} control={control} disabled={isDisabled} />
+    {targetType !== 'drop' && (
+      <TextField
+        {...fields.targetValue}
+        control={control}
+        // 'internet_gateway' targetTypes can only have the value 'outbound', so we disable the field
+        disabled={isDisabled || targetType === 'internet_gateway'}
+        description={targetValueDescription(targetType)}
+      />
+    )}
+  </>
+)

--- a/app/forms/vpc-router-route-common.tsx
+++ b/app/forms/vpc-router-route-common.tsx
@@ -35,7 +35,7 @@ export const routeFormMessage = {
   noDeletingSystemRouters: 'System routers cannot be deleted',
 }
 
-// VPCs can not be specified as a destination in custom routers
+// VPCs cannot be specified as a destination in custom routers
 // https://github.com/oxidecomputer/omicron/blob/4f27433d1bca57eb02073a4ea1cd14557f70b8c7/nexus/src/app/vpc_router.rs#L363
 const destTypes: Record<Exclude<RouteDestination['type'], 'vpc'>, string> = {
   ip: 'IP',

--- a/app/forms/vpc-router-route-common.tsx
+++ b/app/forms/vpc-router-route-common.tsx
@@ -6,7 +6,21 @@
  * Copyright Oxide Computer Company
  */
 
-import type { RouteDestination, RouteTarget } from '~/api'
+import type { Control } from 'react-hook-form'
+
+import type {
+  RouteDestination,
+  RouterRouteCreate,
+  RouterRouteUpdate,
+  RouteTarget,
+} from '~/api'
+import { DescriptionField } from '~/components/form/fields/DescriptionField'
+import { ListboxField } from '~/components/form/fields/ListboxField'
+import { NameField } from '~/components/form/fields/NameField'
+import { TextField } from '~/components/form/fields/TextField'
+import { Message } from '~/ui/lib/Message'
+
+export type RouteFormValues = RouterRouteCreate | Required<RouterRouteUpdate>
 
 // VPCs can not be specified as a destination in custom routers
 // https://github.com/oxidecomputer/omicron/blob/4f27433d1bca57eb02073a4ea1cd14557f70b8c7/nexus/src/app/vpc_router.rs#L363
@@ -74,3 +88,36 @@ export const targetValueDescription = (targetType: RouteTarget['type']) =>
   targetType === 'internet_gateway'
     ? routeFormMessage.internetGatewayTargetValue
     : undefined
+
+type RouteFormFieldsProps = {
+  control: Control<RouteFormValues>
+  targetType: RouteTarget['type']
+  isDisabled?: boolean
+}
+export const RouteFormFields = ({
+  control,
+  targetType,
+  isDisabled,
+}: RouteFormFieldsProps) => {
+  return (
+    <>
+      {isDisabled && (
+        <Message variant="info" content={routeFormMessage.vpcSubnetNotModifiable} />
+      )}
+      <NameField name="name" control={control} disabled={isDisabled} />
+      <DescriptionField name="description" control={control} disabled={isDisabled} />
+      <ListboxField {...fields.destType} control={control} disabled={isDisabled} />
+      <TextField {...fields.destValue} control={control} disabled={isDisabled} />
+      <ListboxField {...fields.targetType} control={control} disabled={isDisabled} />
+      {targetType !== 'drop' && (
+        <TextField
+          {...fields.targetValue}
+          control={control}
+          // when targetType is 'internet_gateway', we set it to `outbound` and make it non-editable
+          disabled={isDisabled || targetType === 'internet_gateway'}
+          description={targetValueDescription(targetType)}
+        />
+      )}
+    </>
+  )
+}

--- a/app/forms/vpc-router-route-create.tsx
+++ b/app/forms/vpc-router-route-create.tsx
@@ -5,7 +5,6 @@
  *
  * Copyright Oxide Computer Company
  */
-import { useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router-dom'
 
@@ -17,17 +16,18 @@ import { useVpcRouterSelector } from '~/hooks/use-params'
 import { addToast } from '~/stores/toast'
 import { pb } from '~/util/path-builder'
 
-const defaultValues: RouteFormValues = {
-  name: '',
-  description: '',
-  destination: { type: 'ip', value: '' },
-  target: { type: 'ip', value: '' },
-}
-
 export function CreateRouterRouteSideModalForm() {
   const queryClient = useApiQueryClient()
   const routerSelector = useVpcRouterSelector()
   const navigate = useNavigate()
+
+  const defaultValues: RouteFormValues = {
+    name: '',
+    description: '',
+    destination: { type: 'ip', value: '' },
+    target: { type: 'ip', value: '' },
+  }
+  const form = useForm({ defaultValues })
 
   const createRouterRoute = useApiMutation('vpcRouterRouteCreate', {
     onSuccess() {
@@ -36,14 +36,6 @@ export function CreateRouterRouteSideModalForm() {
       navigate(pb.vpcRouter(routerSelector))
     },
   })
-
-  const form = useForm({ defaultValues })
-  const targetType = form.watch('target.type')
-
-  useEffect(() => {
-    // when targetType is 'internet_gateway', we set it to `outbound`
-    form.setValue('target.value', targetType === 'internet_gateway' ? 'outbound' : '')
-  }, [form, targetType])
 
   return (
     <SideModalForm
@@ -66,7 +58,7 @@ export function CreateRouterRouteSideModalForm() {
       loading={createRouterRoute.isPending}
       submitError={createRouterRoute.error}
     >
-      <RouteFormFields control={form.control} targetType={targetType} />
+      <RouteFormFields form={form} />
     </SideModalForm>
   )
 }

--- a/app/forms/vpc-router-route-create.tsx
+++ b/app/forms/vpc-router-route-create.tsx
@@ -16,17 +16,18 @@ import { useVpcRouterSelector } from '~/hooks/use-params'
 import { addToast } from '~/stores/toast'
 import { pb } from '~/util/path-builder'
 
+const defaultValues: RouteFormValues = {
+  name: '',
+  description: '',
+  destination: { type: 'ip', value: '' },
+  target: { type: 'ip', value: '' },
+}
+
 export function CreateRouterRouteSideModalForm() {
   const queryClient = useApiQueryClient()
   const routerSelector = useVpcRouterSelector()
   const navigate = useNavigate()
 
-  const defaultValues: RouteFormValues = {
-    name: '',
-    description: '',
-    destination: { type: 'ip', value: '' },
-    target: { type: 'ip', value: '' },
-  }
   const form = useForm({ defaultValues })
 
   const createRouterRoute = useApiMutation('vpcRouterRouteCreate', {

--- a/app/forms/vpc-router-route-edit.tsx
+++ b/app/forms/vpc-router-route-edit.tsx
@@ -62,12 +62,15 @@ export function EditRouterRouteSideModalForm() {
 
   const form = useForm({ defaultValues })
   const targetType = form.watch('target.type')
+  const targetValue = form.watch('target.value')
   const isDisabled = route?.kind === 'vpc_subnet'
-
   useEffect(() => {
     // when targetType is 'internet_gateway', we set it to `outbound`
-    form.setValue('target.value', targetType === 'internet_gateway' ? 'outbound' : '')
-  }, [form, targetType])
+    form.setValue(
+      'target.value',
+      targetType === 'internet_gateway' ? 'outbound' : targetValue
+    )
+  }, [form, targetType, targetValue])
 
   return (
     <SideModalForm

--- a/app/forms/vpc-router-route-edit.tsx
+++ b/app/forms/vpc-router-route-edit.tsx
@@ -5,6 +5,7 @@
  *
  * Copyright Oxide Computer Company
  */
+import { useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { useNavigate, type LoaderFunctionArgs } from 'react-router-dom'
 import * as R from 'remeda'
@@ -14,84 +15,70 @@ import {
   useApiMutation,
   useApiQueryClient,
   usePrefetchedApiQuery,
-  type RouterRouteUpdate,
 } from '@oxide/api'
 
-import { DescriptionField } from '~/components/form/fields/DescriptionField'
-import { ListboxField } from '~/components/form/fields/ListboxField'
-import { NameField } from '~/components/form/fields/NameField'
-import { TextField } from '~/components/form/fields/TextField'
 import { SideModalForm } from '~/components/form/SideModalForm'
 import {
-  fields,
+  RouteFormFields,
   routeFormMessage,
-  targetValueDescription,
-} from '~/forms/vpc-router-route/shared'
+  type RouteFormValues,
+} from '~/forms/vpc-router-route-common'
 import { getVpcRouterRouteSelector, useVpcRouterRouteSelector } from '~/hooks/use-params'
 import { addToast } from '~/stores/toast'
-import { Message } from '~/ui/lib/Message'
 import { pb } from '~/util/path-builder'
 
 EditRouterRouteSideModalForm.loader = async ({ params }: LoaderFunctionArgs) => {
-  const { project, vpc, router, route } = getVpcRouterRouteSelector(params)
+  const { route, ...routerSelector } = getVpcRouterRouteSelector(params)
   await apiQueryClient.prefetchQuery('vpcRouterRouteView', {
     path: { route },
-    query: { project, vpc, router },
+    query: routerSelector,
   })
   return null
 }
 
 export function EditRouterRouteSideModalForm() {
   const queryClient = useApiQueryClient()
-  const routeSelector = useVpcRouterRouteSelector()
-  const { project, vpc, router: routerName, route: routeName } = routeSelector
+  const { route: routeName, ...routerSelector } = useVpcRouterRouteSelector()
   const navigate = useNavigate()
   const { data: route } = usePrefetchedApiQuery('vpcRouterRouteView', {
     path: { route: routeName },
-    query: { project, vpc, router: routerName },
+    query: routerSelector,
   })
 
-  const defaultValues: RouterRouteUpdate = R.pick(route, [
+  const defaultValues: RouteFormValues = R.pick(route, [
     'name',
     'description',
     'target',
     'destination',
   ])
 
-  const onDismiss = () => {
-    navigate(pb.vpcRouter({ project, vpc, router: routerName }))
-  }
-
   const updateRouterRoute = useApiMutation('vpcRouterRouteUpdate', {
     onSuccess() {
       queryClient.invalidateQueries('vpcRouterRouteList')
       addToast({ content: 'Your route has been updated' })
-      onDismiss()
+      navigate(pb.vpcRouter(routerSelector))
     },
   })
 
   const form = useForm({ defaultValues })
   const targetType = form.watch('target.type')
+  const isDisabled = route?.kind === 'vpc_subnet'
 
-  let isDisabled = false
-  let disabledReason = ''
-
-  // Can simplify this if there aren't other disabling reasons
-  if (route?.kind === 'vpc_subnet') {
-    isDisabled = true
-    disabledReason = routeFormMessage.vpcSubnetNotModifiable
-  }
+  useEffect(() => {
+    // when targetType is 'internet_gateway', we set it to `outbound`
+    form.setValue('target.value', targetType === 'internet_gateway' ? 'outbound' : '')
+  }, [form, targetType])
 
   return (
     <SideModalForm
       form={form}
       formType="edit"
       resourceName="route"
-      onDismiss={onDismiss}
+      onDismiss={() => navigate(pb.vpcRouter(routerSelector))}
       onSubmit={({ name, description, destination, target }) =>
         updateRouterRoute.mutate({
-          query: { project, vpc, router: routerName },
           path: { route: routeName },
+          query: routerSelector,
           body: {
             name,
             description,
@@ -103,35 +90,13 @@ export function EditRouterRouteSideModalForm() {
       }
       loading={updateRouterRoute.isPending}
       submitError={updateRouterRoute.error}
+      submitDisabled={isDisabled ? routeFormMessage.vpcSubnetNotModifiable : undefined}
     >
-      {isDisabled && <Message variant="info" content={disabledReason} />}
-      <NameField name="name" control={form.control} disabled={isDisabled} />
-      <DescriptionField name="description" control={form.control} disabled={isDisabled} />
-      <ListboxField {...fields.destType} control={form.control} disabled={isDisabled} />
-      <TextField {...fields.destValue} control={form.control} disabled={isDisabled} />
-      <ListboxField
-        {...fields.targetType}
+      <RouteFormFields
         control={form.control}
-        disabled={isDisabled}
-        onChange={(value) => {
-          // 'outbound' is only valid option when targetType is 'internet_gateway'
-          if (value === 'internet_gateway') {
-            form.setValue('target.value', 'outbound')
-          }
-          if (value === 'drop') {
-            form.setValue('target.value', '')
-          }
-        }}
+        targetType={targetType}
+        isDisabled={isDisabled}
       />
-      {targetType !== 'drop' && (
-        <TextField
-          {...fields.targetValue}
-          control={form.control}
-          // when targetType is 'internet_gateway', we set it to `outbound` and make it non-editable
-          disabled={isDisabled || targetType === 'internet_gateway'}
-          description={targetValueDescription(targetType)}
-        />
-      )}
     </SideModalForm>
   )
 }

--- a/app/forms/vpc-router-route-edit.tsx
+++ b/app/forms/vpc-router-route-edit.tsx
@@ -5,7 +5,6 @@
  *
  * Copyright Oxide Computer Company
  */
-import { useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { useNavigate, type LoaderFunctionArgs } from 'react-router-dom'
 import * as R from 'remeda'
@@ -51,6 +50,8 @@ export function EditRouterRouteSideModalForm() {
     'target',
     'destination',
   ])
+  const form = useForm({ defaultValues })
+  const isDisabled = route?.kind === 'vpc_subnet'
 
   const updateRouterRoute = useApiMutation('vpcRouterRouteUpdate', {
     onSuccess() {
@@ -59,18 +60,6 @@ export function EditRouterRouteSideModalForm() {
       navigate(pb.vpcRouter(routerSelector))
     },
   })
-
-  const form = useForm({ defaultValues })
-  const targetType = form.watch('target.type')
-  const targetValue = form.watch('target.value')
-  const isDisabled = route?.kind === 'vpc_subnet'
-  useEffect(() => {
-    // when targetType is 'internet_gateway', we set it to `outbound`
-    form.setValue(
-      'target.value',
-      targetType === 'internet_gateway' ? 'outbound' : targetValue
-    )
-  }, [form, targetType, targetValue])
 
   return (
     <SideModalForm
@@ -95,11 +84,7 @@ export function EditRouterRouteSideModalForm() {
       submitError={updateRouterRoute.error}
       submitDisabled={isDisabled ? routeFormMessage.vpcSubnetNotModifiable : undefined}
     >
-      <RouteFormFields
-        control={form.control}
-        targetType={targetType}
-        isDisabled={isDisabled}
-      />
+      <RouteFormFields form={form} isDisabled={isDisabled} />
     </SideModalForm>
   )
 }

--- a/app/pages/project/vpcs/RouterPage.tsx
+++ b/app/pages/project/vpcs/RouterPage.tsx
@@ -23,7 +23,7 @@ import {
 import { DocsPopover } from '~/components/DocsPopover'
 import { HL } from '~/components/HL'
 import { MoreActionsMenu } from '~/components/MoreActionsMenu'
-import { routeFormMessage } from '~/forms/vpc-router-route/shared'
+import { routeFormMessage } from '~/forms/vpc-router-route-common'
 import { getVpcRouterSelector, useVpcRouterSelector } from '~/hooks/use-params'
 import { confirmAction } from '~/stores/confirm-action'
 import { addToast } from '~/stores/toast'

--- a/app/pages/project/vpcs/VpcPage/tabs/VpcRoutersTab.tsx
+++ b/app/pages/project/vpcs/VpcPage/tabs/VpcRoutersTab.tsx
@@ -11,7 +11,7 @@ import { Outlet, useNavigate, type LoaderFunctionArgs } from 'react-router-dom'
 
 import { apiQueryClient, useApiMutation, type VpcRouter } from '@oxide/api'
 
-import { routeFormMessage } from '~/forms/vpc-router-route/shared'
+import { routeFormMessage } from '~/forms/vpc-router-route-common'
 import { getVpcSelector, useVpcSelector } from '~/hooks/use-params'
 import { confirmDelete } from '~/stores/confirm-delete'
 import { addToast } from '~/stores/toast'


### PR DESCRIPTION
There was a lot of duplicated code in the VPC router route create/edit forms. I started on #2388, but realized it'd be good to clean the forms up a little first, so this is the result of that refactoring. Open to other refinements, if anything stands out.