### PR TITLE
Switch from double-slash to doc comment, for better help at callsites

### DIFF
--- a/app/util/consts.ts
+++ b/app/util/consts.ts
@@ -6,5 +6,5 @@
  * Copyright Oxide Computer Company
  */
 
-// Used as a stand-in for "approximately everything" limit value in queries
+/** Used as a stand-in for "approximately everything" limit value in queries */
 export const ALL_ISH = 1000


### PR DESCRIPTION
Should've entered this as a doc comment instead of two slashes.
<img width="688" alt="Screenshot 2024-09-20 at 2 39 33 PM" src="https://github.com/user-attachments/assets/91da34f0-d073-4bec-a108-13f4d674e117">
