### PR TITLE
Fix instance disk row menu closing on instance state change

### DIFF
--- a/app/pages/project/instances/instance/tabs/StorageTab.tsx
+++ b/app/pages/project/instances/instance/tabs/StorageTab.tsx
@@ -18,7 +18,7 @@ import {
   useApiQueryClient,
   usePrefetchedApiQuery,
   type Disk,
-  type Instance,
+  type InstanceState,
 } from '@oxide/api'
 import { Storage24Icon } from '@oxide/design-system/icons/react'
 
@@ -61,22 +61,19 @@ StorageTab.loader = async ({ params }: LoaderFunctionArgs) => {
   return null
 }
 
-type InstanceDisk = {
-  // hack to opt in to auto copy ID button
-  id: string // disk ID
-  disk: Disk
-  instance: Instance
+type InstanceDisk = Disk & {
+  instanceState: InstanceState
 }
 
 const colHelper = createColumnHelper<InstanceDisk>()
 const staticCols = [
-  colHelper.accessor('disk.name', { header: 'Disk' }),
-  colHelper.accessor('disk.size', Columns.size),
-  colHelper.accessor((row) => row.disk.state.state, {
+  colHelper.accessor('name', { header: 'Disk' }),
+  colHelper.accessor('size', Columns.size),
+  colHelper.accessor((row) => row.state.state, {
     header: 'state',
     cell: (info) => <DiskStateBadge state={info.getValue()} />,
   }),
-  colHelper.accessor('disk.timeCreated', Columns.timeCreated),
+  colHelper.accessor('timeCreated', Columns.timeCreated),
 ]
 
 export function StorageTab() {
@@ -120,7 +117,7 @@ export function StorageTab() {
   const { data: instance } = usePrefetchedApiQuery('instanceView', instancePathQuery)
 
   const makeActions = useCallback(
-    ({ disk, instance }: InstanceDisk): MenuAction[] => [
+    (disk: InstanceDisk): MenuAction[] => [
       {
         label: 'Snapshot',
         disabled: !diskCan.snapshot(disk) && (
@@ -143,7 +140,7 @@ export function StorageTab() {
         // don't bother checking disk state: assume that if it is showing up
         // in this list, it can be detached
         label: 'Detach',
-        disabled: !instanceCan.detachDisk(instance) && (
+        disabled: !instanceCan.detachDisk({ runState: disk.instanceState }) && (
           <>
             Instance must be <span className="text-default">stopped</span> before disk can
             be detached
@@ -176,8 +173,8 @@ export function StorageTab() {
   const { data: disks } = usePrefetchedApiQuery('instanceDiskList', instancePathQuery)
 
   const rows = useMemo(
-    () => disks.items.map((disk) => ({ id: disk.id, disk, instance })),
-    [disks.items, instance]
+    () => disks.items.map((disk) => ({ ...disk, instanceState: instance.runState })),
+    [disks.items, instance.runState]
   )
 
   const table = useReactTable({

--- a/app/pages/project/instances/instance/tabs/StorageTab.tsx
+++ b/app/pages/project/instances/instance/tabs/StorageTab.tsx
@@ -61,6 +61,10 @@ StorageTab.loader = async ({ params }: LoaderFunctionArgs) => {
   return null
 }
 
+// Bit of a hack: by putting the instance state in the row data, we can avoid
+// remaking the row actions callback whenever the instance state changes, which
+// causes the whole table to get re-rendered, which jarringly closes any open
+// row actions menus
 type InstanceDisk = Disk & {
   instanceState: InstanceState
 }


### PR DESCRIPTION
I don't like this very much but we might be stuck with it. The make actions callback depending on the instance state means it gets remade when the instance state changes, which means the whole table gets nuked when the instance goes from stopping to stopped, causing the row actions menu to be closed.

https://github.com/user-attachments/assets/5ecf8f2b-3d8e-4f02-9843-c7c0eb77d1e8

