### PR TITLE
Allow user to start failed instances

### DIFF
--- a/app/api/util.ts
+++ b/app/api/util.ts
@@ -90,8 +90,8 @@ export const genName = (...parts: [string, ...string[]]) => {
 }
 
 const instanceActions: Record<string, InstanceState[]> = {
-  // https://github.com/oxidecomputer/omicron/blob/6dd9802/nexus/src/app/instance.rs#L1960-L1963
-  start: ['stopped'],
+  // https://github.com/oxidecomputer/omicron/blob/0496637/nexus/src/app/instance.rs#L2064
+  start: ['stopped', 'failed'],
 
   // https://github.com/oxidecomputer/omicron/blob/6dd9802/nexus/db-queries/src/db/datastore/instance.rs#L865
   delete: ['stopped', 'failed'],


### PR DESCRIPTION
Closes #2438. I might add a test, though.

https://github.com/user-attachments/assets/0f8c61d2-da56-4295-abc0-5117ef4afdf8

