### PR TITLE
minor: change incorrect `createRef` to `useRef`

### DIFF
--- a/app/ui/lib/ActionMenu.tsx
+++ b/app/ui/lib/ActionMenu.tsx
@@ -8,7 +8,7 @@
 import * as Dialog from '@radix-ui/react-dialog'
 import cn from 'classnames'
 import { matchSorter } from 'match-sorter'
-import React, { useState } from 'react'
+import { useRef, useState } from 'react'
 
 import { Close12Icon } from '@oxide/design-system/icons/react'
 
@@ -70,9 +70,9 @@ export function ActionMenu(props: ActionMenuProps) {
   const [selectedIdx, setSelectedIdx] = useState(0)
   const selectedItem = itemsInOrder[selectedIdx] as QuickActionItem | undefined
 
-  const divRef = React.createRef<HTMLDivElement>()
-  const ulRef = React.createRef<HTMLUListElement>()
-  const inputRef = React.createRef<HTMLInputElement>()
+  const divRef = useRef<HTMLDivElement>(null)
+  const ulRef = useRef<HTMLUListElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
 
   useSteppedScroll(divRef, ulRef, selectedIdx, LIST_HEIGHT)
 

--- a/app/ui/lib/use-stepped-scroll.ts
+++ b/app/ui/lib/use-stepped-scroll.ts
@@ -67,7 +67,11 @@ export function useSteppedScroll(
         outer.scrollTo({ top: itemBottomScrollTo - outerContainerHeight + 2 })
       }
     }
-    // don't depend on the refs because they get nuked on every render
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [outerContainerHeight, selectedIdx, itemSelector])
+  }, [
+    outerContainerRef,
+    innerContainerRef,
+    outerContainerHeight,
+    selectedIdx,
+    itemSelector,
+  ])
 }


### PR DESCRIPTION
Just a small thing I noticed while checking our few uses of `eslint-disable-next-line react-hooks/exhaustive-deps` because of [this tweet](https://x.com/mjackson/status/1836277438550282546). [`createRef`](https://react.dev/reference/react/createRef) is not really a thing anymore — it's for class components. Refs created with `useRef` are referentially stable and fine to use in the dep array.