### PR TITLE
Use destructured mutate method for dependency array

### DIFF
--- a/app/pages/project/disks/DisksPage.tsx
+++ b/app/pages/project/disks/DisksPage.tsx
@@ -104,7 +104,7 @@ export function DisksPage() {
     },
   })
 
-  const createSnapshot = useApiMutation('snapshotCreate', {
+  const { mutate: createSnapshot } = useApiMutation('snapshotCreate', {
     onSuccess() {
       queryClient.invalidateQueries('snapshotList')
       addToast({ content: 'Snapshot successfully created' })
@@ -124,7 +124,7 @@ export function DisksPage() {
         label: 'Snapshot',
         onActivate() {
           addToast({ title: `Creating snapshot of disk '${disk.name}'` })
-          createSnapshot.mutate({
+          createSnapshot({
             query: { project },
             body: {
               name: genName(disk.name),


### PR DESCRIPTION
I believe this is the last migration needed to close out #2367. I scanned through looking at all instances of `= useApiMutation` to see if their variables were A) not destructured and B) used in a dependency array, and this was the only one that I saw that still needed to be switched over.