### PR TITLE
Validate IPs and IP networks

### DIFF
--- a/app/components/form/fields/ComboboxField.tsx
+++ b/app/components/form/fields/ComboboxField.tsx
@@ -10,7 +10,9 @@ import {
   useController,
   type Control,
   type FieldPath,
+  type FieldPathValue,
   type FieldValues,
+  type Validate,
 } from 'react-hook-form'
 
 import { Combobox, type ComboboxBaseProps } from '~/ui/lib/Combobox'
@@ -25,6 +27,7 @@ export type ComboboxFieldProps<
   name: TName
   control: Control<TFieldValues>
   onChange?: (value: string | null | undefined) => void
+  validate?: Validate<FieldPathValue<TFieldValues, TName>, TFieldValues>
 } & ComboboxBaseProps
 
 export function ComboboxField<
@@ -51,9 +54,14 @@ export function ComboboxField<
     : allowArbitraryValues
       ? 'Select an option or enter a custom value'
       : 'Select an option',
+  validate,
   ...props
 }: ComboboxFieldProps<TFieldValues, TName>) {
-  const { field, fieldState } = useController({ name, control, rules: { required } })
+  const { field, fieldState } = useController({
+    name,
+    control,
+    rules: { required, validate },
+  })
   return (
     <div className="max-w-lg">
       <Combobox

--- a/app/forms/firewall-rules-common.tsx
+++ b/app/forms/firewall-rules-common.tsx
@@ -261,8 +261,7 @@ export const CommonFields = ({ control, nameTaken, error }: CommonFieldsProps) =
   // Targets
   const targetForm = useForm({ defaultValues: targetAndHostDefaultValues })
   const targets = useController({ name: 'targets', control }).field
-  const targetType = targetForm.watch('type')
-  const targetValue = targetForm.watch('value')
+  const [targetType, targetValue] = targetForm.watch(['type', 'value'])
   // get the list of items that are not already in the list of targets
   const targetItems = {
     vpc: availableItems(targets.value, 'vpc', vpcs),
@@ -308,8 +307,7 @@ export const CommonFields = ({ control, nameTaken, error }: CommonFieldsProps) =
   // Host Filters
   const hostForm = useForm({ defaultValues: targetAndHostDefaultValues })
   const hosts = useController({ name: 'hosts', control }).field
-  const hostType = hostForm.watch('type')
-  const hostValue = hostForm.watch('value')
+  const [hostType, hostValue] = hostForm.watch(['type', 'value'])
   // get the list of items that are not already in the list of host filters
   const hostFilterItems = {
     vpc: availableItems(hosts.value, 'vpc', vpcs),
@@ -445,7 +443,7 @@ export const CommonFields = ({ control, nameTaken, error }: CommonFieldsProps) =
         />
         <MiniTable.ClearAndAddButtons
           addButtonCopy="Add target"
-          disableClear={!!targetValue}
+          disableClear={!targetValue}
           onClear={() => targetForm.reset()}
           onSubmit={submitTarget}
         />
@@ -496,8 +494,8 @@ export const CommonFields = ({ control, nameTaken, error }: CommonFieldsProps) =
         </div>
         <MiniTable.ClearAndAddButtons
           addButtonCopy="Add port filter"
-          disableClear={!!portValue}
-          onClear={portRangeForm.reset}
+          disableClear={!portValue}
+          onClear={() => portRangeForm.reset()}
           onSubmit={submitPortRange}
         />
       </div>
@@ -557,7 +555,7 @@ export const CommonFields = ({ control, nameTaken, error }: CommonFieldsProps) =
         />
         <MiniTable.ClearAndAddButtons
           addButtonCopy="Add host filter"
-          disableClear={!!hostValue}
+          disableClear={!hostValue}
           onClear={() => hostForm.reset()}
           onSubmit={submitHost}
         />

--- a/app/forms/firewall-rules-common.tsx
+++ b/app/forms/firewall-rules-common.tsx
@@ -134,7 +134,10 @@ const DynamicTypeAndValueFields = ({
           allowArbitraryValues
           hideOptionalTag
           validate={(value) =>
-            // TODO: is required false correct here? should this function even have that argument?
+            // required: false arg is desirable because otherwise if you put in
+            // a bad name and submit, causing it to revalidate onChange, then
+            // clear the field you're left with a BS "Target name is required"
+            // error message
             validateName(value, `${capitalize(sectionType)} name`, false)
           }
         />

--- a/app/forms/firewall-rules-common.tsx
+++ b/app/forms/firewall-rules-common.tsx
@@ -434,7 +434,12 @@ export const CommonFields = ({ control, nameTaken, error }: CommonFieldsProps) =
           control={targetForm.control}
           valueType={targetType}
           items={targetItems[targetType]}
-          onTypeChange={() => targetForm.resetField('value')}
+          // HACK: reset the whole subform, keeping type (because we just set
+          // it). most importantly, this resets isSubmitted so the form can go
+          // back to validating on submit instead of change
+          onTypeChange={() =>
+            targetForm.reset({ type: targetForm.getValues('type'), value: '' })
+          }
           onInputChange={(value) => targetForm.setValue('value', value)}
           onSubmitTextField={submitTarget}
         />
@@ -541,7 +546,12 @@ export const CommonFields = ({ control, nameTaken, error }: CommonFieldsProps) =
           control={hostForm.control}
           valueType={hostType}
           items={hostFilterItems[hostType]}
-          onTypeChange={() => targetForm.resetField('value')}
+          // HACK: reset the whole subform, keeping type (because we just set
+          // it). most importantly, this resets isSubmitted so the form can go
+          // back to validating on submit instead of change
+          onTypeChange={() =>
+            hostForm.reset({ type: hostForm.getValues('type'), value: '' })
+          }
           onInputChange={(value) => hostForm.setValue('value', value)}
           onSubmitTextField={submitHost}
         />

--- a/app/forms/ip-pool-range-add.tsx
+++ b/app/forms/ip-pool-range-add.tsx
@@ -23,8 +23,6 @@ const defaultValues: IpRange = {
   last: '',
 }
 
-const invalidAddressError = { type: 'pattern', message: 'Not a valid IP address' }
-
 const ipv6Error = { type: 'pattern', message: 'IPv6 ranges are not yet supported' }
 
 /**
@@ -40,15 +38,15 @@ function resolver(values: IpRange) {
 
   const errors: FieldErrors<IpRange> = {}
 
-  if (!first.valid) {
-    errors.first = invalidAddressError
-  } else if (first.isv6) {
+  if (first.type === 'error') {
+    errors.first = { type: 'pattern', message: first.message }
+  } else if (first.type === 'v6') {
     errors.first = ipv6Error
   }
 
-  if (!last.valid) {
-    errors.last = invalidAddressError
-  } else if (last.isv6) {
+  if (last.type === 'error') {
+    errors.last = { type: 'pattern', message: last.message }
+  } else if (last.type === 'v6') {
     errors.last = ipv6Error
   }
 

--- a/app/forms/ip-pool-range-add.tsx
+++ b/app/forms/ip-pool-range-add.tsx
@@ -15,7 +15,7 @@ import { SideModalForm } from '~/components/form/SideModalForm'
 import { useIpPoolSelector } from '~/hooks/use-params'
 import { addToast } from '~/stores/toast'
 import { Message } from '~/ui/lib/Message'
-import { validateIp } from '~/util/ip'
+import { parseIp } from '~/util/ip'
 import { pb } from '~/util/path-builder'
 
 const defaultValues: IpRange = {
@@ -33,8 +33,8 @@ const ipv6Error = { type: 'pattern', message: 'IPv6 ranges are not yet supported
  * regex twice, though.
  */
 function resolver(values: IpRange) {
-  const first = validateIp(values.first)
-  const last = validateIp(values.last)
+  const first = parseIp(values.first)
+  const last = parseIp(values.last)
 
   const errors: FieldErrors<IpRange> = {}
 

--- a/app/forms/ip-pool-range-add.tsx
+++ b/app/forms/ip-pool-range-add.tsx
@@ -15,8 +15,8 @@ import { SideModalForm } from '~/components/form/SideModalForm'
 import { useIpPoolSelector } from '~/hooks/use-params'
 import { addToast } from '~/stores/toast'
 import { Message } from '~/ui/lib/Message'
+import { validateIp } from '~/util/ip'
 import { pb } from '~/util/path-builder'
-import { validateIp } from '~/util/str'
 
 const defaultValues: IpRange = {
   first: '',

--- a/app/forms/network-interface-edit.tsx
+++ b/app/forms/network-interface-edit.tsx
@@ -5,6 +5,7 @@
  *
  * Copyright Oxide Computer Company
  */
+import { useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import * as R from 'remeda'
 
@@ -57,13 +58,18 @@ export function EditNetworkInterfaceForm({
   const transitIps = form.watch('transitIps') || []
 
   const transitIpsForm = useForm({ defaultValues: { transitIp: '' } })
-  const transitIpValue = transitIpsForm.watch('transitIp').trim()
+  const transitIpValue = transitIpsForm.watch('transitIp')
+  const { isSubmitSuccessful: transitIpSubmitSuccessful } = transitIpsForm.formState
 
   const submitTransitIp = transitIpsForm.handleSubmit(({ transitIp }) => {
     // validate has already checked to make sure it's not in the list
     form.setValue('transitIps', [...transitIps, transitIp])
     transitIpsForm.reset()
   })
+
+  useEffect(() => {
+    if (transitIpSubmitSuccessful) transitIpsForm.reset()
+  }, [transitIpSubmitSuccessful, transitIpsForm])
 
   return (
     <SideModalForm

--- a/app/forms/network-interface-edit.tsx
+++ b/app/forms/network-interface-edit.tsx
@@ -107,10 +107,7 @@ export function EditNetworkInterfaceForm({
                 submitTransitIp()
               }
             }}
-            validate={(value) => {
-              const result = validateIpNet(value)
-              if (result.type === 'error') return result.message
-            }}
+            validate={validateIpNet}
             placeholder="Enter an IP network"
           />
         </div>

--- a/app/forms/network-interface-edit.tsx
+++ b/app/forms/network-interface-edit.tsx
@@ -25,6 +25,7 @@ import { FieldLabel } from '~/ui/lib/FieldLabel'
 import * as MiniTable from '~/ui/lib/MiniTable'
 import { TextInputHint } from '~/ui/lib/TextInput'
 import { KEYS } from '~/ui/util/keys'
+import { validateIpNet } from '~/util/ip'
 import { links } from '~/util/links'
 
 type EditNetworkInterfaceFormProps = {
@@ -57,12 +58,11 @@ export function EditNetworkInterfaceForm({
 
   const transitIpsForm = useForm({ defaultValues: { transitIp: '' } })
 
-  const submitTransitIp = () => {
-    const transitIp = transitIpsForm.getValues('transitIp')
+  const submitTransitIp = transitIpsForm.handleSubmit(({ transitIp }) => {
     if (!transitIp) return
     form.setValue('transitIps', [...transitIps, transitIp])
     transitIpsForm.reset()
-  }
+  })
 
   return (
     <SideModalForm
@@ -92,7 +92,7 @@ export function EditNetworkInterfaceForm({
             Transit IPs
           </FieldLabel>
           <TextInputHint id="transitIp-help-text" className="mb-2">
-            Enter an IPv4 or IPv6 address.{' '}
+            An IP network, like 192.168.0.0/16.{' '}
             <a href={links.transitIpsDocs} target="_blank" rel="noreferrer">
               Learn more about transit IPs.
             </a>
@@ -107,10 +107,16 @@ export function EditNetworkInterfaceForm({
                 submitTransitIp()
               }
             }}
+            validate={(value) => {
+              const result = validateIpNet(value)
+              if (result.type === 'error') return result.message
+            }}
+            placeholder="Enter an IP network"
           />
         </div>
         <MiniTable.ClearAndAddButtons
           addButtonCopy="Add Transit IP"
+          // TODO: calling formState this way may not always trigger a render when it changes
           disableClear={!!transitIpsForm.formState.dirtyFields.transitIp}
           onClear={transitIpsForm.reset}
           onSubmit={submitTransitIp}

--- a/app/forms/network-interface-edit.tsx
+++ b/app/forms/network-interface-edit.tsx
@@ -60,10 +60,8 @@ export function EditNetworkInterfaceForm({
   const transitIpValue = transitIpsForm.watch('transitIp').trim()
 
   const submitTransitIp = transitIpsForm.handleSubmit(({ transitIp }) => {
-    // only add the IP if it isn't already in the list of transit IPs
-    if (!transitIps.includes(transitIp)) {
-      form.setValue('transitIps', [...transitIps, transitIp])
-    }
+    // validate has already checked to make sure it's not in the list
+    form.setValue('transitIps', [...transitIps, transitIp])
     transitIpsForm.reset()
   })
 
@@ -110,7 +108,12 @@ export function EditNetworkInterfaceForm({
                 submitTransitIp()
               }
             }}
-            validate={validateIpNet}
+            validate={(value) => {
+              const error = validateIpNet(value)
+              if (error) return error
+
+              if (transitIps.includes(value)) return 'Transit IP already in list'
+            }}
             placeholder="Enter an IP network"
           />
         </div>

--- a/app/forms/network-interface-edit.tsx
+++ b/app/forms/network-interface-edit.tsx
@@ -57,10 +57,13 @@ export function EditNetworkInterfaceForm({
   const transitIps = form.watch('transitIps') || []
 
   const transitIpsForm = useForm({ defaultValues: { transitIp: '' } })
+  const transitIpValue = transitIpsForm.watch('transitIp').trim()
 
   const submitTransitIp = transitIpsForm.handleSubmit(({ transitIp }) => {
-    if (!transitIp) return
-    form.setValue('transitIps', [...transitIps, transitIp])
+    // only add the IP if it isn't already in the list of transit IPs
+    if (!transitIps.includes(transitIp)) {
+      form.setValue('transitIps', [...transitIps, transitIp])
+    }
     transitIpsForm.reset()
   })
 
@@ -113,9 +116,8 @@ export function EditNetworkInterfaceForm({
         </div>
         <MiniTable.ClearAndAddButtons
           addButtonCopy="Add Transit IP"
-          // TODO: calling formState this way may not always trigger a render when it changes
-          disableClear={!!transitIpsForm.formState.dirtyFields.transitIp}
-          onClear={transitIpsForm.reset}
+          disableClear={!transitIpValue}
+          onClear={() => transitIpsForm.reset()}
           onSubmit={submitTransitIp}
         />
       </div>

--- a/app/forms/vpc-router-route-common.tsx
+++ b/app/forms/vpc-router-route-common.tsx
@@ -165,9 +165,8 @@ export const RouteFormFields = ({ form, disabled }: RouteFormFieldsProps) => {
               const result = validateIpNet(value)
               if (result.type === 'error') return result.message
             } else if (destType === 'ip') {
-              if (!validateIp(value).valid) {
-                return 'Not a valid IP address'
-              }
+              const result = validateIp(value)
+              if (result.type === 'error') return result.message
             }
           }}
         />
@@ -191,8 +190,9 @@ export const RouteFormFields = ({ form, disabled }: RouteFormFieldsProps) => {
         <TextField
           {...targetValueProps}
           validate={(value, formValues) => {
-            if (formValues.target.type === 'ip' && !validateIp(value).valid) {
-              return 'Not a valid IP address'
+            if (formValues.target.type === 'ip') {
+              const result = validateIp(value)
+              if (result.type === 'error') return result.message
             }
           }}
         />

--- a/app/forms/vpc-router-route-common.tsx
+++ b/app/forms/vpc-router-route-common.tsx
@@ -159,16 +159,10 @@ export const RouteFormFields = ({ form, disabled }: RouteFormFieldsProps) => {
       ) : (
         <TextField
           {...destinationValueProps}
-          validate={(value, formValues) => {
-            const destType = formValues.destination.type
-            if (destType === 'ip_net') {
-              const result = validateIpNet(value)
-              if (result.type === 'error') return result.message
-            } else if (destType === 'ip') {
-              const result = validateIp(value)
-              if (result.type === 'error') return result.message
-            }
-          }}
+          validate={(value, { destination }) =>
+            (destination.type === 'ip_net' && validateIpNet(value)) ||
+            (destination.type === 'ip' && validateIp(value))
+          }
         />
       )}
       <ListboxField
@@ -189,12 +183,7 @@ export const RouteFormFields = ({ form, disabled }: RouteFormFieldsProps) => {
       ) : (
         <TextField
           {...targetValueProps}
-          validate={(value, formValues) => {
-            if (formValues.target.type === 'ip') {
-              const result = validateIp(value)
-              if (result.type === 'error') return result.message
-            }
-          }}
+          validate={(value, { target }) => target.type === 'ip' && validateIp(value)}
         />
       )}
     </>

--- a/app/forms/vpc-router-route-common.tsx
+++ b/app/forms/vpc-router-route-common.tsx
@@ -123,6 +123,9 @@ export const RouteFormFields = ({ form, disabled }: RouteFormFieldsProps) => {
     required: true,
     disabled,
     description: destinationValueDescription[destinationType],
+    // need a default to prevent the text field validation function from
+    // sticking around when we switch to the combobox
+    validate: () => undefined,
   }
   const targetValueProps = {
     name: 'target.value' as const,
@@ -133,6 +136,9 @@ export const RouteFormFields = ({ form, disabled }: RouteFormFieldsProps) => {
     // 'internet_gateway' targetTypes can only have the value 'outbound', so we disable the field
     disabled: disabled || targetType === 'internet_gateway',
     description: targetValueDescription[targetType],
+    // need a default to prevent the text field validation function from
+    // sticking around when we switch to the combobox
+    validate: () => undefined,
   }
   return (
     <>
@@ -159,13 +165,11 @@ export const RouteFormFields = ({ form, disabled }: RouteFormFieldsProps) => {
       ) : (
         <TextField
           {...destinationValueProps}
-          // it seems this validation function stays registered on the combobox
-          // even when the type is switched to  subnet!!!?!?!?!?!
-          validate={
-            (value, { destination }) =>
-              (destination.type === 'ip_net' && validateIpNet(value)) ||
-              (destination.type === 'ip' && validateIp(value)) ||
-              undefined // false is invalid but true and undefined are valid?????
+          validate={(value, { destination }) =>
+            (destination.type === 'ip_net' && validateIpNet(value)) ||
+            (destination.type === 'ip' && validateIp(value)) ||
+            // false is invalid but true and undefined are valid so we need this
+            undefined
           }
         />
       )}

--- a/app/forms/vpc-router-route-common.tsx
+++ b/app/forms/vpc-router-route-common.tsx
@@ -159,9 +159,13 @@ export const RouteFormFields = ({ form, disabled }: RouteFormFieldsProps) => {
       ) : (
         <TextField
           {...destinationValueProps}
-          validate={(value, { destination }) =>
-            (destination.type === 'ip_net' && validateIpNet(value)) ||
-            (destination.type === 'ip' && validateIp(value))
+          // it seems this validation function stays registered on the combobox
+          // even when the type is switched to  subnet!!!?!?!?!?!
+          validate={
+            (value, { destination }) =>
+              (destination.type === 'ip_net' && validateIpNet(value)) ||
+              (destination.type === 'ip' && validateIp(value)) ||
+              undefined // false is invalid but true and undefined are valid?????
           }
         />
       )}
@@ -183,7 +187,9 @@ export const RouteFormFields = ({ form, disabled }: RouteFormFieldsProps) => {
       ) : (
         <TextField
           {...targetValueProps}
-          validate={(value, { target }) => target.type === 'ip' && validateIp(value)}
+          validate={(value, { target }) =>
+            (target.type === 'ip' && validateIp(value)) || undefined
+          }
         />
       )}
     </>

--- a/app/util/ip.spec.ts
+++ b/app/util/ip.spec.ts
@@ -1,0 +1,79 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
+ */
+
+import { expect, test } from 'vitest'
+
+import { validateIp } from './ip'
+
+// Small Rust project where we validate that the built-in Ipv4Addr and Ipv6Addr
+// and oxnet's Ipv4Net and Ipv6Net have the same validation behavior as our code.
+// https://github.com/oxidecomputer/test-ip-validation
+
+const v4 = ['123.4.56.7', '1.2.3.4']
+
+test.each(v4)('validateIp catches valid IPV4 / invalid IPV6: %s', (s) => {
+  expect(validateIp(s)).toStrictEqual({ isv4: true, isv6: false, valid: true })
+})
+
+const v6 = [
+  '2001:db8:3333:4444:5555:6666:7777:8888',
+  '2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF',
+  '::',
+  '2001:db8::',
+  '::1234:5678',
+  '2001:db8::1234:5678',
+  '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+  '::ffff:192.0.2.128',
+  '1:2:3:4:5:6:7:8',
+  '::ffff:10.0.0.1',
+  '::ffff:1.2.3.4',
+  '::ffff:0.0.0.0',
+  '1:2:3:4:5:6:77:88',
+  '::ffff:255.255.255.255',
+  'fe08::7:8',
+  'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
+]
+
+test.each(v6)('validateIp catches invalid IPV4 / valid IPV6: %s', (s) => {
+  expect(validateIp(s)).toStrictEqual({ isv4: false, isv6: true, valid: true })
+})
+
+const invalid = [
+  '',
+  '1',
+  'abc',
+  'a.b.c.d',
+  // some implementations (I think incorrectly) allow leading zeros but nexus does not
+  '01.102.103.104',
+  '127.0.0',
+  '127.0.0.1.',
+  '127.0.0.1 ',
+  ' 127.0.0.1',
+  '10002.3.4',
+  '1.2.3.4.5',
+  '256.0.0.0',
+  '260.0.0.0',
+  '256.1.1.1',
+  '2001:0db8:85a3:0000:0000:8a2e:0370:7334 ',
+  ' 2001:db8::',
+  '1:2:3:4:5:6:7:8:9',
+  '1:2:3:4:5:6::7:8',
+  ':1:2:3:4:5:6:7:8',
+  '1:2:3:4:5:6:7:8:',
+  '::1:2:3:4:5:6:7:8',
+  '1:2:3:4:5:6:7:8::',
+  '1:2:3:4:5:6:7:88888',
+  '2001:db8:3:4:5::192.0.2.33', // std::new::Ipv6Net allows this one
+  'fe08::7:8%',
+  'fe08::7:8i',
+  'fe08::7:8interface',
+]
+
+test.each(invalid)('validateIp catches invalid IP: %s', (s) => {
+  expect(validateIp(s)).toStrictEqual({ isv4: false, isv6: false, valid: false })
+})

--- a/app/util/ip.spec.ts
+++ b/app/util/ip.spec.ts
@@ -79,13 +79,16 @@ test.each(invalid)('parseIp catches invalid IP: %s', (s) => {
   expect(parseIp(s)).toStrictEqual({ type: 'error', message: 'Not a valid IP address' })
 })
 
-test.each(v4.map((ip) => ip + '/10'))('%s', (s) => {
+test.each([...v4.map((ip) => ip + '/10'), '1.1.1.1/04', '1.1.1.1/000004'])('%s', (s) => {
   expect(parseIpNet(s).type).toBe('v4')
 })
 
-test.each([...v6.map((ip) => ip + '/10'), '2001:db8::/128'])('%s', (s) => {
-  expect(parseIpNet(s).type).toBe('v6')
-})
+test.each([...v6.map((ip) => ip + '/10'), '2001:db8::/128', '2001:db8::/00004'])(
+  '%s',
+  (s) => {
+    expect(parseIpNet(s).type).toBe('v6')
+  }
+)
 
 test.each(invalid.map((ip) => ip + '/10'))('parseIpNet catches invalid value: %s', (s) => {
   expect(parseIpNet(s).type).toBe('error')

--- a/app/util/ip.spec.ts
+++ b/app/util/ip.spec.ts
@@ -17,7 +17,7 @@ import { validateIp, validateIpNet } from './ip'
 const v4 = ['123.4.56.7', '1.2.3.4']
 
 test.each(v4)('validateIp catches valid IPV4 / invalid IPV6: %s', (s) => {
-  expect(validateIp(s)).toStrictEqual({ isv4: true, isv6: false, valid: true })
+  expect(validateIp(s)).toStrictEqual({ type: 'v4', address: s })
 })
 
 const v6 = [
@@ -40,7 +40,7 @@ const v6 = [
 ]
 
 test.each(v6)('validateIp catches invalid IPV4 / valid IPV6: %s', (s) => {
-  expect(validateIp(s)).toStrictEqual({ isv4: false, isv6: true, valid: true })
+  expect(validateIp(s).type).toEqual('v6')
 })
 
 const invalid = [
@@ -75,7 +75,7 @@ const invalid = [
 ]
 
 test.each(invalid)('validateIp catches invalid IP: %s', (s) => {
-  expect(validateIp(s)).toStrictEqual({ isv4: false, isv6: false, valid: false })
+  expect(validateIp(s)).toStrictEqual({ type: 'error', message: 'Not a valid IP address' })
 })
 
 test.each(v4.map((ip) => ip + '/10'))('%s', (s) => {

--- a/app/util/ip.spec.ts
+++ b/app/util/ip.spec.ts
@@ -78,8 +78,12 @@ test.each(invalid)('validateIp catches invalid IP: %s', (s) => {
   expect(validateIp(s)).toStrictEqual({ isv4: false, isv6: false, valid: false })
 })
 
-test.each([...v4.concat(v6).map((ip) => ip + '/10'), '2001:db8::/128'])('%s', (s) => {
-  expect(validateIpNet(s).valid).toBe(true)
+test.each(v4.map((ip) => ip + '/10'))('%s', (s) => {
+  expect(validateIpNet(s).type).toBe('v4')
+})
+
+test.each([...v6.map((ip) => ip + '/10'), '2001:db8::/128'])('%s', (s) => {
+  expect(validateIpNet(s).type).toBe('v6')
 })
 
 test.each([
@@ -95,5 +99,5 @@ test.each([
   '192.168.0/24',
   '2001:db8::/129',
 ])('validateIpNet catches invalid value: %s', (s) => {
-  expect(validateIpNet(s).valid).toBe(false)
+  expect(validateIpNet(s).type).toBe('error')
 })

--- a/app/util/ip.spec.ts
+++ b/app/util/ip.spec.ts
@@ -8,7 +8,7 @@
 
 import { expect, test } from 'vitest'
 
-import { validateIp, validateIpNet } from './ip'
+import { parseIp, parseIpNet } from './ip'
 
 // Small Rust project where we validate that the built-in Ipv4Addr and Ipv6Addr
 // and oxnet's Ipv4Net and Ipv6Net have the same validation behavior as our code.
@@ -16,8 +16,8 @@ import { validateIp, validateIpNet } from './ip'
 
 const v4 = ['123.4.56.7', '1.2.3.4']
 
-test.each(v4)('validateIp catches valid IPV4 / invalid IPV6: %s', (s) => {
-  expect(validateIp(s)).toStrictEqual({ type: 'v4', address: s })
+test.each(v4)('parseIp catches valid IPV4 / invalid IPV6: %s', (s) => {
+  expect(parseIp(s)).toStrictEqual({ type: 'v4', address: s })
 })
 
 const v6 = [
@@ -39,8 +39,8 @@ const v6 = [
   'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
 ]
 
-test.each(v6)('validateIp catches invalid IPV4 / valid IPV6: %s', (s) => {
-  expect(validateIp(s).type).toEqual('v6')
+test.each(v6)('parseIp catches invalid IPV4 / valid IPV6: %s', (s) => {
+  expect(parseIp(s).type).toEqual('v6')
 })
 
 const invalid = [
@@ -75,24 +75,21 @@ const invalid = [
   'fe08::7:8interface',
 ]
 
-test.each(invalid)('validateIp catches invalid IP: %s', (s) => {
-  expect(validateIp(s)).toStrictEqual({ type: 'error', message: 'Not a valid IP address' })
+test.each(invalid)('parseIp catches invalid IP: %s', (s) => {
+  expect(parseIp(s)).toStrictEqual({ type: 'error', message: 'Not a valid IP address' })
 })
 
 test.each(v4.map((ip) => ip + '/10'))('%s', (s) => {
-  expect(validateIpNet(s).type).toBe('v4')
+  expect(parseIpNet(s).type).toBe('v4')
 })
 
 test.each([...v6.map((ip) => ip + '/10'), '2001:db8::/128'])('%s', (s) => {
-  expect(validateIpNet(s).type).toBe('v6')
+  expect(parseIpNet(s).type).toBe('v6')
 })
 
-test.each(invalid.map((ip) => ip + '/10'))(
-  'validateIpNet catches invalid value: %s',
-  (s) => {
-    expect(validateIpNet(s).type).toBe('error')
-  }
-)
+test.each(invalid.map((ip) => ip + '/10'))('parseIpNet catches invalid value: %s', (s) => {
+  expect(parseIpNet(s).type).toBe('error')
+})
 
 const nonsense = 'Must contain an IP address and a width, separated by a /'
 const badWidth = 'Width must be an integer'
@@ -113,6 +110,6 @@ test.each([
   ['fd::/a', badWidth],
   ['1.1.1.1/33', ipv4Width],
   ['fd::/129', ipv6Width],
-])('validateIpNet message: %s', (input, message) => {
-  expect(validateIpNet(input)).toEqual({ type: 'error', message })
+])('parseIpNet message: %s', (input, message) => {
+  expect(parseIpNet(input)).toEqual({ type: 'error', message })
 })

--- a/app/util/ip.spec.ts
+++ b/app/util/ip.spec.ts
@@ -8,7 +8,7 @@
 
 import { expect, test } from 'vitest'
 
-import { validateIp } from './ip'
+import { validateIp, validateIpNet } from './ip'
 
 // Small Rust project where we validate that the built-in Ipv4Addr and Ipv6Addr
 // and oxnet's Ipv4Net and Ipv6Net have the same validation behavior as our code.
@@ -76,4 +76,24 @@ const invalid = [
 
 test.each(invalid)('validateIp catches invalid IP: %s', (s) => {
   expect(validateIp(s)).toStrictEqual({ isv4: false, isv6: false, valid: false })
+})
+
+test.each([...v4.concat(v6).map((ip) => ip + '/10'), '2001:db8::/128'])('%s', (s) => {
+  expect(validateIpNet(s).valid).toBe(true)
+})
+
+test.each([
+  ...invalid.map((ip) => ip + '/10'),
+  'abc',
+  '',
+  '1.1.1.1',
+  '1.1.1.1/180',
+  '256.0.0.0/24',
+  '192.168.0.0/33',
+  '192.168.0.0/-1',
+  '192.168.0.0.0/24',
+  '192.168.0/24',
+  '2001:db8::/129',
+])('validateIpNet catches invalid value: %s', (s) => {
+  expect(validateIpNet(s).valid).toBe(false)
 })

--- a/app/util/ip.spec.ts
+++ b/app/util/ip.spec.ts
@@ -59,6 +59,7 @@ const invalid = [
   '256.0.0.0',
   '260.0.0.0',
   '256.1.1.1',
+  '192.168.0.0.0',
   '2001:0db8:85a3:0000:0000:8a2e:0370:7334 ',
   ' 2001:db8::',
   '1:2:3:4:5:6:7:8:9',
@@ -86,18 +87,32 @@ test.each([...v6.map((ip) => ip + '/10'), '2001:db8::/128'])('%s', (s) => {
   expect(validateIpNet(s).type).toBe('v6')
 })
 
+test.each(invalid.map((ip) => ip + '/10'))(
+  'validateIpNet catches invalid value: %s',
+  (s) => {
+    expect(validateIpNet(s).type).toBe('error')
+  }
+)
+
+const nonsense = 'Must contain an IP address and a width, separated by a /'
+const badWidth = 'Width must be an integer'
+const ipv4Width = 'Max width for IPv4 is 32'
+const ipv6Width = 'Max width for IPv6 is 128'
+
 test.each([
-  ...invalid.map((ip) => ip + '/10'),
-  'abc',
-  '',
-  '1.1.1.1',
-  '1.1.1.1/180',
-  '256.0.0.0/24',
-  '192.168.0.0/33',
-  '192.168.0.0/-1',
-  '192.168.0.0.0/24',
-  '192.168.0/24',
-  '2001:db8::/129',
-])('validateIpNet catches invalid value: %s', (s) => {
-  expect(validateIpNet(s).type).toBe('error')
+  ['', nonsense],
+  ['abc', nonsense],
+  ['/32', nonsense],
+  ['1.1.1.1', nonsense],
+  ['abc/2', nonsense],
+  ['1.1.1.1/', nonsense],
+  ['192.168.0.0.0/24', nonsense],
+  ['fd::/', nonsense],
+  ['1.1.1.1/a', badWidth],
+  ['192.168.0.0/-1', badWidth],
+  ['fd::/a', badWidth],
+  ['1.1.1.1/33', ipv4Width],
+  ['fd::/129', ipv6Width],
+])('validateIpNet message: %s', (input, message) => {
+  expect(validateIpNet(input)).toEqual({ type: 'error', message })
 })

--- a/app/util/ip.ts
+++ b/app/util/ip.ts
@@ -1,0 +1,23 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
+ */
+
+// Borrowed from Valibot. I tried some from Zod and an O'Reilly regex cookbook
+// but they didn't match results with std::net on simple test cases
+// https://github.com/fabian-hiller/valibot/blob/2554aea5/library/src/regex.ts#L43-L54
+
+const IPV4_REGEX =
+  /^(?:(?:[1-9]|1\d|2[0-4])?\d|25[0-5])(?:\.(?:(?:[1-9]|1\d|2[0-4])?\d|25[0-5])){3}$/u
+
+const IPV6_REGEX =
+  /^(?:(?:[\da-f]{1,4}:){7}[\da-f]{1,4}|(?:[\da-f]{1,4}:){1,7}:|(?:[\da-f]{1,4}:){1,6}:[\da-f]{1,4}|(?:[\da-f]{1,4}:){1,5}(?::[\da-f]{1,4}){1,2}|(?:[\da-f]{1,4}:){1,4}(?::[\da-f]{1,4}){1,3}|(?:[\da-f]{1,4}:){1,3}(?::[\da-f]{1,4}){1,4}|(?:[\da-f]{1,4}:){1,2}(?::[\da-f]{1,4}){1,5}|[\da-f]{1,4}:(?::[\da-f]{1,4}){1,6}|:(?:(?::[\da-f]{1,4}){1,7}|:)|fe80:(?::[\da-f]{0,4}){0,4}%[\da-z]+|::(?:f{4}(?::0{1,4})?:)?(?:(?:25[0-5]|(?:2[0-4]|1?\d)?\d)\.){3}(?:25[0-5]|(?:2[0-4]|1?\d)?\d)|(?:[\da-f]{1,4}:){1,4}:(?:(?:25[0-5]|(?:2[0-4]|1?\d)?\d)\.){3}(?:25[0-5]|(?:2[0-4]|1?\d)?\d))$/iu
+
+export function validateIp(ip: string) {
+  const isv4 = IPV4_REGEX.test(ip)
+  const isv6 = !isv4 && IPV6_REGEX.test(ip)
+  return { isv4, isv6, valid: isv4 || isv6 }
+}

--- a/app/util/ip.ts
+++ b/app/util/ip.ts
@@ -21,3 +21,38 @@ export function validateIp(ip: string) {
   const isv6 = !isv4 && IPV6_REGEX.test(ip)
   return { isv4, isv6, valid: isv4 || isv6 }
 }
+
+// Following oxnet:
+// https://github.com/oxidecomputer/oxnet/blob/7dacd265f1bcd0f8b47bd4805250c4f0812da206/src/ipnet.rs#L373-L385
+// https://github.com/oxidecomputer/oxnet/blob/7dacd265f1bcd0f8b47bd4805250c4f0812da206/src/ipnet.rs#L217-L223
+
+// TODO: change this terrible result type to include more info, including a message
+const invalidResult = { isv4: false, isv6: false, valid: false }
+
+export function validateIpNet(ipNet: string) {
+  // don't trim -- the form field should disallow whitespace
+  const splits = ipNet.split('/')
+  if (splits.length !== 2) {
+    return { isv4: false, isv6: false, valid: false }
+  }
+
+  const [addrStr, widthStr] = splits
+
+  const { isv4, isv6, valid } = validateIp(addrStr)
+
+  if (!/^\d+$/.test(widthStr)) {
+    // TODO: return message about bad width
+    return { isv4: false, isv6: false, valid: false }
+  }
+  const width = parseInt(widthStr, 10)
+
+  // validate width is a number and for IPv4 is under <= 32
+  // https://github.com/oxidecomputer/oxnet/blob/7dacd265f1bcd0f8b47bd4805250c4f0812da206/src/ipnet.rs#L206
+  // and for IPv6 is <= 128
+  // https://github.com/oxidecomputer/oxnet/blob/7dacd265f1bcd0f8b47bd4805250c4f0812da206/src/ipnet.rs#L443
+  // TODO: return message about bad width
+  if (isv4 && width > 32) return invalidResult
+  if (isv6 && width > 128) return invalidResult
+
+  return { isv4, isv6, valid }
+}

--- a/app/util/ip.ts
+++ b/app/util/ip.ts
@@ -34,20 +34,21 @@ type IpNetValidation =
   | { type: 'v4' | 'v6'; address: string; width: number }
   | { type: 'error'; message: string }
 
+const nonsenseError = {
+  type: 'error' as const,
+  message: 'Must contain an IP address and a width, separated by a /',
+}
+
 export function validateIpNet(ipNet: string): IpNetValidation {
   const splits = ipNet.split('/')
-  if (splits.length !== 2) {
-    return {
-      type: 'error',
-      message: 'Must contain an address and a width, separated by a /',
-    }
-  }
+  if (splits.length !== 2) return nonsenseError
 
   const [addrStr, widthStr] = splits
 
   const { type: ipType } = validateIp(addrStr)
 
-  if (ipType === 'error') return { type: 'error', message: 'Invalid IP address' }
+  if (ipType === 'error') return nonsenseError
+  if (widthStr.trim().length === 0) return nonsenseError
 
   if (!/^\d+$/.test(widthStr)) {
     return { type: 'error', message: 'Width must be an integer' }

--- a/app/util/str.spec.ts
+++ b/app/util/str.spec.ts
@@ -5,9 +5,9 @@
  *
  * Copyright Oxide Computer Company
  */
-import { describe, expect, it, test } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
-import { camelCase, capitalize, commaSeries, kebabCase, titleCase, validateIp } from './str'
+import { camelCase, capitalize, commaSeries, kebabCase, titleCase } from './str'
 
 describe('capitalize', () => {
   it('capitalizes the first letter', () => {
@@ -75,68 +75,4 @@ describe('titleCase', () => {
   it('doesn’t modify non-letter characters', () => {
     expect(titleCase('123 abc')).toBe('123 Abc')
   })
-})
-
-// Rust playground comparing results with std::net::{Ipv4Addr, Ipv6Addr}
-// https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=493b3345b9f6c0b1c8ee91834e99ef7b
-
-test.each(['123.4.56.7', '1.2.3.4'])(
-  'validateIp catches valid IPV4 / invalid IPV6: %s',
-  (s) => {
-    expect(validateIp(s)).toStrictEqual({ isv4: true, isv6: false, valid: true })
-  }
-)
-
-test.each([
-  '2001:db8:3333:4444:5555:6666:7777:8888',
-  '2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF',
-  '::',
-  '2001:db8::',
-  '::1234:5678',
-  '2001:db8::1234:5678',
-  '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
-  '::ffff:192.0.2.128',
-  '1:2:3:4:5:6:7:8',
-  '::ffff:10.0.0.1',
-  '::ffff:1.2.3.4',
-  '::ffff:0.0.0.0',
-  '1:2:3:4:5:6:77:88',
-  '::ffff:255.255.255.255',
-  'fe08::7:8',
-  'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
-])('validateIp catches invalid IPV4 / valid IPV6: %s', (s) => {
-  expect(validateIp(s)).toStrictEqual({ isv4: false, isv6: true, valid: true })
-})
-
-test.each([
-  '',
-  '1',
-  'abc',
-  'a.b.c.d',
-  // some implementations (I think incorrectly) allow leading zeros but nexus does not
-  '01.102.103.104',
-  '127.0.0',
-  '127.0.0.1.',
-  '127.0.0.1 ',
-  ' 127.0.0.1',
-  '10002.3.4',
-  '1.2.3.4.5',
-  '256.0.0.0',
-  '260.0.0.0',
-  '256.1.1.1',
-  '2001:0db8:85a3:0000:0000:8a2e:0370:7334 ',
-  ' 2001:db8::',
-  '1:2:3:4:5:6:7:8:9',
-  '1:2:3:4:5:6::7:8',
-  ':1:2:3:4:5:6:7:8',
-  '1:2:3:4:5:6:7:8:',
-  '::1:2:3:4:5:6:7:8',
-  '1:2:3:4:5:6:7:8::',
-  '1:2:3:4:5:6:7:88888',
-  '2001:db8:3:4:5::192.0.2.33', // std::new::Ipv6Net allows this one
-  'fe08::7:8%',
-  'fe08::7:8i',
-  'fe08::7:8interface',
-])('validateIp catches invalid IP: %s', (s) => {
-  expect(validateIp(s)).toStrictEqual({ isv4: false, isv6: false, valid: false })
 })

--- a/app/util/str.ts
+++ b/app/util/str.ts
@@ -50,22 +50,6 @@ export const titleCase = (text: string): string => {
   )
 }
 
-// Borrowed from Valibot. I tried some from Zod and an O'Reilly regex cookbook
-// but they didn't match results with std::new on simple test cases
-// https://github.com/fabian-hiller/valibot/blob/2554aea5/library/src/regex.ts#L43-L54
-
-const IPV4_REGEX =
-  /^(?:(?:[1-9]|1\d|2[0-4])?\d|25[0-5])(?:\.(?:(?:[1-9]|1\d|2[0-4])?\d|25[0-5])){3}$/u
-
-const IPV6_REGEX =
-  /^(?:(?:[\da-f]{1,4}:){7}[\da-f]{1,4}|(?:[\da-f]{1,4}:){1,7}:|(?:[\da-f]{1,4}:){1,6}:[\da-f]{1,4}|(?:[\da-f]{1,4}:){1,5}(?::[\da-f]{1,4}){1,2}|(?:[\da-f]{1,4}:){1,4}(?::[\da-f]{1,4}){1,3}|(?:[\da-f]{1,4}:){1,3}(?::[\da-f]{1,4}){1,4}|(?:[\da-f]{1,4}:){1,2}(?::[\da-f]{1,4}){1,5}|[\da-f]{1,4}:(?::[\da-f]{1,4}){1,6}|:(?:(?::[\da-f]{1,4}){1,7}|:)|fe80:(?::[\da-f]{0,4}){0,4}%[\da-z]+|::(?:f{4}(?::0{1,4})?:)?(?:(?:25[0-5]|(?:2[0-4]|1?\d)?\d)\.){3}(?:25[0-5]|(?:2[0-4]|1?\d)?\d)|(?:[\da-f]{1,4}:){1,4}:(?:(?:25[0-5]|(?:2[0-4]|1?\d)?\d)\.){3}(?:25[0-5]|(?:2[0-4]|1?\d)?\d))$/iu
-
-export const validateIp = (ip: string) => {
-  const isv4 = IPV4_REGEX.test(ip)
-  const isv6 = !isv4 && IPV6_REGEX.test(ip)
-  return { isv4, isv6, valid: isv4 || isv6 }
-}
-
 /**
  * Does a base64 string represent underlying data that's all zeros, i.e., does
  * it look like `AAAAAAAAAAAAAAAA==`?

--- a/mock-api/msw/handlers.ts
+++ b/mock-api/msw/handlers.ts
@@ -22,7 +22,8 @@ import {
 
 import { json, makeHandlers, type Json } from '~/api/__generated__/msw-handlers'
 import { instanceCan } from '~/api/util'
-import { commaSeries, validateIp } from '~/util/str'
+import { validateIp } from '~/util/ip'
+import { commaSeries } from '~/util/str'
 import { GiB } from '~/util/units'
 
 import { genCumulativeI64Data } from '../metrics'

--- a/mock-api/msw/handlers.ts
+++ b/mock-api/msw/handlers.ts
@@ -729,7 +729,10 @@ export const handlers = makeHandlers({
     const ranges = db.ipPoolRanges
       .filter((r) => r.ip_pool_id === pool.id)
       .map((r) => r.range)
-    const [ipv4Ranges, ipv6Ranges] = R.partition(ranges, (r) => validateIp(r.first).isv4)
+    const [ipv4Ranges, ipv6Ranges] = R.partition(
+      ranges,
+      (r) => validateIp(r.first).type === 'v4'
+    )
 
     // in the real backend there are also SNAT IPs, but we don't currently
     // represent those because they are not exposed through the API (except

--- a/mock-api/msw/handlers.ts
+++ b/mock-api/msw/handlers.ts
@@ -22,7 +22,7 @@ import {
 
 import { json, makeHandlers, type Json } from '~/api/__generated__/msw-handlers'
 import { instanceCan } from '~/api/util'
-import { validateIp } from '~/util/ip'
+import { parseIp } from '~/util/ip'
 import { commaSeries } from '~/util/str'
 import { GiB } from '~/util/units'
 
@@ -731,7 +731,7 @@ export const handlers = makeHandlers({
       .map((r) => r.range)
     const [ipv4Ranges, ipv6Ranges] = R.partition(
       ranges,
-      (r) => validateIp(r.first).type === 'v4'
+      (r) => parseIp(r.first).type === 'v4'
     )
 
     // in the real backend there are also SNAT IPs, but we don't currently

--- a/mock-api/msw/util.ts
+++ b/mock-api/msw/util.ts
@@ -25,7 +25,7 @@ import {
 } from '@oxide/api'
 
 import { json, type Json } from '~/api/__generated__/msw-handlers'
-import { validateIp } from '~/util/str'
+import { validateIp } from '~/util/ip'
 import { GiB, TiB } from '~/util/units'
 
 import type { DbRoleAssignmentResourceType } from '..'

--- a/mock-api/msw/util.ts
+++ b/mock-api/msw/util.ts
@@ -25,7 +25,7 @@ import {
 } from '@oxide/api'
 
 import { json, type Json } from '~/api/__generated__/msw-handlers'
-import { validateIp } from '~/util/ip'
+import { parseIp } from '~/util/ip'
 import { GiB, TiB } from '~/util/units'
 
 import type { DbRoleAssignmentResourceType } from '..'
@@ -384,14 +384,14 @@ export function requireRole(
 }
 
 const ipToBigInt = (ip: string): bigint =>
-  validateIp(ip).type === 'v4' ? new IPv4(ip).value : new IPv6(ip).value
+  parseIp(ip).type === 'v4' ? new IPv4(ip).value : new IPv6(ip).value
 
 export const ipRangeLen = ({ first, last }: IpRange) =>
   ipToBigInt(last) - ipToBigInt(first) + 1n
 
 function ipInRange(ip: string, { first, last }: IpRange): boolean {
-  const ipIsV4 = validateIp(ip).type === 'v4'
-  const rangeIsV4 = validateIp(first).type === 'v4'
+  const ipIsV4 = parseIp(ip).type === 'v4'
+  const rangeIsV4 = parseIp(first).type === 'v4'
 
   // if they're not the same version then definitely false
   if (ipIsV4 !== rangeIsV4) return false

--- a/mock-api/msw/util.ts
+++ b/mock-api/msw/util.ts
@@ -384,14 +384,14 @@ export function requireRole(
 }
 
 const ipToBigInt = (ip: string): bigint =>
-  validateIp(ip).isv4 ? new IPv4(ip).value : new IPv6(ip).value
+  validateIp(ip).type === 'v4' ? new IPv4(ip).value : new IPv6(ip).value
 
 export const ipRangeLen = ({ first, last }: IpRange) =>
   ipToBigInt(last) - ipToBigInt(first) + 1n
 
 function ipInRange(ip: string, { first, last }: IpRange): boolean {
-  const ipIsV4 = validateIp(ip).isv4
-  const rangeIsV4 = validateIp(first).isv4
+  const ipIsV4 = validateIp(ip).type === 'v4'
+  const rangeIsV4 = validateIp(first).type === 'v4'
 
   // if they're not the same version then definitely false
   if (ipIsV4 !== rangeIsV4) return false

--- a/test/e2e/firewall-rules.e2e.ts
+++ b/test/e2e/firewall-rules.e2e.ts
@@ -156,7 +156,8 @@ test('firewall rule form targets table', async ({ page }) => {
   await page.getByRole('link', { name: 'New rule' }).click()
 
   const targets = page.getByRole('table', { name: 'Targets' })
-  const targetVpcNameField = page.getByRole('combobox', { name: 'VPC name' }).nth(0)
+  const targetVpcNameField = page.getByRole('combobox', { name: 'VPC name' }).first()
+
   const addButton = page.getByRole('button', { name: 'Add target' })
 
   // add targets with overlapping names and types to test delete
@@ -202,6 +203,125 @@ test('firewall rule form targets table', async ({ page }) => {
 
   // we still have the IP target
   await expectRowVisible(targets, { Type: 'ip', Value: '192.168.0.1' })
+})
+
+test('firewall rule form target validation', async ({ page }) => {
+  await page.goto('/projects/mock-project/vpcs/mock-vpc/firewall-rules-new')
+
+  const addButton = page.getByRole('button', { name: 'Add target' })
+  const targets = page.getByRole('table', { name: 'Targets' })
+
+  const formModal = page.getByRole('dialog', { name: 'Add firewall rule' })
+  const nameError = formModal.getByText('Must end with a letter or number')
+
+  // Enter invalid VPC name
+  const vpcNameField = page.getByRole('combobox', { name: 'VPC name' }).first()
+  await vpcNameField.fill('ab-')
+  await addButton.click()
+  await expect(nameError).toBeVisible()
+
+  // Change to IP, error should disappear and value field should be empty
+  await selectOption(page, 'Target type', 'IP')
+  await expect(nameError).toBeHidden()
+  const ipField = page.getByRole('textbox', { name: 'IP address' })
+  await expect(ipField).toHaveValue('')
+
+  // Type '1', error should not appear immediately (back to validating onSubmit)
+  await ipField.fill('1')
+  const ipError = formModal.getByText('Not a valid IP address')
+  await expect(ipError).toBeHidden()
+  await addButton.click()
+  await expect(ipError).toBeVisible()
+
+  // Change back to VPC, enter valid value
+  await selectOption(page, 'Target type', 'VPC')
+  await expect(ipError).toBeHidden()
+  await expect(nameError).toBeHidden()
+  await vpcNameField.fill('abc')
+  await addButton.click()
+  await expectRowVisible(targets, { Type: 'vpc', Value: 'abc' })
+
+  // Switch to IP again
+  await selectOption(page, 'Target type', 'IP')
+  await ipField.fill('1')
+
+  // No error means we're back to validating on submit
+  await expect(ipError).toBeHidden()
+
+  // Hit submit to get error
+  await addButton.click()
+  await expect(ipError).toBeVisible()
+
+  // Fill out valid IP and submit
+  await ipField.fill('1.1.1.1')
+  await addButton.click()
+  await expect(ipError).toBeHidden()
+  await expectRowVisible(targets, { Type: 'ip', Value: '1.1.1.1' })
+})
+
+// This test may appear redundant because host and target share their logic, but
+// testing them separately is still valuable because we want to make sure we're
+// hooking up the shared code correctly and we don't break them if we refactor
+// that code.
+
+test('firewall rule form host validation', async ({ page }) => {
+  await page.goto('/projects/mock-project/vpcs/mock-vpc/firewall-rules-new')
+
+  const addButton = page.getByRole('button', { name: 'Add host filter' })
+  const hosts = page.getByRole('table', { name: 'Host filters' })
+
+  const formModal = page.getByRole('dialog', { name: 'Add firewall rule' })
+  const nameError = formModal.getByText('Must end with a letter or number')
+
+  // Enter invalid VPC name
+  const vpcNameField = page.getByRole('combobox', { name: 'VPC name' }).nth(1)
+  await vpcNameField.fill('ab-')
+  await addButton.click()
+  await expect(nameError).toBeVisible()
+
+  // Change to IP, error should disappear and value field should be empty
+  await selectOption(page, 'Host type', 'IP')
+  await expect(nameError).toBeHidden()
+  const ipField = page.getByRole('textbox', { name: 'IP address' })
+  await expect(ipField).toHaveValue('')
+
+  // Type '1', error should not appear immediately (back to validating onSubmit)
+  await ipField.fill('1')
+  const ipError = formModal.getByText('Not a valid IP address')
+  await expect(ipError).toBeHidden()
+  await addButton.click()
+  await expect(ipError).toBeVisible()
+
+  // Change back to VPC, enter valid value
+  await selectOption(page, 'Host type', 'VPC')
+  await expect(ipError).toBeHidden()
+  await expect(nameError).toBeHidden()
+  await vpcNameField.fill('abc')
+  await addButton.click()
+  await expectRowVisible(hosts, { Type: 'vpc', Value: 'abc' })
+
+  // use subnet to be slightly different from the target validation test
+
+  // Switch to IP subnet
+  await selectOption(page, 'Host type', 'IP subnet')
+  const ipSubnetField = page.getByRole('textbox', { name: 'IP network' })
+  await ipSubnetField.fill('1')
+
+  // No error means we're back to validating on submit
+  const ipNetError = formModal.getByText(
+    'Must contain an IP address and a width, separated by a /'
+  )
+  await expect(ipNetError).toBeHidden()
+
+  // Hit submit to get error
+  await addButton.click()
+  await expect(ipNetError).toBeVisible()
+
+  // Fill out valid IP and submit
+  await ipSubnetField.fill('1.1.1.1/1')
+  await addButton.click()
+  await expect(ipNetError).toBeHidden()
+  await expectRowVisible(hosts, { Type: 'ip_net', Value: '1.1.1.1/1' })
 })
 
 test('firewall rule form hosts table', async ({ page }) => {

--- a/test/e2e/firewall-rules.e2e.ts
+++ b/test/e2e/firewall-rules.e2e.ts
@@ -67,6 +67,10 @@ test('can create firewall rule', async ({ page }) => {
   await addPortButton.click()
   await expect(invalidPort).toBeVisible()
 
+  // test clear button
+  await page.getByRole('button', { name: 'Clear' }).nth(1).click()
+  await expect(portRangeField).toHaveValue('')
+
   await portRangeField.fill('123-456')
   await addPortButton.click()
   await expect(invalidPort).toBeHidden()
@@ -233,6 +237,10 @@ test('firewall rule form target validation', async ({ page }) => {
   await addButton.click()
   await expect(ipError).toBeVisible()
 
+  // test clear button
+  await page.getByRole('button', { name: 'Clear' }).first().click()
+  await expect(ipField).toHaveValue('')
+
   // Change back to VPC, enter valid value
   await selectOption(page, 'Target type', 'VPC')
   await expect(ipError).toBeHidden()
@@ -291,6 +299,10 @@ test('firewall rule form host validation', async ({ page }) => {
   await expect(ipError).toBeHidden()
   await addButton.click()
   await expect(ipError).toBeVisible()
+
+  // test clear button
+  await page.getByRole('button', { name: 'Clear' }).nth(2).click()
+  await expect(ipField).toHaveValue('')
 
   // Change back to VPC, enter valid value
   await selectOption(page, 'Host type', 'VPC')

--- a/test/e2e/instance-networking.e2e.ts
+++ b/test/e2e/instance-networking.e2e.ts
@@ -153,3 +153,60 @@ test('Instance networking tab — floating IPs', async ({ page }) => {
   // And that button should be enabled again
   await expect(attachFloatingIpButton).toBeEnabled()
 })
+
+test('Edit network interface - Transit IPs', async ({ page }) => {
+  await page.goto('/projects/mock-project/instances/db1/networking')
+
+  // Stop the instance to enable editing
+  await stopInstance(page)
+
+  await clickRowAction(page, 'my-nic', 'Edit')
+
+  const modal = page.getByRole('dialog', { name: 'Edit network interface' })
+  const transitIpField = modal.getByRole('textbox', { name: 'Transit IPs' })
+  const addTransitIpButton = modal.getByRole('button', { name: 'Add Transit IP' })
+  const clearButton = modal.getByRole('button', { name: 'Clear' })
+  const errorMessage = modal.getByText(
+    'Must contain an IP address and a width, separated by a /'
+  )
+  const transitIpsTable = modal.getByRole('table', { name: 'Transit IPs' })
+
+  // Type invalid value
+  await transitIpField.fill('invalid-ip')
+  await expect(errorMessage).toBeHidden()
+
+  // Hit add transit IP button
+  await addTransitIpButton.click()
+  await expect(errorMessage).toBeVisible()
+
+  // Clear the value and error
+  await clearButton.click()
+  await expect(errorMessage).toBeHidden()
+  await expect(transitIpField).toHaveValue('')
+
+  // Type bad value again
+  await transitIpField.fill('invalid-ip')
+  await expect(errorMessage).toBeHidden()
+
+  // Hit add again to get the error
+  await addTransitIpButton.click()
+  await expect(errorMessage).toBeVisible()
+
+  // Change to valid IP network
+  await transitIpField.fill('192.168.0.0/16')
+  await expect(errorMessage).toBeHidden()
+
+  // Submit and assert it's in the table
+  await addTransitIpButton.click()
+  await expect(transitIpField).toHaveValue('')
+  await expectRowVisible(transitIpsTable, { 'Transit IPs': '192.168.0.0/16' })
+
+  // Submit the form
+  await modal.getByRole('button', { name: 'Update network interface' }).click()
+
+  // Assert the transit IP is in the NICs table
+  const nicTable = page.getByRole('table', { name: 'Network interfaces' })
+  await expectRowVisible(nicTable, { 'Transit IPs': '172.30.0.0/22+1' })
+  // TODO: now hover over the +1 to see the one we just added
+  // await page.getByText('Other IPs 192.168.0.0/16')
+})

--- a/test/e2e/instance-networking.e2e.ts
+++ b/test/e2e/instance-networking.e2e.ts
@@ -215,6 +215,9 @@ test('Edit network interface - Transit IPs', async ({ page }) => {
   // Assert the transit IP is in the NICs table
   const nicTable = page.getByRole('table', { name: 'Network interfaces' })
   await expectRowVisible(nicTable, { 'Transit IPs': '172.30.0.0/22+1' })
-  // TODO: now hover over the +1 to see the one we just added
-  // await page.getByText('Other IPs 192.168.0.0/16')
+
+  await page.getByText('+1').hover()
+  await expect(
+    page.getByRole('tooltip', { name: 'Other transit IPs 192.168.0.0/16' })
+  ).toBeVisible()
 })

--- a/test/e2e/instance-networking.e2e.ts
+++ b/test/e2e/instance-networking.e2e.ts
@@ -201,6 +201,14 @@ test('Edit network interface - Transit IPs', async ({ page }) => {
   await expect(transitIpField).toHaveValue('')
   await expectRowVisible(transitIpsTable, { 'Transit IPs': '192.168.0.0/16' })
 
+  const dupeError = modal.getByText('Transit IP already in list')
+
+  // try to add the same one again to see the dupe message
+  await transitIpField.fill('192.168.0.0/16')
+  await expect(dupeError).toBeHidden()
+  await addTransitIpButton.click()
+  await expect(dupeError).toBeVisible()
+
   // Submit the form
   await modal.getByRole('button', { name: 'Update network interface' }).click()
 


### PR DESCRIPTION
Followup work for https://github.com/oxidecomputer/console/pull/2437#issuecomment-2362290469

- [x] Basic parsing-based validation with `ip-num`
- ~~Confirm Rust code has the same validation results (https://github.com/oxidecomputer/test-ip-validation)~~
- [x] Abandon `ip-num` because it does _not_ have the same validation results
- [x] Decide on return type of parser function
- [x] Figure out how this should be integrated into forms
- [x] Validate transit IP nets
- [x] Validate IPs and IP nets in route form
- [x] Validate IPs and IP nets in firewall rule form
- [x] Polish up weird behavior on host and target subform on type change, submit success, and clear
- [x] Write some e2e tests