### PR TITLE
Migrate disk selector in instance-create to Combobox

### DIFF
--- a/app/forms/instance-create.tsx
+++ b/app/forms/instance-create.tsx
@@ -37,6 +37,7 @@ import {
 import { AccordionItem } from '~/components/AccordionItem'
 import { DocsPopover } from '~/components/DocsPopover'
 import { CheckboxField } from '~/components/form/fields/CheckboxField'
+import { ComboboxField } from '~/components/form/fields/ComboboxField'
 import { DescriptionField } from '~/components/form/fields/DescriptionField'
 import { DiskSizeField } from '~/components/form/fields/DiskSizeField'
 import {
@@ -45,7 +46,6 @@ import {
 } from '~/components/form/fields/DisksTableField'
 import { FileField } from '~/components/form/fields/FileField'
 import { BootDiskImageSelectField as ImageSelectField } from '~/components/form/fields/ImageSelectField'
-import { ListboxField } from '~/components/form/fields/ListboxField'
 import { NameField } from '~/components/form/fields/NameField'
 import { NetworkInterfaceField } from '~/components/form/fields/NetworkInterfaceField'
 import { NumberField } from '~/components/form/fields/NumberField'
@@ -150,8 +150,6 @@ const baseDefaultValues: InstanceCreateInput = {
   externalIps: [{ type: 'ephemeral' }],
 }
 
-const DISK_FETCH_LIMIT = 1000
-
 CreateInstanceForm.loader = async ({ params }: LoaderFunctionArgs) => {
   const { project } = getProjectSelector(params)
   await Promise.all([
@@ -159,7 +157,7 @@ CreateInstanceForm.loader = async ({ params }: LoaderFunctionArgs) => {
     apiQueryClient.prefetchQuery('imageList', { query: { project } }),
     apiQueryClient.prefetchQuery('imageList', {}),
     apiQueryClient.prefetchQuery('diskList', {
-      query: { project, limit: DISK_FETCH_LIMIT },
+      query: { project, limit: ALL_ISH },
     }),
     apiQueryClient.prefetchQuery('currentUserSshKeyList', {}),
     apiQueryClient.prefetchQuery('projectIpPoolList', { query: { limit: ALL_ISH } }),
@@ -197,7 +195,7 @@ export function CreateInstanceForm() {
   const defaultImage = allImages[0]
 
   const allDisks = usePrefetchedApiQuery('diskList', {
-    query: { project, limit: DISK_FETCH_LIMIT },
+    query: { project, limit: ALL_ISH },
   }).data.items
   const disks = useMemo(
     () => allDisks.filter(diskCan.attach).map(({ name }) => ({ value: name, label: name })),
@@ -548,7 +546,7 @@ export function CreateInstanceForm() {
                 />
               </div>
             ) : (
-              <ListboxField
+              <ComboboxField
                 label="Disk"
                 name="diskSource"
                 description="Existing disks that are not attached to an instance"

--- a/test/e2e/instance-create.e2e.ts
+++ b/test/e2e/instance-create.e2e.ts
@@ -30,7 +30,7 @@ const selectAProjectImage = async (page: Page, name: string) => {
 
 const selectAnExistingDisk = async (page: Page, name: string) => {
   await page.getByRole('tab', { name: 'Existing disks' }).click()
-  await page.getByRole('button', { name: 'Select a disk' }).click()
+  await page.getByRole('combobox', { name: 'Disk' }).click()
   await page.getByRole('option', { name }).click()
 }
 


### PR DESCRIPTION
This swaps the boot disk selector for existing images from a Listbox to a Combobox. The two components expect the same props, so this is actually really easy. This is part of #1837.

<img width="534" alt="Screenshot 2024-09-23 at 5 04 03 PM" src="https://github.com/user-attachments/assets/ec36e108-ca07-466a-9510-ae7db7379175">

This also now moves from the one-off `DISK_FETCH_LIMIT` to `ALL_ISH`, both being equivalent to 1,000.

We'll have a more involved change to handle the image selector change (also for #1837), since we'll be moving from basic strings in the dropdown to using ReactNodes, so I'll pull all of that into a different PR.