### PR TITLE
minor: tweak image upload cancel e2e for less flake

### DIFF
--- a/test/e2e/image-upload.e2e.ts
+++ b/test/e2e/image-upload.e2e.ts
@@ -119,17 +119,18 @@ test.describe('Image upload', () => {
 
     await page.click('role=button[name="Upload image"]')
 
+    const progressModal = page.getByRole('dialog', { name: 'Image upload progress' })
+    await expect(progressModal).toBeVisible()
+
     // wait to be in the middle of upload
     const uploadStep = page
-      .locator('div[data-status]')
+      .getByTestId('upload-step')
       .filter({ hasText: 'Upload image file' })
       .first()
     await expect(uploadStep).toHaveAttribute('data-status', 'running')
 
     // form is disabled and semi-hidden
     // await expectNotVisible(page, ['role=textbox[name="Name"]'])
-
-    const progressModal = page.getByRole('dialog', { name: 'Image upload progress' })
 
     page.on('dialog', (dialog) => dialog.accept()) // click yes on the are you sure prompt
     await progressModal.getByRole('button', { name: 'Cancel' }).click()


### PR DESCRIPTION
Followup to #2415. Flakes seem less frequent but we still [saw one](https://github.com/oxidecomputer/console/actions/runs/10820606878/job/30021009761).