### PR TITLE
Add makeHeadCell helper function

### DIFF
--- a/app/components/form/fields/DisksTableField.tsx
+++ b/app/components/form/fields/DisksTableField.tsx
@@ -48,9 +48,7 @@ export function DisksTableField({
         {!!items.length && (
           <MiniTable.Table className="mb-4">
             <MiniTable.Header>
-              <MiniTable.HeadCell>Name</MiniTable.HeadCell>
-              <MiniTable.HeadCell>Type</MiniTable.HeadCell>
-              <MiniTable.HeadCell>Size</MiniTable.HeadCell>
+              {['Name', 'Type', 'Size'].map((label) => MiniTable.makeHeadCell(label))}
               {/* For remove button */}
               <MiniTable.HeadCell className="w-12" />
             </MiniTable.Header>

--- a/app/components/form/fields/NetworkInterfaceField.tsx
+++ b/app/components/form/fields/NetworkInterfaceField.tsx
@@ -78,9 +78,7 @@ export function NetworkInterfaceField({
             {value.params.length > 0 && (
               <MiniTable.Table className="pt-2">
                 <MiniTable.Header>
-                  <MiniTable.HeadCell>Name</MiniTable.HeadCell>
-                  <MiniTable.HeadCell>VPC</MiniTable.HeadCell>
-                  <MiniTable.HeadCell>Subnet</MiniTable.HeadCell>
+                  {['Name', 'VPC', 'Subnet'].map((label) => MiniTable.makeHeadCell(label))}
                   {/* For remove button */}
                   <MiniTable.HeadCell className="w-12" />
                 </MiniTable.Header>

--- a/app/forms/firewall-rules-common.tsx
+++ b/app/forms/firewall-rules-common.tsx
@@ -192,8 +192,7 @@ const TypeAndValueTable = ({ sectionType, items }: TypeAndValueTableProps) => (
     aria-label={sectionType === 'target' ? 'Targets' : 'Host filters'}
   >
     <MiniTable.Header>
-      <MiniTable.HeadCell>Type</MiniTable.HeadCell>
-      <MiniTable.HeadCell>Value</MiniTable.HeadCell>
+      {['Type', 'Value'].map((label) => MiniTable.makeHeadCell(label))}
       {/* For remove button */}
       <MiniTable.HeadCell className="w-12" />
     </MiniTable.Header>

--- a/app/forms/instance-create.tsx
+++ b/app/forms/instance-create.tsx
@@ -765,8 +765,7 @@ const AdvancedAccordion = ({
           {isFloatingIpAttached && (
             <MiniTable.Table>
               <MiniTable.Header>
-                <MiniTable.HeadCell>Name</MiniTable.HeadCell>
-                <MiniTable.HeadCell>IP</MiniTable.HeadCell>
+                {['Name', 'IP'].map((label) => MiniTable.makeHeadCell(label))}
                 {/* For remove button */}
                 <MiniTable.HeadCell className="w-12" />
               </MiniTable.Header>

--- a/app/ui/lib/MiniTable.stories.tsx
+++ b/app/ui/lib/MiniTable.stories.tsx
@@ -10,9 +10,7 @@ import * as MiniTable from './MiniTable'
 export const Default = () => (
   <MiniTable.Table>
     <MiniTable.Header>
-      <MiniTable.HeadCell>Name</MiniTable.HeadCell>
-      <MiniTable.HeadCell>Source Type</MiniTable.HeadCell>
-      <MiniTable.HeadCell>Size</MiniTable.HeadCell>
+      {['Name', 'Source Type', 'Size'].map((label) => MiniTable.makeHeadCell(label))}
     </MiniTable.Header>
     <MiniTable.Body>
       <MiniTable.Row>

--- a/app/ui/lib/MiniTable.tsx
+++ b/app/ui/lib/MiniTable.tsx
@@ -23,6 +23,10 @@ export const Header = ({ children }: Children) => (
 
 export const HeadCell = BigTable.HeadCell
 
+export const makeHeadCell = (label: string, className?: string) => (
+  <HeadCell className={className}>{label}</HeadCell>
+)
+
 export const Body = classed.tbody``
 
 export const Row = classed.tr`is-selected children:border-default first:children:border-l children:last:border-b last:children:border-r`


### PR DESCRIPTION
A rather small improvement, and I'm fine if we decide not to move forward with it.

Essentially, this reduces some of the duplication in `MiniTable`s by pulling the header cells into a helper function. We pass in the relevant strings and they get turned into the appropriate `HeadCell`s, with an optional CSS `className` string.

<img width="531" alt="Screenshot 2024-09-16 at 5 34 27 PM" src="https://github.com/user-attachments/assets/7d2631ac-a5f2-4b40-8646-36e4df696ea4">

<img width="462" alt="Screenshot 2024-09-16 at 5 34 40 PM" src="https://github.com/user-attachments/assets/ad7a9f4e-e097-4c75-87b0-4028c4271cac">
