### PR TITLE
Extract const for APPROXIMATELY_EVERYTHING

### DIFF
--- a/app/api/window.ts
+++ b/app/api/window.ts
@@ -60,9 +60,7 @@ if (typeof window !== 'undefined') {
       return data
     },
     schemas: async (search?: string) => {
-      const result = await api.methods.timeseriesSchemaList({
-        query: { limit: ALL_ISH },
-      })
+      const result = await api.methods.timeseriesSchemaList({ query: { limit: ALL_ISH } })
       const data = handleResult(result)
 
       let filtered = data.items

--- a/app/api/window.ts
+++ b/app/api/window.ts
@@ -9,7 +9,7 @@
 // Here we add some handy stuff to window for use from the browser JS console.
 // requests will use the session cookie, same as normal API calls
 
-import { APPROXIMATELY_EVERYTHING } from '~/util/consts'
+import { ALL_ISH } from '~/util/consts'
 
 import { type ApiResult } from './__generated__/http-client'
 import { api } from './client'
@@ -61,7 +61,7 @@ if (typeof window !== 'undefined') {
     },
     schemas: async (search?: string) => {
       const result = await api.methods.timeseriesSchemaList({
-        query: { limit: APPROXIMATELY_EVERYTHING },
+        query: { limit: ALL_ISH },
       })
       const data = handleResult(result)
 

--- a/app/api/window.ts
+++ b/app/api/window.ts
@@ -9,6 +9,8 @@
 // Here we add some handy stuff to window for use from the browser JS console.
 // requests will use the session cookie, same as normal API calls
 
+import { APPROXIMATELY_EVERYTHING } from '~/util/consts'
+
 import { type ApiResult } from './__generated__/http-client'
 import { api } from './client'
 
@@ -58,7 +60,9 @@ if (typeof window !== 'undefined') {
       return data
     },
     schemas: async (search?: string) => {
-      const result = await api.methods.timeseriesSchemaList({ query: { limit: 1000 } })
+      const result = await api.methods.timeseriesSchemaList({
+        query: { limit: APPROXIMATELY_EVERYTHING },
+      })
       const data = handleResult(result)
 
       let filtered = data.items

--- a/app/components/AttachEphemeralIpModal.tsx
+++ b/app/components/AttachEphemeralIpModal.tsx
@@ -15,13 +15,13 @@ import { useInstanceSelector } from '~/hooks/use-params'
 import { addToast } from '~/stores/toast'
 import { Badge } from '~/ui/lib/Badge'
 import { Modal } from '~/ui/lib/Modal'
-import { APPROXIMATELY_EVERYTHING } from '~/util/consts'
+import { ALL_ISH } from '~/util/consts'
 
 export const AttachEphemeralIpModal = ({ onDismiss }: { onDismiss: () => void }) => {
   const queryClient = useApiQueryClient()
   const { project, instance } = useInstanceSelector()
   const { data: siloPools } = usePrefetchedApiQuery('projectIpPoolList', {
-    query: { limit: APPROXIMATELY_EVERYTHING },
+    query: { limit: ALL_ISH },
   })
   const defaultPool = useMemo(
     () => siloPools?.items.find((pool) => pool.isDefault),

--- a/app/components/AttachEphemeralIpModal.tsx
+++ b/app/components/AttachEphemeralIpModal.tsx
@@ -15,12 +15,13 @@ import { useInstanceSelector } from '~/hooks/use-params'
 import { addToast } from '~/stores/toast'
 import { Badge } from '~/ui/lib/Badge'
 import { Modal } from '~/ui/lib/Modal'
+import { APPROXIMATELY_EVERYTHING } from '~/util/consts'
 
 export const AttachEphemeralIpModal = ({ onDismiss }: { onDismiss: () => void }) => {
   const queryClient = useApiQueryClient()
   const { project, instance } = useInstanceSelector()
   const { data: siloPools } = usePrefetchedApiQuery('projectIpPoolList', {
-    query: { limit: 1000 },
+    query: { limit: APPROXIMATELY_EVERYTHING },
   })
   const defaultPool = useMemo(
     () => siloPools?.items.find((pool) => pool.isDefault),

--- a/app/forms/disk-attach.tsx
+++ b/app/forms/disk-attach.tsx
@@ -12,7 +12,7 @@ import { useApiQuery, type ApiError } from '@oxide/api'
 import { ComboboxField } from '~/components/form/fields/ComboboxField'
 import { SideModalForm } from '~/components/form/SideModalForm'
 import { useProjectSelector } from '~/hooks/use-params'
-import { APPROXIMATELY_EVERYTHING } from '~/util/consts'
+import { ALL_ISH } from '~/util/consts'
 
 const defaultValues = { name: '' }
 
@@ -39,7 +39,7 @@ export function AttachDiskSideModalForm({
   const { project } = useProjectSelector()
 
   const { data } = useApiQuery('diskList', {
-    query: { project, limit: APPROXIMATELY_EVERYTHING },
+    query: { project, limit: ALL_ISH },
   })
   const detachedDisks =
     data?.items.filter(

--- a/app/forms/disk-attach.tsx
+++ b/app/forms/disk-attach.tsx
@@ -12,6 +12,7 @@ import { useApiQuery, type ApiError } from '@oxide/api'
 import { ComboboxField } from '~/components/form/fields/ComboboxField'
 import { SideModalForm } from '~/components/form/SideModalForm'
 import { useProjectSelector } from '~/hooks/use-params'
+import { APPROXIMATELY_EVERYTHING } from '~/util/consts'
 
 const defaultValues = { name: '' }
 
@@ -37,7 +38,9 @@ export function AttachDiskSideModalForm({
 }: AttachDiskProps) {
   const { project } = useProjectSelector()
 
-  const { data } = useApiQuery('diskList', { query: { project, limit: 1000 } })
+  const { data } = useApiQuery('diskList', {
+    query: { project, limit: APPROXIMATELY_EVERYTHING },
+  })
   const detachedDisks =
     data?.items.filter(
       (d) => d.state.state === 'detached' && !diskNamesToExclude.includes(d.name)

--- a/app/forms/firewall-rules-common.tsx
+++ b/app/forms/firewall-rules-common.tsx
@@ -38,6 +38,7 @@ import { Message } from '~/ui/lib/Message'
 import * as MiniTable from '~/ui/lib/MiniTable'
 import { TextInputHint } from '~/ui/lib/TextInput'
 import { KEYS } from '~/ui/util/keys'
+import { APPROXIMATELY_EVERYTHING } from '~/util/consts'
 import { links } from '~/util/links'
 import { capitalize } from '~/util/str'
 
@@ -244,12 +245,12 @@ export const CommonFields = ({ control, nameTaken, error }: CommonFieldsProps) =
   const {
     data: { items: instances },
   } = usePrefetchedApiQuery('instanceList', {
-    query: { project, limit: 1000 },
+    query: { project, limit: APPROXIMATELY_EVERYTHING },
   })
   const {
     data: { items: vpcs },
   } = usePrefetchedApiQuery('vpcList', {
-    query: { project, limit: 1000 },
+    query: { project, limit: APPROXIMATELY_EVERYTHING },
   })
   const {
     data: { items: vpcSubnets },

--- a/app/forms/firewall-rules-common.tsx
+++ b/app/forms/firewall-rules-common.tsx
@@ -244,14 +244,10 @@ export const CommonFields = ({ control, nameTaken, error }: CommonFieldsProps) =
   // prefetchedApiQueries below are prefetched in firewall-rules-create and -edit
   const {
     data: { items: instances },
-  } = usePrefetchedApiQuery('instanceList', {
-    query: { project, limit: ALL_ISH },
-  })
+  } = usePrefetchedApiQuery('instanceList', { query: { project, limit: ALL_ISH } })
   const {
     data: { items: vpcs },
-  } = usePrefetchedApiQuery('vpcList', {
-    query: { project, limit: ALL_ISH },
-  })
+  } = usePrefetchedApiQuery('vpcList', { query: { project, limit: ALL_ISH } })
   const {
     data: { items: vpcSubnets },
   } = usePrefetchedApiQuery('vpcSubnetList', { query: { project, vpc } })

--- a/app/forms/firewall-rules-common.tsx
+++ b/app/forms/firewall-rules-common.tsx
@@ -38,7 +38,7 @@ import { Message } from '~/ui/lib/Message'
 import * as MiniTable from '~/ui/lib/MiniTable'
 import { TextInputHint } from '~/ui/lib/TextInput'
 import { KEYS } from '~/ui/util/keys'
-import { APPROXIMATELY_EVERYTHING } from '~/util/consts'
+import { ALL_ISH } from '~/util/consts'
 import { links } from '~/util/links'
 import { capitalize } from '~/util/str'
 
@@ -245,12 +245,12 @@ export const CommonFields = ({ control, nameTaken, error }: CommonFieldsProps) =
   const {
     data: { items: instances },
   } = usePrefetchedApiQuery('instanceList', {
-    query: { project, limit: APPROXIMATELY_EVERYTHING },
+    query: { project, limit: ALL_ISH },
   })
   const {
     data: { items: vpcs },
   } = usePrefetchedApiQuery('vpcList', {
-    query: { project, limit: APPROXIMATELY_EVERYTHING },
+    query: { project, limit: ALL_ISH },
   })
   const {
     data: { items: vpcSubnets },

--- a/app/forms/firewall-rules-create.tsx
+++ b/app/forms/firewall-rules-create.tsx
@@ -58,12 +58,8 @@ CreateFirewallRuleForm.loader = async ({ params }: LoaderFunctionArgs) => {
   const { project, vpc } = getVpcSelector(params)
   await Promise.all([
     apiQueryClient.prefetchQuery('vpcFirewallRulesView', { query: { project, vpc } }),
-    apiQueryClient.prefetchQuery('instanceList', {
-      query: { project, limit: ALL_ISH },
-    }),
-    apiQueryClient.prefetchQuery('vpcList', {
-      query: { project, limit: ALL_ISH },
-    }),
+    apiQueryClient.prefetchQuery('instanceList', { query: { project, limit: ALL_ISH } }),
+    apiQueryClient.prefetchQuery('vpcList', { query: { project, limit: ALL_ISH } }),
     apiQueryClient.prefetchQuery('vpcSubnetList', { query: { project, vpc } }),
   ])
 

--- a/app/forms/firewall-rules-create.tsx
+++ b/app/forms/firewall-rules-create.tsx
@@ -20,7 +20,7 @@ import {
 import { SideModalForm } from '~/components/form/SideModalForm'
 import { getVpcSelector, useVpcSelector } from '~/hooks/use-params'
 import { addToast } from '~/stores/toast'
-import { APPROXIMATELY_EVERYTHING } from '~/util/consts'
+import { ALL_ISH } from '~/util/consts'
 import { pb } from '~/util/path-builder'
 
 import { CommonFields } from './firewall-rules-common'
@@ -59,10 +59,10 @@ CreateFirewallRuleForm.loader = async ({ params }: LoaderFunctionArgs) => {
   await Promise.all([
     apiQueryClient.prefetchQuery('vpcFirewallRulesView', { query: { project, vpc } }),
     apiQueryClient.prefetchQuery('instanceList', {
-      query: { project, limit: APPROXIMATELY_EVERYTHING },
+      query: { project, limit: ALL_ISH },
     }),
     apiQueryClient.prefetchQuery('vpcList', {
-      query: { project, limit: APPROXIMATELY_EVERYTHING },
+      query: { project, limit: ALL_ISH },
     }),
     apiQueryClient.prefetchQuery('vpcSubnetList', { query: { project, vpc } }),
   ])

--- a/app/forms/firewall-rules-create.tsx
+++ b/app/forms/firewall-rules-create.tsx
@@ -20,6 +20,7 @@ import {
 import { SideModalForm } from '~/components/form/SideModalForm'
 import { getVpcSelector, useVpcSelector } from '~/hooks/use-params'
 import { addToast } from '~/stores/toast'
+import { APPROXIMATELY_EVERYTHING } from '~/util/consts'
 import { pb } from '~/util/path-builder'
 
 import { CommonFields } from './firewall-rules-common'
@@ -57,8 +58,12 @@ CreateFirewallRuleForm.loader = async ({ params }: LoaderFunctionArgs) => {
   const { project, vpc } = getVpcSelector(params)
   await Promise.all([
     apiQueryClient.prefetchQuery('vpcFirewallRulesView', { query: { project, vpc } }),
-    apiQueryClient.prefetchQuery('instanceList', { query: { project, limit: 1000 } }),
-    apiQueryClient.prefetchQuery('vpcList', { query: { project, limit: 1000 } }),
+    apiQueryClient.prefetchQuery('instanceList', {
+      query: { project, limit: APPROXIMATELY_EVERYTHING },
+    }),
+    apiQueryClient.prefetchQuery('vpcList', {
+      query: { project, limit: APPROXIMATELY_EVERYTHING },
+    }),
     apiQueryClient.prefetchQuery('vpcSubnetList', { query: { project, vpc } }),
   ])
 

--- a/app/forms/firewall-rules-edit.tsx
+++ b/app/forms/firewall-rules-edit.tsx
@@ -23,6 +23,7 @@ import {
   useFirewallRuleSelector,
   useVpcSelector,
 } from '~/hooks/use-params'
+import { APPROXIMATELY_EVERYTHING } from '~/util/consts'
 import { invariant } from '~/util/invariant'
 import { pb } from '~/util/path-builder'
 
@@ -34,8 +35,12 @@ EditFirewallRuleForm.loader = async ({ params }: LoaderFunctionArgs) => {
 
   const [firewallRules] = await Promise.all([
     apiQueryClient.fetchQuery('vpcFirewallRulesView', { query: { project, vpc } }),
-    apiQueryClient.prefetchQuery('instanceList', { query: { project, limit: 1000 } }),
-    apiQueryClient.prefetchQuery('vpcList', { query: { project, limit: 1000 } }),
+    apiQueryClient.prefetchQuery('instanceList', {
+      query: { project, limit: APPROXIMATELY_EVERYTHING },
+    }),
+    apiQueryClient.prefetchQuery('vpcList', {
+      query: { project, limit: APPROXIMATELY_EVERYTHING },
+    }),
     apiQueryClient.prefetchQuery('vpcSubnetList', { query: { project, vpc } }),
   ])
 

--- a/app/forms/firewall-rules-edit.tsx
+++ b/app/forms/firewall-rules-edit.tsx
@@ -35,12 +35,8 @@ EditFirewallRuleForm.loader = async ({ params }: LoaderFunctionArgs) => {
 
   const [firewallRules] = await Promise.all([
     apiQueryClient.fetchQuery('vpcFirewallRulesView', { query: { project, vpc } }),
-    apiQueryClient.prefetchQuery('instanceList', {
-      query: { project, limit: ALL_ISH },
-    }),
-    apiQueryClient.prefetchQuery('vpcList', {
-      query: { project, limit: ALL_ISH },
-    }),
+    apiQueryClient.prefetchQuery('instanceList', { query: { project, limit: ALL_ISH } }),
+    apiQueryClient.prefetchQuery('vpcList', { query: { project, limit: ALL_ISH } }),
     apiQueryClient.prefetchQuery('vpcSubnetList', { query: { project, vpc } }),
   ])
 

--- a/app/forms/firewall-rules-edit.tsx
+++ b/app/forms/firewall-rules-edit.tsx
@@ -23,7 +23,7 @@ import {
   useFirewallRuleSelector,
   useVpcSelector,
 } from '~/hooks/use-params'
-import { APPROXIMATELY_EVERYTHING } from '~/util/consts'
+import { ALL_ISH } from '~/util/consts'
 import { invariant } from '~/util/invariant'
 import { pb } from '~/util/path-builder'
 
@@ -36,10 +36,10 @@ EditFirewallRuleForm.loader = async ({ params }: LoaderFunctionArgs) => {
   const [firewallRules] = await Promise.all([
     apiQueryClient.fetchQuery('vpcFirewallRulesView', { query: { project, vpc } }),
     apiQueryClient.prefetchQuery('instanceList', {
-      query: { project, limit: APPROXIMATELY_EVERYTHING },
+      query: { project, limit: ALL_ISH },
     }),
     apiQueryClient.prefetchQuery('vpcList', {
-      query: { project, limit: APPROXIMATELY_EVERYTHING },
+      query: { project, limit: ALL_ISH },
     }),
     apiQueryClient.prefetchQuery('vpcSubnetList', { query: { project, vpc } }),
   ])

--- a/app/forms/floating-ip-create.tsx
+++ b/app/forms/floating-ip-create.tsx
@@ -27,6 +27,7 @@ import { useProjectSelector } from '~/hooks/use-params'
 import { addToast } from '~/stores/toast'
 import { Badge } from '~/ui/lib/Badge'
 import { Message } from '~/ui/lib/Message'
+import { APPROXIMATELY_EVERYTHING } from '~/util/consts'
 import { pb } from '~/util/path-builder'
 
 const toListboxItem = (p: SiloIpPool) => {
@@ -58,7 +59,7 @@ export function CreateFloatingIpSideModalForm() {
   // Fetch 1000 to we can be sure to get them all. Don't bother prefetching
   // because the list is hidden under the Advanced accordion.
   const { data: allPools } = useApiQuery('projectIpPoolList', {
-    query: { limit: 1000 },
+    query: { limit: APPROXIMATELY_EVERYTHING },
   })
 
   const queryClient = useApiQueryClient()

--- a/app/forms/floating-ip-create.tsx
+++ b/app/forms/floating-ip-create.tsx
@@ -27,7 +27,7 @@ import { useProjectSelector } from '~/hooks/use-params'
 import { addToast } from '~/stores/toast'
 import { Badge } from '~/ui/lib/Badge'
 import { Message } from '~/ui/lib/Message'
-import { APPROXIMATELY_EVERYTHING } from '~/util/consts'
+import { ALL_ISH } from '~/util/consts'
 import { pb } from '~/util/path-builder'
 
 const toListboxItem = (p: SiloIpPool) => {
@@ -59,7 +59,7 @@ export function CreateFloatingIpSideModalForm() {
   // Fetch 1000 to we can be sure to get them all. Don't bother prefetching
   // because the list is hidden under the Advanced accordion.
   const { data: allPools } = useApiQuery('projectIpPoolList', {
-    query: { limit: APPROXIMATELY_EVERYTHING },
+    query: { limit: ALL_ISH },
   })
 
   const queryClient = useApiQueryClient()

--- a/app/forms/floating-ip-create.tsx
+++ b/app/forms/floating-ip-create.tsx
@@ -58,9 +58,7 @@ const defaultValues: Omit<FloatingIpCreate, 'ip'> = {
 export function CreateFloatingIpSideModalForm() {
   // Fetch 1000 to we can be sure to get them all. Don't bother prefetching
   // because the list is hidden under the Advanced accordion.
-  const { data: allPools } = useApiQuery('projectIpPoolList', {
-    query: { limit: ALL_ISH },
-  })
+  const { data: allPools } = useApiQuery('projectIpPoolList', { query: { limit: ALL_ISH } })
 
   const queryClient = useApiQueryClient()
   const projectSelector = useProjectSelector()

--- a/app/forms/instance-create.tsx
+++ b/app/forms/instance-create.tsx
@@ -72,7 +72,7 @@ import { Slash } from '~/ui/lib/Slash'
 import { Tabs } from '~/ui/lib/Tabs'
 import { TextInputHint } from '~/ui/lib/TextInput'
 import { TipIcon } from '~/ui/lib/TipIcon'
-import { APPROXIMATELY_EVERYTHING } from '~/util/consts'
+import { ALL_ISH } from '~/util/consts'
 import { readBlobAsBase64 } from '~/util/file'
 import { docLinks, links } from '~/util/links'
 import { nearest10 } from '~/util/math'
@@ -163,10 +163,10 @@ CreateInstanceForm.loader = async ({ params }: LoaderFunctionArgs) => {
     }),
     apiQueryClient.prefetchQuery('currentUserSshKeyList', {}),
     apiQueryClient.prefetchQuery('projectIpPoolList', {
-      query: { limit: APPROXIMATELY_EVERYTHING },
+      query: { limit: ALL_ISH },
     }),
     apiQueryClient.prefetchQuery('floatingIpList', {
-      query: { project, limit: APPROXIMATELY_EVERYTHING },
+      query: { project, limit: ALL_ISH },
     }),
   ])
   return null
@@ -213,7 +213,7 @@ export function CreateInstanceForm() {
 
   // projectIpPoolList fetches the pools linked to the current silo
   const { data: siloPools } = usePrefetchedApiQuery('projectIpPoolList', {
-    query: { limit: APPROXIMATELY_EVERYTHING },
+    query: { limit: ALL_ISH },
   })
   const defaultPool = useMemo(
     () => (siloPools ? siloPools.items.find((p) => p.isDefault)?.name : undefined),
@@ -632,7 +632,7 @@ const AdvancedAccordion = ({
 
   const { project } = useProjectSelector()
   const { data: floatingIpList } = usePrefetchedApiQuery('floatingIpList', {
-    query: { project, limit: APPROXIMATELY_EVERYTHING },
+    query: { project, limit: ALL_ISH },
   })
 
   // Filter out the IPs that are already attached to an instance

--- a/app/forms/instance-create.tsx
+++ b/app/forms/instance-create.tsx
@@ -162,12 +162,8 @@ CreateInstanceForm.loader = async ({ params }: LoaderFunctionArgs) => {
       query: { project, limit: DISK_FETCH_LIMIT },
     }),
     apiQueryClient.prefetchQuery('currentUserSshKeyList', {}),
-    apiQueryClient.prefetchQuery('projectIpPoolList', {
-      query: { limit: ALL_ISH },
-    }),
-    apiQueryClient.prefetchQuery('floatingIpList', {
-      query: { project, limit: ALL_ISH },
-    }),
+    apiQueryClient.prefetchQuery('projectIpPoolList', { query: { limit: ALL_ISH } }),
+    apiQueryClient.prefetchQuery('floatingIpList', { query: { project, limit: ALL_ISH } }),
   ])
   return null
 }

--- a/app/forms/instance-create.tsx
+++ b/app/forms/instance-create.tsx
@@ -72,6 +72,7 @@ import { Slash } from '~/ui/lib/Slash'
 import { Tabs } from '~/ui/lib/Tabs'
 import { TextInputHint } from '~/ui/lib/TextInput'
 import { TipIcon } from '~/ui/lib/TipIcon'
+import { APPROXIMATELY_EVERYTHING } from '~/util/consts'
 import { readBlobAsBase64 } from '~/util/file'
 import { docLinks, links } from '~/util/links'
 import { nearest10 } from '~/util/math'
@@ -161,8 +162,12 @@ CreateInstanceForm.loader = async ({ params }: LoaderFunctionArgs) => {
       query: { project, limit: DISK_FETCH_LIMIT },
     }),
     apiQueryClient.prefetchQuery('currentUserSshKeyList', {}),
-    apiQueryClient.prefetchQuery('projectIpPoolList', { query: { limit: 1000 } }),
-    apiQueryClient.prefetchQuery('floatingIpList', { query: { project, limit: 1000 } }),
+    apiQueryClient.prefetchQuery('projectIpPoolList', {
+      query: { limit: APPROXIMATELY_EVERYTHING },
+    }),
+    apiQueryClient.prefetchQuery('floatingIpList', {
+      query: { project, limit: APPROXIMATELY_EVERYTHING },
+    }),
   ])
   return null
 }
@@ -208,7 +213,7 @@ export function CreateInstanceForm() {
 
   // projectIpPoolList fetches the pools linked to the current silo
   const { data: siloPools } = usePrefetchedApiQuery('projectIpPoolList', {
-    query: { limit: 1000 },
+    query: { limit: APPROXIMATELY_EVERYTHING },
   })
   const defaultPool = useMemo(
     () => (siloPools ? siloPools.items.find((p) => p.isDefault)?.name : undefined),
@@ -627,7 +632,7 @@ const AdvancedAccordion = ({
 
   const { project } = useProjectSelector()
   const { data: floatingIpList } = usePrefetchedApiQuery('floatingIpList', {
-    query: { project, limit: 1000 },
+    query: { project, limit: APPROXIMATELY_EVERYTHING },
   })
 
   // Filter out the IPs that are already attached to an instance

--- a/app/forms/snapshot-create.tsx
+++ b/app/forms/snapshot-create.tsx
@@ -23,11 +23,12 @@ import { NameField } from '~/components/form/fields/NameField'
 import { SideModalForm } from '~/components/form/SideModalForm'
 import { useProjectSelector } from '~/hooks/use-params'
 import { addToast } from '~/stores/toast'
+import { APPROXIMATELY_EVERYTHING } from '~/util/consts'
 import { pb } from '~/util/path-builder'
 
 const useSnapshotDiskItems = (projectSelector: PP.Project) => {
   const { data: disks } = useApiQuery('diskList', {
-    query: { ...projectSelector, limit: 1000 },
+    query: { ...projectSelector, limit: APPROXIMATELY_EVERYTHING },
   })
   return (
     disks?.items

--- a/app/forms/snapshot-create.tsx
+++ b/app/forms/snapshot-create.tsx
@@ -23,12 +23,12 @@ import { NameField } from '~/components/form/fields/NameField'
 import { SideModalForm } from '~/components/form/SideModalForm'
 import { useProjectSelector } from '~/hooks/use-params'
 import { addToast } from '~/stores/toast'
-import { APPROXIMATELY_EVERYTHING } from '~/util/consts'
+import { ALL_ISH } from '~/util/consts'
 import { pb } from '~/util/path-builder'
 
 const useSnapshotDiskItems = (projectSelector: PP.Project) => {
   const { data: disks } = useApiQuery('diskList', {
-    query: { ...projectSelector, limit: APPROXIMATELY_EVERYTHING },
+    query: { ...projectSelector, limit: ALL_ISH },
   })
   return (
     disks?.items

--- a/app/pages/project/floating-ips/FloatingIpsPage.tsx
+++ b/app/pages/project/floating-ips/FloatingIpsPage.tsx
@@ -40,6 +40,7 @@ import { Modal } from '~/ui/lib/Modal'
 import { PageHeader, PageTitle } from '~/ui/lib/PageHeader'
 import { TableActions } from '~/ui/lib/Table'
 import { Tooltip } from '~/ui/lib/Tooltip'
+import { APPROXIMATELY_EVERYTHING } from '~/util/consts'
 import { docLinks } from '~/util/links'
 import { pb } from '~/util/path-builder'
 
@@ -63,7 +64,7 @@ FloatingIpsPage.loader = async ({ params }: LoaderFunctionArgs) => {
       query: { project },
     }),
     apiQueryClient
-      .fetchQuery('projectIpPoolList', { query: { limit: 1000 } })
+      .fetchQuery('projectIpPoolList', { query: { limit: APPROXIMATELY_EVERYTHING } })
       .then((pools) => {
         for (const pool of pools.items) {
           apiQueryClient.setQueryData(

--- a/app/pages/project/floating-ips/FloatingIpsPage.tsx
+++ b/app/pages/project/floating-ips/FloatingIpsPage.tsx
@@ -40,7 +40,7 @@ import { Modal } from '~/ui/lib/Modal'
 import { PageHeader, PageTitle } from '~/ui/lib/PageHeader'
 import { TableActions } from '~/ui/lib/Table'
 import { Tooltip } from '~/ui/lib/Tooltip'
-import { APPROXIMATELY_EVERYTHING } from '~/util/consts'
+import { ALL_ISH } from '~/util/consts'
 import { docLinks } from '~/util/links'
 import { pb } from '~/util/path-builder'
 
@@ -64,7 +64,7 @@ FloatingIpsPage.loader = async ({ params }: LoaderFunctionArgs) => {
       query: { project },
     }),
     apiQueryClient
-      .fetchQuery('projectIpPoolList', { query: { limit: APPROXIMATELY_EVERYTHING } })
+      .fetchQuery('projectIpPoolList', { query: { limit: ALL_ISH } })
       .then((pools) => {
         for (const pool of pools.items) {
           apiQueryClient.setQueryData(

--- a/app/pages/project/instances/instance/tabs/NetworkingTab.tsx
+++ b/app/pages/project/instances/instance/tabs/NetworkingTab.tsx
@@ -47,6 +47,7 @@ import { CreateButton } from '~/ui/lib/CreateButton'
 import { EmptyMessage } from '~/ui/lib/EmptyMessage'
 import { TableControls, TableEmptyBox, TableTitle } from '~/ui/lib/Table'
 import { TipIcon } from '~/ui/lib/TipIcon'
+import { APPROXIMATELY_EVERYTHING } from '~/util/consts'
 import { pb } from '~/util/path-builder'
 
 import { fancifyStates } from './common'
@@ -86,10 +87,10 @@ NetworkingTab.loader = async ({ params }: LoaderFunctionArgs) => {
   await Promise.all([
     apiQueryClient.prefetchQuery('instanceNetworkInterfaceList', {
       // we want this to cover all NICs; TODO: determine actual limit?
-      query: { project, instance, limit: 1000 },
+      query: { project, instance, limit: APPROXIMATELY_EVERYTHING },
     }),
     apiQueryClient.prefetchQuery('floatingIpList', {
-      query: { project, limit: 1000 },
+      query: { project, limit: APPROXIMATELY_EVERYTHING },
     }),
     // dupe of page-level fetch but that's fine, RQ dedupes
     apiQueryClient.prefetchQuery('instanceExternalIpList', {
@@ -104,7 +105,7 @@ NetworkingTab.loader = async ({ params }: LoaderFunctionArgs) => {
     }),
     // This is used in AttachEphemeralIpModal
     apiQueryClient.prefetchQuery('projectIpPoolList', {
-      query: { limit: 1000 },
+      query: { limit: APPROXIMATELY_EVERYTHING },
     }),
   ])
   return null
@@ -184,7 +185,7 @@ export function NetworkingTab() {
 
   // Fetch the floating IPs to show in the "Attach floating IP" modal
   const { data: ips } = usePrefetchedApiQuery('floatingIpList', {
-    query: { project, limit: 1000 },
+    query: { project, limit: APPROXIMATELY_EVERYTHING },
   })
   // Filter out the IPs that are already attached to an instance
   const availableIps = useMemo(() => ips.items.filter((ip) => !ip.instanceId), [ips])
@@ -266,7 +267,7 @@ export function NetworkingTab() {
   const columns = useColsWithActions(staticCols, makeActions)
 
   const nics = usePrefetchedApiQuery('instanceNetworkInterfaceList', {
-    query: { ...instanceSelector, limit: 1000 },
+    query: { ...instanceSelector, limit: APPROXIMATELY_EVERYTHING },
   }).data.items
 
   const tableInstance = useReactTable({

--- a/app/pages/project/instances/instance/tabs/NetworkingTab.tsx
+++ b/app/pages/project/instances/instance/tabs/NetworkingTab.tsx
@@ -47,7 +47,7 @@ import { CreateButton } from '~/ui/lib/CreateButton'
 import { EmptyMessage } from '~/ui/lib/EmptyMessage'
 import { TableControls, TableEmptyBox, TableTitle } from '~/ui/lib/Table'
 import { TipIcon } from '~/ui/lib/TipIcon'
-import { APPROXIMATELY_EVERYTHING } from '~/util/consts'
+import { ALL_ISH } from '~/util/consts'
 import { pb } from '~/util/path-builder'
 
 import { fancifyStates } from './common'
@@ -87,10 +87,10 @@ NetworkingTab.loader = async ({ params }: LoaderFunctionArgs) => {
   await Promise.all([
     apiQueryClient.prefetchQuery('instanceNetworkInterfaceList', {
       // we want this to cover all NICs; TODO: determine actual limit?
-      query: { project, instance, limit: APPROXIMATELY_EVERYTHING },
+      query: { project, instance, limit: ALL_ISH },
     }),
     apiQueryClient.prefetchQuery('floatingIpList', {
-      query: { project, limit: APPROXIMATELY_EVERYTHING },
+      query: { project, limit: ALL_ISH },
     }),
     // dupe of page-level fetch but that's fine, RQ dedupes
     apiQueryClient.prefetchQuery('instanceExternalIpList', {
@@ -105,7 +105,7 @@ NetworkingTab.loader = async ({ params }: LoaderFunctionArgs) => {
     }),
     // This is used in AttachEphemeralIpModal
     apiQueryClient.prefetchQuery('projectIpPoolList', {
-      query: { limit: APPROXIMATELY_EVERYTHING },
+      query: { limit: ALL_ISH },
     }),
   ])
   return null
@@ -185,7 +185,7 @@ export function NetworkingTab() {
 
   // Fetch the floating IPs to show in the "Attach floating IP" modal
   const { data: ips } = usePrefetchedApiQuery('floatingIpList', {
-    query: { project, limit: APPROXIMATELY_EVERYTHING },
+    query: { project, limit: ALL_ISH },
   })
   // Filter out the IPs that are already attached to an instance
   const availableIps = useMemo(() => ips.items.filter((ip) => !ip.instanceId), [ips])
@@ -267,7 +267,7 @@ export function NetworkingTab() {
   const columns = useColsWithActions(staticCols, makeActions)
 
   const nics = usePrefetchedApiQuery('instanceNetworkInterfaceList', {
-    query: { ...instanceSelector, limit: APPROXIMATELY_EVERYTHING },
+    query: { ...instanceSelector, limit: ALL_ISH },
   }).data.items
 
   const tableInstance = useReactTable({

--- a/app/pages/project/instances/instance/tabs/NetworkingTab.tsx
+++ b/app/pages/project/instances/instance/tabs/NetworkingTab.tsx
@@ -89,9 +89,7 @@ NetworkingTab.loader = async ({ params }: LoaderFunctionArgs) => {
       // we want this to cover all NICs; TODO: determine actual limit?
       query: { project, instance, limit: ALL_ISH },
     }),
-    apiQueryClient.prefetchQuery('floatingIpList', {
-      query: { project, limit: ALL_ISH },
-    }),
+    apiQueryClient.prefetchQuery('floatingIpList', { query: { project, limit: ALL_ISH } }),
     // dupe of page-level fetch but that's fine, RQ dedupes
     apiQueryClient.prefetchQuery('instanceExternalIpList', {
       path: { instance },
@@ -104,9 +102,7 @@ NetworkingTab.loader = async ({ params }: LoaderFunctionArgs) => {
       query: { project },
     }),
     // This is used in AttachEphemeralIpModal
-    apiQueryClient.prefetchQuery('projectIpPoolList', {
-      query: { limit: ALL_ISH },
-    }),
+    apiQueryClient.prefetchQuery('projectIpPoolList', { query: { limit: ALL_ISH } }),
   ])
   return null
 }

--- a/app/pages/system/networking/IpPoolPage.tsx
+++ b/app/pages/system/networking/IpPoolPage.tsx
@@ -46,7 +46,7 @@ import { Modal } from '~/ui/lib/Modal'
 import { PageHeader, PageTitle } from '~/ui/lib/PageHeader'
 import { Tabs } from '~/ui/lib/Tabs'
 import { TipIcon } from '~/ui/lib/TipIcon'
-import { APPROXIMATELY_EVERYTHING } from '~/util/consts'
+import { ALL_ISH } from '~/util/consts'
 import { docLinks } from '~/util/links'
 import { pb } from '~/util/path-builder'
 
@@ -372,9 +372,9 @@ function LinkSiloModal({ onDismiss }: { onDismiss: () => void }) {
 
   const linkedSilos = useApiQuery('ipPoolSiloList', {
     path: { pool },
-    query: { limit: APPROXIMATELY_EVERYTHING },
+    query: { limit: ALL_ISH },
   })
-  const allSilos = useApiQuery('siloList', { query: { limit: APPROXIMATELY_EVERYTHING } })
+  const allSilos = useApiQuery('siloList', { query: { limit: ALL_ISH } })
 
   // in order to get the list of remaining unlinked silos, we have to get the
   // list of all silos and remove the already linked ones

--- a/app/pages/system/networking/IpPoolPage.tsx
+++ b/app/pages/system/networking/IpPoolPage.tsx
@@ -46,6 +46,7 @@ import { Modal } from '~/ui/lib/Modal'
 import { PageHeader, PageTitle } from '~/ui/lib/PageHeader'
 import { Tabs } from '~/ui/lib/Tabs'
 import { TipIcon } from '~/ui/lib/TipIcon'
+import { APPROXIMATELY_EVERYTHING } from '~/util/consts'
 import { docLinks } from '~/util/links'
 import { pb } from '~/util/path-builder'
 
@@ -371,9 +372,9 @@ function LinkSiloModal({ onDismiss }: { onDismiss: () => void }) {
 
   const linkedSilos = useApiQuery('ipPoolSiloList', {
     path: { pool },
-    query: { limit: 1000 },
+    query: { limit: APPROXIMATELY_EVERYTHING },
   })
-  const allSilos = useApiQuery('siloList', { query: { limit: 1000 } })
+  const allSilos = useApiQuery('siloList', { query: { limit: APPROXIMATELY_EVERYTHING } })
 
   // in order to get the list of remaining unlinked silos, we have to get the
   // list of all silos and remove the already linked ones

--- a/app/pages/system/silos/SiloIpPoolsTab.tsx
+++ b/app/pages/system/silos/SiloIpPoolsTab.tsx
@@ -27,7 +27,7 @@ import { CreateButton } from '~/ui/lib/CreateButton'
 import { EmptyMessage } from '~/ui/lib/EmptyMessage'
 import { Message } from '~/ui/lib/Message'
 import { Modal } from '~/ui/lib/Modal'
-import { APPROXIMATELY_EVERYTHING } from '~/util/consts'
+import { ALL_ISH } from '~/util/consts'
 import { pb } from '~/util/path-builder'
 
 const EmptyState = () => (
@@ -63,7 +63,7 @@ export function SiloIpPoolsTab() {
   // default that fast anyway.
   const { data: allPools } = useApiQuery('siloIpPoolList', {
     path: { silo },
-    query: { limit: APPROXIMATELY_EVERYTHING },
+    query: { limit: ALL_ISH },
   })
 
   // used in change default confirm modal
@@ -199,9 +199,9 @@ function LinkPoolModal({ onDismiss }: { onDismiss: () => void }) {
 
   const linkedPools = useApiQuery('siloIpPoolList', {
     path: { silo },
-    query: { limit: APPROXIMATELY_EVERYTHING },
+    query: { limit: ALL_ISH },
   })
-  const allPools = useApiQuery('ipPoolList', { query: { limit: APPROXIMATELY_EVERYTHING } })
+  const allPools = useApiQuery('ipPoolList', { query: { limit: ALL_ISH } })
 
   // in order to get the list of remaining unlinked pools, we have to get the
   // list of all pools and remove the already linked ones

--- a/app/pages/system/silos/SiloIpPoolsTab.tsx
+++ b/app/pages/system/silos/SiloIpPoolsTab.tsx
@@ -27,6 +27,7 @@ import { CreateButton } from '~/ui/lib/CreateButton'
 import { EmptyMessage } from '~/ui/lib/EmptyMessage'
 import { Message } from '~/ui/lib/Message'
 import { Modal } from '~/ui/lib/Modal'
+import { APPROXIMATELY_EVERYTHING } from '~/util/consts'
 import { pb } from '~/util/path-builder'
 
 const EmptyState = () => (
@@ -62,7 +63,7 @@ export function SiloIpPoolsTab() {
   // default that fast anyway.
   const { data: allPools } = useApiQuery('siloIpPoolList', {
     path: { silo },
-    query: { limit: 1000 },
+    query: { limit: APPROXIMATELY_EVERYTHING },
   })
 
   // used in change default confirm modal
@@ -198,9 +199,9 @@ function LinkPoolModal({ onDismiss }: { onDismiss: () => void }) {
 
   const linkedPools = useApiQuery('siloIpPoolList', {
     path: { silo },
-    query: { limit: 1000 },
+    query: { limit: APPROXIMATELY_EVERYTHING },
   })
-  const allPools = useApiQuery('ipPoolList', { query: { limit: 1000 } })
+  const allPools = useApiQuery('ipPoolList', { query: { limit: APPROXIMATELY_EVERYTHING } })
 
   // in order to get the list of remaining unlinked pools, we have to get the
   // list of all pools and remove the already linked ones

--- a/app/util/consts.ts
+++ b/app/util/consts.ts
@@ -1,0 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
+ */
+
+export const APPROXIMATELY_EVERYTHING = 1000

--- a/app/util/consts.ts
+++ b/app/util/consts.ts
@@ -6,4 +6,5 @@
  * Copyright Oxide Computer Company
  */
 
-export const APPROXIMATELY_EVERYTHING = 1000
+// Used as a stand-in for "approximately everything" limit value in queries
+export const ALL_ISH = 1000


### PR DESCRIPTION
Extract the constant used in `limit: 1000` — our shorthand for "approximately everything" — into a new exported const, `APPROXIMATELY_EVERYTHING`.

Closes #2459 