### PR TITLE
Update id for combobox and listbox

### DIFF
--- a/app/ui/lib/Combobox.tsx
+++ b/app/ui/lib/Combobox.tsx
@@ -16,7 +16,7 @@ import {
 } from '@headlessui/react'
 import cn from 'classnames'
 import { matchSorter } from 'match-sorter'
-import { useState } from 'react'
+import { useId, useState } from 'react'
 
 import { SelectArrows6Icon } from '@oxide/design-system/icons/react'
 
@@ -34,7 +34,6 @@ export type ComboboxBaseProps = {
   placeholder?: string
   required?: boolean
   tooltipText?: string
-  ariaLabel?: string
   hideOptionalTag?: boolean
   /**
    * Pass in `allowArbitraryValues` as `true` when the user should be able to
@@ -69,7 +68,6 @@ export const Combobox = ({
   onChange,
   onInputChange,
   allowArbitraryValues = false,
-  ariaLabel,
   hideOptionalTag,
 }: ComboboxProps) => {
   const [query, setQuery] = useState(selected || '')
@@ -81,7 +79,7 @@ export const Combobox = ({
   })
 
   const zIndex = usePopoverZIndex()
-
+  const id = useId()
   return (
     <>
       <HCombobox
@@ -93,17 +91,18 @@ export const Combobox = ({
         disabled={disabled || isLoading}
       >
         {label && (
-          // TODO: FieldLabel needs a real ID
           <div className="mb-2">
             <FieldLabel
-              id="FieldLabel"
+              id={`${id}-label`}
               as="div"
               tip={tooltipText}
               optional={!required && !hideOptionalTag}
             >
               <Label>{label}</Label>
             </FieldLabel>
-            {description && <TextInputHint id="TextInputHint">{description}</TextInputHint>}
+            {description && (
+              <TextInputHint id={`${id}-help-text`}>{description}</TextInputHint>
+            )}
           </div>
         )}
         <ComboboxButton
@@ -120,7 +119,7 @@ export const Combobox = ({
           )}
         >
           <ComboboxInput
-            aria-label={ariaLabel}
+            aria-labelledby={`${id}-label ${id}-help-text`}
             displayValue={() => (selected ? selected : query)}
             onChange={(event) => {
               setQuery(event.target.value)

--- a/app/ui/lib/Combobox.tsx
+++ b/app/ui/lib/Combobox.tsx
@@ -34,6 +34,7 @@ export type ComboboxBaseProps = {
   placeholder?: string
   required?: boolean
   tooltipText?: string
+  ariaLabel?: string
   hideOptionalTag?: boolean
   /**
    * Pass in `allowArbitraryValues` as `true` when the user should be able to
@@ -68,6 +69,7 @@ export const Combobox = ({
   onChange,
   onInputChange,
   allowArbitraryValues = false,
+  ariaLabel,
   hideOptionalTag,
 }: ComboboxProps) => {
   const [query, setQuery] = useState(selected || '')
@@ -119,7 +121,7 @@ export const Combobox = ({
           )}
         >
           <ComboboxInput
-            aria-labelledby={`${id}-label ${id}-help-text`}
+            aria-label={ariaLabel}
             displayValue={() => (selected ? selected : query)}
             onChange={(event) => {
               setQuery(event.target.value)

--- a/app/ui/lib/Listbox.tsx
+++ b/app/ui/lib/Listbox.tsx
@@ -13,7 +13,7 @@ import {
   ListboxOptions,
 } from '@headlessui/react'
 import cn from 'classnames'
-import { type ReactNode, type Ref } from 'react'
+import { useId, type ReactNode, type Ref } from 'react'
 
 import { SelectArrows6Icon } from '@oxide/design-system/icons/react'
 
@@ -70,7 +70,7 @@ export const Listbox = <Value extends string = string>({
   const noItems = !isLoading && items.length === 0
   const isDisabled = disabled || noItems
   const zIndex = usePopoverZIndex()
-
+  const id = useId()
   return (
     <div className={cn('relative', className)}>
       <HListbox
@@ -86,14 +86,16 @@ export const Listbox = <Value extends string = string>({
             {label && (
               <div className="mb-2">
                 <FieldLabel
-                  id={``}
+                  id={`${id}-label`}
                   as="div"
                   tip={tooltipText}
                   optional={!required && !hideOptionalTag}
                 >
                   <Label>{label}</Label>
                 </FieldLabel>
-                {description && <TextInputHint id={``}>{description}</TextInputHint>}
+                {description && (
+                  <TextInputHint id={`${id}-help-text`}>{description}</TextInputHint>
+                )}
               </div>
             )}
             <ListboxButton


### PR DESCRIPTION
Closes #2417 

This follows the pattern for labels and description text in other form fields. I had trouble getting VoiceOver to read out the relevant content when I passed in specific strings for the `ariaLabel` prop (not changed in this PR), so I think it would be worth doing a deeper dive down the road. But this at least gets the Listbox and Combobox components to follow a similar pattern as the other form field inputs.