### PR TITLE
Add dropdowns to router route form for destinations and targets

### DIFF
--- a/app/api/hooks.ts
+++ b/app/api/hooks.ts
@@ -177,7 +177,7 @@ export const getUsePrefetchedApiQuery =
       `Expected query to be prefetched.
 Key: ${JSON.stringify(queryKey)}
 Ensure the following:
-• loader is running
+• loader is called in routes.tsx and is running
 • query matches in both the loader and the component
 • request isn't erroring-out server-side (check the Networking tab)
 • mock API endpoint is implemented in handlers.ts

--- a/app/forms/vpc-router-route-common.tsx
+++ b/app/forms/vpc-router-route-common.tsx
@@ -65,7 +65,7 @@ type RouteFormFieldsProps = {
 export const RouteFormFields = ({ form, isDisabled }: RouteFormFieldsProps) => {
   const routerSelector = useVpcRouterSelector()
   const { project, vpc } = routerSelector
-  // usePrefetchedApiQuery items below are initially fetched in the loaders in the vpc-router-route-create and -edit forms
+  // usePrefetchedApiQuery items below are initially fetched in the loaders in vpc-router-route-create and -edit
   const {
     data: { items: vpcSubnets },
   } = usePrefetchedApiQuery('vpcSubnetList', { query: { project, vpc, limit: 1000 } })

--- a/app/forms/vpc-router-route-common.tsx
+++ b/app/forms/vpc-router-route-common.tsx
@@ -103,6 +103,7 @@ export const RouteFormFields = ({ form, isDisabled }: RouteFormFieldsProps) => {
           items={vpcSubnets.map(({ name }) => ({ value: name, label: name }))}
           placeholder="Select a destination value"
           required
+          isDisabled={isDisabled}
         />
       ) : (
         <TextField
@@ -134,6 +135,7 @@ export const RouteFormFields = ({ form, isDisabled }: RouteFormFieldsProps) => {
           items={instances.map(({ name }) => ({ value: name, label: name }))}
           placeholder="Select a target value"
           required
+          isDisabled={isDisabled}
         />
       ) : (
         <TextField

--- a/app/forms/vpc-router-route-common.tsx
+++ b/app/forms/vpc-router-route-common.tsx
@@ -131,8 +131,9 @@ export const RouteFormFields = ({ form, isDisabled }: RouteFormFieldsProps) => {
           name="target.value"
           label="Target value"
           control={control}
-          placeholder="Select a target value"
           items={instances.map(({ name }) => ({ value: name, label: name }))}
+          placeholder="Select a target value"
+          required
         />
       ) : (
         <TextField

--- a/app/forms/vpc-router-route-common.tsx
+++ b/app/forms/vpc-router-route-common.tsx
@@ -96,9 +96,9 @@ const toItems = (mapping: Record<string, string>) =>
 
 type RouteFormFieldsProps = {
   form: UseFormReturn<RouteFormValues>
-  isDisabled?: boolean
+  disabled?: boolean
 }
-export const RouteFormFields = ({ form, isDisabled }: RouteFormFieldsProps) => {
+export const RouteFormFields = ({ form, disabled }: RouteFormFieldsProps) => {
   const routerSelector = useVpcRouterSelector()
   const { project, vpc } = routerSelector
   // usePrefetchedApiQuery items below are initially fetched in the loaders in vpc-router-route-create and -edit
@@ -118,7 +118,7 @@ export const RouteFormFields = ({ form, isDisabled }: RouteFormFieldsProps) => {
     control,
     placeholder: getDestinationValuePlaceholder(destinationType),
     required: true,
-    disabled: isDisabled,
+    disabled,
     description: getDestinationValueDescription(destinationType),
   }
   const targetValueProps = {
@@ -129,16 +129,16 @@ export const RouteFormFields = ({ form, isDisabled }: RouteFormFieldsProps) => {
     placeholder: getTargetValuePlaceholder(targetType),
     required: true,
     // 'internet_gateway' targetTypes can only have the value 'outbound', so we disable the field
-    disabled: isDisabled || targetType === 'internet_gateway',
+    disabled: disabled || targetType === 'internet_gateway',
     description: getTargetValueDescription(targetType),
   }
   return (
     <>
-      {isDisabled && (
+      {disabled && (
         <Message variant="info" content={routeFormMessage.vpcSubnetNotModifiable} />
       )}
-      <NameField name="name" control={control} disabled={isDisabled} />
-      <DescriptionField name="description" control={control} disabled={isDisabled} />
+      <NameField name="name" control={control} disabled={disabled} />
+      <DescriptionField name="description" control={control} disabled={disabled} />
       <ListboxField
         name="destination.type"
         label="Destination type"
@@ -149,13 +149,12 @@ export const RouteFormFields = ({ form, isDisabled }: RouteFormFieldsProps) => {
         onChange={() => {
           form.setValue('destination.value', '')
         }}
-        disabled={isDisabled}
+        disabled={disabled}
       />
       {destinationType === 'subnet' ? (
         <ComboboxField
           {...destinationValueProps}
           items={vpcSubnets.map(({ name }) => ({ value: name, label: name }))}
-          isDisabled={isDisabled}
         />
       ) : (
         <TextField {...destinationValueProps} />
@@ -170,13 +169,12 @@ export const RouteFormFields = ({ form, isDisabled }: RouteFormFieldsProps) => {
         onChange={(value) => {
           form.setValue('target.value', value === 'internet_gateway' ? 'outbound' : '')
         }}
-        disabled={isDisabled}
+        disabled={disabled}
       />
       {targetType === 'drop' ? null : targetType === 'instance' ? (
         <ComboboxField
           {...targetValueProps}
           items={instances.map(({ name }) => ({ value: name, label: name }))}
-          isDisabled={isDisabled}
         />
       ) : (
         <TextField {...targetValueProps} />

--- a/app/forms/vpc-router-route-common.tsx
+++ b/app/forms/vpc-router-route-common.tsx
@@ -101,7 +101,7 @@ export const RouteFormFields = ({ form, isDisabled }: RouteFormFieldsProps) => {
           label="Destination value"
           control={control}
           items={vpcSubnets.map(({ name }) => ({ value: name, label: name }))}
-          placeholder="Select a destination value"
+          placeholder="Select a subnet"
           required
           isDisabled={isDisabled}
         />
@@ -133,7 +133,7 @@ export const RouteFormFields = ({ form, isDisabled }: RouteFormFieldsProps) => {
           label="Target value"
           control={control}
           items={instances.map(({ name }) => ({ value: name, label: name }))}
-          placeholder="Select a target value"
+          placeholder="Select an instance"
           required
           isDisabled={isDisabled}
         />

--- a/app/forms/vpc-router-route-common.tsx
+++ b/app/forms/vpc-router-route-common.tsx
@@ -76,6 +76,22 @@ export const RouteFormFields = ({ form, isDisabled }: RouteFormFieldsProps) => {
   const { control } = form
   const destinationType = form.watch('destination.type')
   const targetType = form.watch('target.type')
+  const destinationValuePlaceholder = {
+    ip: 'Enter an IP',
+    ip_net: 'Enter an IP network',
+    subnet: 'Select a subnet',
+    // VPC probably won't ever be used, as VPCs cannot be specified
+    // as a destination in custom routers, but is here for completeness
+    vpc: 'Select a VPC',
+  }[destinationType]
+  const getDestinationValueProps = () => ({
+    name: 'destination.value' as const,
+    label: 'Destination value',
+    control,
+    placeholder: destinationValuePlaceholder,
+    required: true,
+    isDisabled,
+  })
   return (
     <>
       {isDisabled && (
@@ -97,23 +113,11 @@ export const RouteFormFields = ({ form, isDisabled }: RouteFormFieldsProps) => {
       />
       {destinationType === 'subnet' ? (
         <ComboboxField
-          name="destination.value"
-          label="Destination value"
-          control={control}
+          {...getDestinationValueProps()}
           items={vpcSubnets.map(({ name }) => ({ value: name, label: name }))}
-          placeholder="Select a subnet"
-          required
-          isDisabled={isDisabled}
         />
       ) : (
-        <TextField
-          name="destination.value"
-          label="Destination value"
-          control={control}
-          placeholder="Enter a destination value"
-          required
-          disabled={isDisabled}
-        />
+        <TextField {...getDestinationValueProps()} />
       )}
       <ListboxField
         name="target.type"

--- a/app/forms/vpc-router-route-create.tsx
+++ b/app/forms/vpc-router-route-create.tsx
@@ -6,13 +6,13 @@
  * Copyright Oxide Computer Company
  */
 import { useForm } from 'react-hook-form'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, type LoaderFunctionArgs } from 'react-router-dom'
 
-import { useApiMutation, useApiQueryClient } from '@oxide/api'
+import { apiQueryClient, useApiMutation, useApiQueryClient } from '@oxide/api'
 
 import { SideModalForm } from '~/components/form/SideModalForm'
 import { RouteFormFields, type RouteFormValues } from '~/forms/vpc-router-route-common'
-import { useVpcRouterSelector } from '~/hooks/use-params'
+import { getVpcRouterSelector, useVpcRouterSelector } from '~/hooks/use-params'
 import { addToast } from '~/stores/toast'
 import { pb } from '~/util/path-builder'
 
@@ -21,6 +21,19 @@ const defaultValues: RouteFormValues = {
   description: '',
   destination: { type: 'ip', value: '' },
   target: { type: 'ip', value: '' },
+}
+
+CreateRouterRouteSideModalForm.loader = async ({ params }: LoaderFunctionArgs) => {
+  const { project, vpc } = getVpcRouterSelector(params)
+  await Promise.all([
+    apiQueryClient.prefetchQuery('vpcSubnetList', {
+      query: { project, vpc, limit: 1000 },
+    }),
+    apiQueryClient.prefetchQuery('instanceList', {
+      query: { project, limit: 1000 },
+    }),
+  ])
+  return null
 }
 
 export function CreateRouterRouteSideModalForm() {

--- a/app/forms/vpc-router-route-edit.tsx
+++ b/app/forms/vpc-router-route-edit.tsx
@@ -27,11 +27,19 @@ import { addToast } from '~/stores/toast'
 import { pb } from '~/util/path-builder'
 
 EditRouterRouteSideModalForm.loader = async ({ params }: LoaderFunctionArgs) => {
-  const { route, ...routerSelector } = getVpcRouterRouteSelector(params)
-  await apiQueryClient.prefetchQuery('vpcRouterRouteView', {
-    path: { route },
-    query: routerSelector,
-  })
+  const { project, vpc, router, route } = getVpcRouterRouteSelector(params)
+  await Promise.all([
+    apiQueryClient.prefetchQuery('vpcRouterRouteView', {
+      path: { route },
+      query: { project, vpc, router },
+    }),
+    apiQueryClient.prefetchQuery('vpcSubnetList', {
+      query: { project, vpc, limit: 1000 },
+    }),
+    apiQueryClient.prefetchQuery('instanceList', {
+      query: { project, limit: 1000 },
+    }),
+  ])
   return null
 }
 

--- a/app/forms/vpc-router-route-edit.tsx
+++ b/app/forms/vpc-router-route-edit.tsx
@@ -59,7 +59,7 @@ export function EditRouterRouteSideModalForm() {
     'destination',
   ])
   const form = useForm({ defaultValues })
-  const isDisabled = route?.kind === 'vpc_subnet'
+  const disabled = route?.kind === 'vpc_subnet'
 
   const updateRouterRoute = useApiMutation('vpcRouterRouteUpdate', {
     onSuccess() {
@@ -90,9 +90,9 @@ export function EditRouterRouteSideModalForm() {
       }
       loading={updateRouterRoute.isPending}
       submitError={updateRouterRoute.error}
-      submitDisabled={isDisabled ? routeFormMessage.vpcSubnetNotModifiable : undefined}
+      submitDisabled={disabled ? routeFormMessage.vpcSubnetNotModifiable : undefined}
     >
-      <RouteFormFields form={form} isDisabled={isDisabled} />
+      <RouteFormFields form={form} disabled={disabled} />
     </SideModalForm>
   )
 }

--- a/app/routes.tsx
+++ b/app/routes.tsx
@@ -424,6 +424,7 @@ export const routes = createRoutesFromElements(
           <Route
             path="routes-new"
             element={<CreateRouterRouteSideModalForm />}
+            loader={CreateRouterRouteSideModalForm.loader}
             handle={{ crumb: 'New Route' }}
           />
           <Route

--- a/test/e2e/vpcs.e2e.ts
+++ b/test/e2e/vpcs.e2e.ts
@@ -7,7 +7,7 @@
  */
 import { expect, test } from '@playwright/test'
 
-import { clickRowAction, expectRowVisible } from './utils'
+import { clickRowAction, expectRowVisible, selectOption } from './utils'
 
 test('can nav to VpcPage from /', async ({ page }) => {
   await page.goto('/')
@@ -248,13 +248,16 @@ test('can create, update, and delete Route', async ({ page }) => {
 
   // update the route by clicking the edit button
   await clickRowAction(page, 'new-route', 'Edit')
-  await page.getByRole('textbox', { name: 'Destination value' }).fill('0.0.0.1')
+  // change the destination type to VPC subnet: `mock-subnet`
+  await selectOption(page, 'Destination type', 'Subnet')
+  await selectOption(page, 'Destination value', 'mock-subnet')
+  await page.getByRole('textbox', { name: 'Target value' }).fill('0.0.0.1')
   await page.getByRole('button', { name: 'Update route' }).click()
   await expect(routeRows).toHaveCount(2)
   await expectRowVisible(table, {
     Name: 'new-route',
-    Destination: 'IP0.0.0.1',
-    Target: 'IP1.1.1.1',
+    Destination: 'VPC subnetmock-subnet',
+    Target: 'IP0.0.0.1',
   })
 
   // delete the route


### PR DESCRIPTION
This PR converts the text fields in the VPC Router Routes form to be — when appropriate — prepopulated dropdowns.

For Destinations, that's when the Destination Type has been selected as `Subnet`; for Targets, `Instance`s.

<img width="514" alt="Screenshot 2024-09-16 at 12 37 14 PM" src="https://github.com/user-attachments/assets/d0a2810e-073e-4980-8163-f8d1d1de7cb3">

Closes #2388 