### PR TITLE
cleanup: Remove "inline" pagination

### DIFF
--- a/app/components/Pagination.tsx
+++ b/app/components/Pagination.tsx
@@ -14,13 +14,7 @@ import {
 
 const Tunnel = tunnel('pagination')
 
-interface PaginationProps extends UIPaginationProps {
-  /** If true pagination will be rendered wherever `Pagination.Target` is included */
-  inline?: boolean
-}
-export function Pagination({ inline = false, ...props }: PaginationProps) {
-  if (inline) return <UIPagination {...props} />
-
+export function Pagination(props: UIPaginationProps) {
   return (
     <Tunnel.In>
       <UIPagination className="gutter h-14 py-5" {...props} />

--- a/app/layouts/helpers.tsx
+++ b/app/layouts/helpers.tsx
@@ -27,7 +27,7 @@ export function ContentPane() {
           <Outlet />
         </main>
       </div>
-      <div className="sticky bottom-0 shrink-0 justify-between overflow-hidden border-t bg-default border-secondary empty:border-t-0">
+      <div className="sticky bottom-0 z-topBar shrink-0 justify-between overflow-hidden border-t bg-default border-secondary empty:border-t-0">
         <Pagination.Target />
         <PageActionsTarget />
       </div>

--- a/app/table/QueryTable.tsx
+++ b/app/table/QueryTable.tsx
@@ -53,8 +53,6 @@ export const useQueryTable = <A extends ApiListMethods, M extends keyof A>(
 type QueryTableProps<Item> = {
   /** Prints table data in the console when enabled */
   debug?: boolean
-  /** Function that produces a list of actions from a row item */
-  pagination?: 'inline' | 'page'
   pageSize?: number
   rowHeight?: 'small' | 'large'
   emptyState: React.ReactElement
@@ -71,7 +69,6 @@ const makeQueryTable = <Item extends Record<string, unknown>>(
 ): ComponentType<QueryTableProps<Item>> =>
   function QueryTable({
     debug,
-    pagination = 'page',
     pageSize = PAGE_SIZE,
     rowHeight = 'small',
     emptyState,
@@ -115,7 +112,6 @@ const makeQueryTable = <Item extends Record<string, unknown>>(
       <>
         <Table table={table} rowHeight={rowHeight} />
         <Pagination
-          inline={pagination === 'inline'}
           pageSize={pageSize}
           hasNext={tableData.length === pageSize}
           hasPrev={hasPrev}

--- a/app/ui/lib/Pagination.tsx
+++ b/app/ui/lib/Pagination.tsx
@@ -27,7 +27,6 @@ const PageInput = ({ number, className }: PageInputProps) => {
 }
 
 export interface PaginationProps {
-  type?: 'inline' | 'page'
   pageSize: number
   hasNext: boolean
   hasPrev: boolean
@@ -37,7 +36,6 @@ export interface PaginationProps {
   className?: string
 }
 export const Pagination = ({
-  type = 'inline',
   pageSize,
   hasNext,
   hasPrev,
@@ -50,7 +48,6 @@ export const Pagination = ({
     <>
       <div
         className={cn(
-          type === 'page' && 'py-5',
           'flex items-center justify-between text-mono-sm text-default bg-default',
           className
         )}

--- a/test/e2e/snapshots.e2e.ts
+++ b/test/e2e/snapshots.e2e.ts
@@ -30,6 +30,10 @@ test('Confirm delete snapshot', async ({ page }) => {
 
   const row = page.getByRole('row', { name: 'disk-1-snapshot-6' })
 
+  // scroll a little so the dropdown menu isn't behind the pagination bar
+  await page.getByRole('table').click() // focus the content pane
+  await page.mouse.wheel(0, 200)
+
   async function clickDelete() {
     await row.getByRole('button', { name: 'Row actions' }).click()
     await page.getByRole('menuitem', { name: 'Delete' }).click()


### PR DESCRIPTION
While looking at #2457 I could not find a place where `inline` pagination is actually used. It's also all wonky, with some components defaulting to `inline` and some components defaulting to `page`. Will comment inline because there's some weirdness, but the goal here is to change nothing about any actually existing usages.