### PR TITLE
Give extra line in confirm modals its own paragraph

### DIFF
--- a/app/pages/project/instances/actions.tsx
+++ b/app/pages/project/instances/actions.tsx
@@ -83,11 +83,15 @@ export const useMakeInstanceActions = (
                 }),
               modalTitle: 'Confirm stop instance',
               modalContent: (
-                <p>
-                  Are you sure you want to stop <HL>{instance.name}</HL>? Stopped instances
-                  retain attached disks and IP addresses, but allocated CPU and memory are
-                  freed.
-                </p>
+                <div className="space-y-2">
+                  <p>
+                    Are you sure you want to stop <HL>{instance.name}</HL>?
+                  </p>
+                  <p>
+                    Stopped instances retain attached disks and IP addresses, but allocated
+                    CPU and memory are freed.
+                  </p>
+                </div>
               ),
               errorTitle: `Error stopping ${instance.name}`,
             })

--- a/app/stores/confirm-delete.tsx
+++ b/app/stores/confirm-delete.tsx
@@ -36,9 +36,10 @@ export const confirmDelete =
       actionConfig: {
         doAction: doDelete,
         modalContent: (
-          <p>
-            Are you sure you want to delete {displayLabel}? {extraContent}
-          </p>
+          <div className="space-y-2">
+            <p>Are you sure you want to delete {displayLabel}?</p>
+            {extraContent ? <p>{extraContent}</p> : null}
+          </div>
         ),
         errorTitle: 'Could not delete resource',
         modalTitle,


### PR DESCRIPTION
It might be nice to give these a slightly different visual treatment, like a top box, but it would also be noisy. This is a slight improvement on the status quo, so I'm going for it.

<img src="https://github.com/user-attachments/assets/2c51b5db-8e18-4f94-993b-2f7473d89563" width="480" alt="Screenshot 2024-10-03 at 11 17 08 AM">

<img src="https://github.com/user-attachments/assets/90e33034-eb91-49be-8233-cbdeae2101af" width="480" alt="Screenshot 2024-10-03 at 11 16 54 AM">

<img src="https://github.com/user-attachments/assets/5eb31a4c-1832-495b-9b83-6b8b23550b6e" width="480" alt="Screenshot 2024-10-03 at 11 16 33 AM">