### PR TITLE
Prototype: Client pagination, searching sorting and filtering

### DIFF
--- a/app/api/__generated__/validate.ts
+++ b/app/api/__generated__/validate.ts
@@ -8,9 +8,8 @@
  * Copyright Oxide Computer Company
  */
 
-import { z, ZodType } from 'zod'
-
-import { processResponseBody, uniqueItems } from './util'
+import { z, ZodType } from "zod";
+import { processResponseBody, uniqueItems } from "./util";
 
 /**
  * Zod only supports string enums at the moment. A previous issue was opened
@@ -20,10 +19,13 @@ import { processResponseBody, uniqueItems } from './util'
  * TODO: PR an update for zod to support other native enum types
  */
 const IntEnum = <T extends readonly number[]>(values: T) =>
-  z.number().refine((v) => values.includes(v)) as ZodType<T[number]>
+  z.number().refine((v) => values.includes(v)) as ZodType<T[number]>;
 
 /** Helper to ensure booleans provided as strings end up with the correct value */
-const SafeBoolean = z.preprocess((v) => (v === 'false' ? false : v), z.coerce.boolean())
+const SafeBoolean = z.preprocess(
+  (v) => (v === "false" ? false : v),
+  z.coerce.boolean(),
+);
 
 /**
  * An IPv4 subnet
@@ -35,9 +37,9 @@ export const Ipv4Net = z.preprocess(
   z
     .string()
     .regex(
-      /^(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\/([0-9]|1[0-9]|2[0-9]|3[0-2])$/
-    )
-)
+      /^(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\/([0-9]|1[0-9]|2[0-9]|3[0-2])$/,
+    ),
+);
 
 /**
  * An IPv6 subnet
@@ -49,11 +51,14 @@ export const Ipv6Net = z.preprocess(
   z
     .string()
     .regex(
-      /^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))\/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$/
-    )
-)
+      /^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))\/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$/,
+    ),
+);
 
-export const IpNet = z.preprocess(processResponseBody, z.union([Ipv4Net, Ipv6Net]))
+export const IpNet = z.preprocess(
+  processResponseBody,
+  z.union([Ipv4Net, Ipv6Net]),
+);
 
 /**
  * A name unique within the parent collection
@@ -67,14 +72,14 @@ export const Name = z.preprocess(
     .min(1)
     .max(63)
     .regex(
-      /^(?![0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)^[a-z]([a-zA-Z0-9-]*[a-zA-Z0-9]+)?$/
-    )
-)
+      /^(?![0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)^[a-z]([a-zA-Z0-9-]*[a-zA-Z0-9]+)?$/,
+    ),
+);
 
 export const NameOrId = z.preprocess(
   processResponseBody,
-  z.union([z.string().uuid(), Name])
-)
+  z.union([z.string().uuid(), Name]),
+);
 
 /**
  * An address tied to an address lot.
@@ -85,21 +90,24 @@ export const Address = z.preprocess(
     address: IpNet,
     addressLot: NameOrId,
     vlanId: z.number().min(0).max(65535).optional(),
-  })
-)
+  }),
+);
 
 /**
  * A set of addresses associated with a port configuration.
  */
 export const AddressConfig = z.preprocess(
   processResponseBody,
-  z.object({ addresses: Address.array() })
-)
+  z.object({ addresses: Address.array() }),
+);
 
 /**
  * The kind associated with an address lot.
  */
-export const AddressLotKind = z.preprocess(processResponseBody, z.enum(['infra', 'pool']))
+export const AddressLotKind = z.preprocess(
+  processResponseBody,
+  z.enum(["infra", "pool"]),
+);
 
 /**
  * Represents an address lot object, containing the id of the lot that can be used in other API calls.
@@ -113,8 +121,8 @@ export const AddressLot = z.preprocess(
     name: Name,
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
-  })
-)
+  }),
+);
 
 /**
  * An address lot block is a part of an address lot and contains a range of addresses. The range is inclusive.
@@ -125,24 +133,24 @@ export const AddressLotBlock = z.preprocess(
     firstAddress: z.string().ip(),
     id: z.string().uuid(),
     lastAddress: z.string().ip(),
-  })
-)
+  }),
+);
 
 /**
  * Parameters for creating an address lot block. Fist and last addresses are inclusive.
  */
 export const AddressLotBlockCreate = z.preprocess(
   processResponseBody,
-  z.object({ firstAddress: z.string().ip(), lastAddress: z.string().ip() })
-)
+  z.object({ firstAddress: z.string().ip(), lastAddress: z.string().ip() }),
+);
 
 /**
  * A single page of results
  */
 export const AddressLotBlockResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: AddressLotBlock.array(), nextPage: z.string().optional() })
-)
+  z.object({ items: AddressLotBlock.array(), nextPage: z.string().optional() }),
+);
 
 /**
  * Parameters for creating an address lot.
@@ -154,34 +162,37 @@ export const AddressLotCreate = z.preprocess(
     description: z.string(),
     kind: AddressLotKind,
     name: Name,
-  })
-)
+  }),
+);
 
 /**
  * An address lot and associated blocks resulting from creating an address lot.
  */
 export const AddressLotCreateResponse = z.preprocess(
   processResponseBody,
-  z.object({ blocks: AddressLotBlock.array(), lot: AddressLot })
-)
+  z.object({ blocks: AddressLotBlock.array(), lot: AddressLot }),
+);
 
 /**
  * A single page of results
  */
 export const AddressLotResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: AddressLot.array(), nextPage: z.string().optional() })
-)
+  z.object({ items: AddressLot.array(), nextPage: z.string().optional() }),
+);
 
-export const BgpMessageHistory = z.preprocess(processResponseBody, z.record(z.unknown()))
+export const BgpMessageHistory = z.preprocess(
+  processResponseBody,
+  z.record(z.unknown()),
+);
 
 /**
  * Identifies switch physical location
  */
 export const SwitchLocation = z.preprocess(
   processResponseBody,
-  z.enum(['switch0', 'switch1'])
-)
+  z.enum(["switch0", "switch1"]),
+);
 
 /**
  * BGP message history for a particular switch.
@@ -191,16 +202,16 @@ export const SwitchBgpHistory = z.preprocess(
   z.object({
     history: z.record(z.string().min(1), BgpMessageHistory),
     switch: SwitchLocation,
-  })
-)
+  }),
+);
 
 /**
  * BGP message history for rack switches.
  */
 export const AggregateBgpMessageHistory = z.preprocess(
   processResponseBody,
-  z.object({ switchHistories: SwitchBgpHistory.array() })
-)
+  z.object({ switchHistories: SwitchBgpHistory.array() }),
+);
 
 /**
  * Description of source IPs allowed to reach rack services.
@@ -208,10 +219,10 @@ export const AggregateBgpMessageHistory = z.preprocess(
 export const AllowedSourceIps = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ allow: z.enum(['any']) }),
-    z.object({ allow: z.enum(['list']), ips: IpNet.array() }),
-  ])
-)
+    z.object({ allow: z.enum(["any"]) }),
+    z.object({ allow: z.enum(["list"]), ips: IpNet.array() }),
+  ]),
+);
 
 /**
  * Allowlist of IPs or subnets that can make requests to user-facing services.
@@ -222,16 +233,16 @@ export const AllowList = z.preprocess(
     allowedIps: AllowedSourceIps,
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
-  })
-)
+  }),
+);
 
 /**
  * Parameters for updating allowed source IPs
  */
 export const AllowListUpdate = z.preprocess(
   processResponseBody,
-  z.object({ allowedIps: AllowedSourceIps })
-)
+  z.object({ allowedIps: AllowedSourceIps }),
+);
 
 /**
  * Authorization scope for a timeseries.
@@ -240,32 +251,36 @@ export const AllowListUpdate = z.preprocess(
  */
 export const AuthzScope = z.preprocess(
   processResponseBody,
-  z.enum(['fleet', 'silo', 'project', 'viewable_to_all'])
-)
+  z.enum(["fleet", "silo", "project", "viewable_to_all"]),
+);
 
 /**
  * Properties that uniquely identify an Oxide hardware component
  */
 export const Baseboard = z.preprocess(
   processResponseBody,
-  z.object({ part: z.string(), revision: z.number(), serial: z.string() })
-)
+  z.object({
+    part: z.string(),
+    revision: z.number().min(0).max(4294967295),
+    serial: z.string(),
+  }),
+);
 
 /**
  * BFD connection mode.
  */
+export const BfdModeEnumArray = ["single_hop", "multi_hop"] as const;
 export const BfdMode = z.preprocess(
   processResponseBody,
-  z.enum(['single_hop', 'multi_hop'])
-)
-
+  z.enum(BfdModeEnumArray),
+);
 /**
  * Information needed to disable a BFD session
  */
 export const BfdSessionDisable = z.preprocess(
   processResponseBody,
-  z.object({ remote: z.string().ip(), switch: Name })
-)
+  z.object({ remote: z.string().ip(), switch: Name }),
+);
 
 /**
  * Information about a bidirectional forwarding detection (BFD) session.
@@ -279,13 +294,13 @@ export const BfdSessionEnable = z.preprocess(
     remote: z.string().ip(),
     requiredRx: z.number().min(0),
     switch: Name,
-  })
-)
+  }),
+);
 
 export const BfdState = z.preprocess(
   processResponseBody,
-  z.enum(['admin_down', 'down', 'init', 'up'])
-)
+  z.enum(["admin_down", "down", "init", "up"]),
+);
 
 export const BfdStatus = z.preprocess(
   processResponseBody,
@@ -297,8 +312,8 @@ export const BfdStatus = z.preprocess(
     requiredRx: z.number().min(0),
     state: BfdState,
     switch: Name,
-  })
-)
+  }),
+);
 
 /**
  * Represents a BGP announce set by id. The id can be used with other API calls to view and manage the announce set.
@@ -311,16 +326,16 @@ export const BgpAnnounceSet = z.preprocess(
     name: Name,
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
-  })
-)
+  }),
+);
 
 /**
  * A BGP announcement tied to a particular address lot block.
  */
 export const BgpAnnouncementCreate = z.preprocess(
   processResponseBody,
-  z.object({ addressLotBlock: NameOrId, network: IpNet })
-)
+  z.object({ addressLotBlock: NameOrId, network: IpNet }),
+);
 
 /**
  * Parameters for creating a named set of BGP announcements.
@@ -331,8 +346,8 @@ export const BgpAnnounceSetCreate = z.preprocess(
     announcement: BgpAnnouncementCreate.array(),
     description: z.string(),
     name: Name,
-  })
-)
+  }),
+);
 
 /**
  * A BGP announcement tied to an address lot block.
@@ -343,8 +358,8 @@ export const BgpAnnouncement = z.preprocess(
     addressLotBlockId: z.string().uuid(),
     announceSetId: z.string().uuid(),
     network: IpNet,
-  })
-)
+  }),
+);
 
 /**
  * A base BGP configuration.
@@ -359,8 +374,8 @@ export const BgpConfig = z.preprocess(
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
     vrf: z.string().optional(),
-  })
-)
+  }),
+);
 
 /**
  * Parameters for creating a BGP configuration. This includes and autonomous system number (ASN) and a virtual routing and forwarding (VRF) identifier.
@@ -373,16 +388,16 @@ export const BgpConfigCreate = z.preprocess(
     description: z.string(),
     name: Name,
     vrf: Name.optional(),
-  })
-)
+  }),
+);
 
 /**
  * A single page of results
  */
 export const BgpConfigResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: BgpConfig.array(), nextPage: z.string().optional() })
-)
+  z.object({ items: BgpConfig.array(), nextPage: z.string().optional() }),
+);
 
 /**
  * A route imported from a BGP peer.
@@ -391,11 +406,11 @@ export const BgpImportedRouteIpv4 = z.preprocess(
   processResponseBody,
   z.object({
     id: z.number().min(0).max(4294967295),
-    nexthop: z.string().ip({ version: 'v4' }),
+    nexthop: z.string().ip({ version: "v4" }),
     prefix: Ipv4Net,
     switch: SwitchLocation,
-  })
-)
+  }),
+);
 
 /**
  * Define policy relating to the import and export of prefixes from a BGP peer.
@@ -403,10 +418,10 @@ export const BgpImportedRouteIpv4 = z.preprocess(
 export const ImportExportPolicy = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ type: z.enum(['no_filtering']) }),
-    z.object({ type: z.enum(['allow']), value: IpNet.array() }),
-  ])
-)
+    z.object({ type: z.enum(["no_filtering"]) }),
+    z.object({ type: z.enum(["allow"]), value: IpNet.array() }),
+  ]),
+);
 
 /**
  * A BGP peer configuration for an interface. Includes the set of announcements that will be advertised to the peer identified by `addr`. The `bgp_config` parameter is a reference to global BGP parameters. The `interface_name` indicates what interface the peer should be contacted on.
@@ -432,13 +447,13 @@ export const BgpPeer = z.preprocess(
     multiExitDiscriminator: z.number().min(0).max(4294967295).optional(),
     remoteAsn: z.number().min(0).max(4294967295).optional(),
     vlanId: z.number().min(0).max(65535).optional(),
-  })
-)
+  }),
+);
 
 export const BgpPeerConfig = z.preprocess(
   processResponseBody,
-  z.object({ peers: BgpPeer.array() })
-)
+  z.object({ peers: BgpPeer.array() }),
+);
 
 /**
  * The current state of a BGP peer.
@@ -446,15 +461,15 @@ export const BgpPeerConfig = z.preprocess(
 export const BgpPeerState = z.preprocess(
   processResponseBody,
   z.enum([
-    'idle',
-    'connect',
-    'active',
-    'open_sent',
-    'open_confirm',
-    'session_setup',
-    'established',
-  ])
-)
+    "idle",
+    "connect",
+    "active",
+    "open_sent",
+    "open_confirm",
+    "session_setup",
+    "established",
+  ]),
+);
 
 /**
  * The current status of a BGP peer.
@@ -468,8 +483,8 @@ export const BgpPeerStatus = z.preprocess(
     state: BgpPeerState,
     stateDurationMillis: z.number().min(0),
     switch: SwitchLocation,
-  })
-)
+  }),
+);
 
 /**
  * A type storing a range over `T`.
@@ -479,11 +494,11 @@ export const BgpPeerStatus = z.preprocess(
 export const BinRangedouble = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ end: z.number(), type: z.enum(['range_to']) }),
-    z.object({ end: z.number(), start: z.number(), type: z.enum(['range']) }),
-    z.object({ start: z.number(), type: z.enum(['range_from']) }),
-  ])
-)
+    z.object({ end: z.number(), type: z.enum(["range_to"]) }),
+    z.object({ end: z.number(), start: z.number(), type: z.enum(["range"]) }),
+    z.object({ start: z.number(), type: z.enum(["range_from"]) }),
+  ]),
+);
 
 /**
  * A type storing a range over `T`.
@@ -493,11 +508,11 @@ export const BinRangedouble = z.preprocess(
 export const BinRangefloat = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ end: z.number(), type: z.enum(['range_to']) }),
-    z.object({ end: z.number(), start: z.number(), type: z.enum(['range']) }),
-    z.object({ start: z.number(), type: z.enum(['range_from']) }),
-  ])
-)
+    z.object({ end: z.number(), type: z.enum(["range_to"]) }),
+    z.object({ end: z.number(), start: z.number(), type: z.enum(["range"]) }),
+    z.object({ start: z.number(), type: z.enum(["range_from"]) }),
+  ]),
+);
 
 /**
  * A type storing a range over `T`.
@@ -507,15 +522,21 @@ export const BinRangefloat = z.preprocess(
 export const BinRangeint16 = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ end: z.number().min(-32767).max(32767), type: z.enum(['range_to']) }),
+    z.object({
+      end: z.number().min(-32767).max(32767),
+      type: z.enum(["range_to"]),
+    }),
     z.object({
       end: z.number().min(-32767).max(32767),
       start: z.number().min(-32767).max(32767),
-      type: z.enum(['range']),
+      type: z.enum(["range"]),
     }),
-    z.object({ start: z.number().min(-32767).max(32767), type: z.enum(['range_from']) }),
-  ])
-)
+    z.object({
+      start: z.number().min(-32767).max(32767),
+      type: z.enum(["range_from"]),
+    }),
+  ]),
+);
 
 /**
  * A type storing a range over `T`.
@@ -527,19 +548,19 @@ export const BinRangeint32 = z.preprocess(
   z.union([
     z.object({
       end: z.number().min(-2147483647).max(2147483647),
-      type: z.enum(['range_to']),
+      type: z.enum(["range_to"]),
     }),
     z.object({
       end: z.number().min(-2147483647).max(2147483647),
       start: z.number().min(-2147483647).max(2147483647),
-      type: z.enum(['range']),
+      type: z.enum(["range"]),
     }),
     z.object({
       start: z.number().min(-2147483647).max(2147483647),
-      type: z.enum(['range_from']),
+      type: z.enum(["range_from"]),
     }),
-  ])
-)
+  ]),
+);
 
 /**
  * A type storing a range over `T`.
@@ -549,11 +570,11 @@ export const BinRangeint32 = z.preprocess(
 export const BinRangeint64 = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ end: z.number(), type: z.enum(['range_to']) }),
-    z.object({ end: z.number(), start: z.number(), type: z.enum(['range']) }),
-    z.object({ start: z.number(), type: z.enum(['range_from']) }),
-  ])
-)
+    z.object({ end: z.number(), type: z.enum(["range_to"]) }),
+    z.object({ end: z.number(), start: z.number(), type: z.enum(["range"]) }),
+    z.object({ start: z.number(), type: z.enum(["range_from"]) }),
+  ]),
+);
 
 /**
  * A type storing a range over `T`.
@@ -563,15 +584,21 @@ export const BinRangeint64 = z.preprocess(
 export const BinRangeint8 = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ end: z.number().min(-127).max(127), type: z.enum(['range_to']) }),
+    z.object({
+      end: z.number().min(-127).max(127),
+      type: z.enum(["range_to"]),
+    }),
     z.object({
       end: z.number().min(-127).max(127),
       start: z.number().min(-127).max(127),
-      type: z.enum(['range']),
+      type: z.enum(["range"]),
     }),
-    z.object({ start: z.number().min(-127).max(127), type: z.enum(['range_from']) }),
-  ])
-)
+    z.object({
+      start: z.number().min(-127).max(127),
+      type: z.enum(["range_from"]),
+    }),
+  ]),
+);
 
 /**
  * A type storing a range over `T`.
@@ -581,15 +608,18 @@ export const BinRangeint8 = z.preprocess(
 export const BinRangeuint16 = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ end: z.number().min(0).max(65535), type: z.enum(['range_to']) }),
+    z.object({ end: z.number().min(0).max(65535), type: z.enum(["range_to"]) }),
     z.object({
       end: z.number().min(0).max(65535),
       start: z.number().min(0).max(65535),
-      type: z.enum(['range']),
+      type: z.enum(["range"]),
     }),
-    z.object({ start: z.number().min(0).max(65535), type: z.enum(['range_from']) }),
-  ])
-)
+    z.object({
+      start: z.number().min(0).max(65535),
+      type: z.enum(["range_from"]),
+    }),
+  ]),
+);
 
 /**
  * A type storing a range over `T`.
@@ -599,15 +629,21 @@ export const BinRangeuint16 = z.preprocess(
 export const BinRangeuint32 = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ end: z.number().min(0).max(4294967295), type: z.enum(['range_to']) }),
+    z.object({
+      end: z.number().min(0).max(4294967295),
+      type: z.enum(["range_to"]),
+    }),
     z.object({
       end: z.number().min(0).max(4294967295),
       start: z.number().min(0).max(4294967295),
-      type: z.enum(['range']),
+      type: z.enum(["range"]),
     }),
-    z.object({ start: z.number().min(0).max(4294967295), type: z.enum(['range_from']) }),
-  ])
-)
+    z.object({
+      start: z.number().min(0).max(4294967295),
+      type: z.enum(["range_from"]),
+    }),
+  ]),
+);
 
 /**
  * A type storing a range over `T`.
@@ -617,11 +653,15 @@ export const BinRangeuint32 = z.preprocess(
 export const BinRangeuint64 = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ end: z.number().min(0), type: z.enum(['range_to']) }),
-    z.object({ end: z.number().min(0), start: z.number().min(0), type: z.enum(['range']) }),
-    z.object({ start: z.number().min(0), type: z.enum(['range_from']) }),
-  ])
-)
+    z.object({ end: z.number().min(0), type: z.enum(["range_to"]) }),
+    z.object({
+      end: z.number().min(0),
+      start: z.number().min(0),
+      type: z.enum(["range"]),
+    }),
+    z.object({ start: z.number().min(0), type: z.enum(["range_from"]) }),
+  ]),
+);
 
 /**
  * A type storing a range over `T`.
@@ -631,116 +671,119 @@ export const BinRangeuint64 = z.preprocess(
 export const BinRangeuint8 = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ end: z.number().min(0).max(255), type: z.enum(['range_to']) }),
+    z.object({ end: z.number().min(0).max(255), type: z.enum(["range_to"]) }),
     z.object({
       end: z.number().min(0).max(255),
       start: z.number().min(0).max(255),
-      type: z.enum(['range']),
+      type: z.enum(["range"]),
     }),
-    z.object({ start: z.number().min(0).max(255), type: z.enum(['range_from']) }),
-  ])
-)
+    z.object({
+      start: z.number().min(0).max(255),
+      type: z.enum(["range_from"]),
+    }),
+  ]),
+);
 
 /**
  * Type storing bin edges and a count of samples within it.
  */
 export const Bindouble = z.preprocess(
   processResponseBody,
-  z.object({ count: z.number().min(0), range: BinRangedouble })
-)
+  z.object({ count: z.number().min(0), range: BinRangedouble }),
+);
 
 /**
  * Type storing bin edges and a count of samples within it.
  */
 export const Binfloat = z.preprocess(
   processResponseBody,
-  z.object({ count: z.number().min(0), range: BinRangefloat })
-)
+  z.object({ count: z.number().min(0), range: BinRangefloat }),
+);
 
 /**
  * Type storing bin edges and a count of samples within it.
  */
 export const Binint16 = z.preprocess(
   processResponseBody,
-  z.object({ count: z.number().min(0), range: BinRangeint16 })
-)
+  z.object({ count: z.number().min(0), range: BinRangeint16 }),
+);
 
 /**
  * Type storing bin edges and a count of samples within it.
  */
 export const Binint32 = z.preprocess(
   processResponseBody,
-  z.object({ count: z.number().min(0), range: BinRangeint32 })
-)
+  z.object({ count: z.number().min(0), range: BinRangeint32 }),
+);
 
 /**
  * Type storing bin edges and a count of samples within it.
  */
 export const Binint64 = z.preprocess(
   processResponseBody,
-  z.object({ count: z.number().min(0), range: BinRangeint64 })
-)
+  z.object({ count: z.number().min(0), range: BinRangeint64 }),
+);
 
 /**
  * Type storing bin edges and a count of samples within it.
  */
 export const Binint8 = z.preprocess(
   processResponseBody,
-  z.object({ count: z.number().min(0), range: BinRangeint8 })
-)
+  z.object({ count: z.number().min(0), range: BinRangeint8 }),
+);
 
 /**
  * Type storing bin edges and a count of samples within it.
  */
 export const Binuint16 = z.preprocess(
   processResponseBody,
-  z.object({ count: z.number().min(0), range: BinRangeuint16 })
-)
+  z.object({ count: z.number().min(0), range: BinRangeuint16 }),
+);
 
 /**
  * Type storing bin edges and a count of samples within it.
  */
 export const Binuint32 = z.preprocess(
   processResponseBody,
-  z.object({ count: z.number().min(0), range: BinRangeuint32 })
-)
+  z.object({ count: z.number().min(0), range: BinRangeuint32 }),
+);
 
 /**
  * Type storing bin edges and a count of samples within it.
  */
 export const Binuint64 = z.preprocess(
   processResponseBody,
-  z.object({ count: z.number().min(0), range: BinRangeuint64 })
-)
+  z.object({ count: z.number().min(0), range: BinRangeuint64 }),
+);
 
 /**
  * Type storing bin edges and a count of samples within it.
  */
 export const Binuint8 = z.preprocess(
   processResponseBody,
-  z.object({ count: z.number().min(0), range: BinRangeuint8 })
-)
+  z.object({ count: z.number().min(0), range: BinRangeuint8 }),
+);
 
 /**
  * disk block size in bytes
  */
+export const BlockSizeEnumArray = [512, 2048, 4096] as const;
 export const BlockSize = z.preprocess(
   processResponseBody,
-  IntEnum([512, 2048, 4096] as const)
-)
-
+  z.enum(BlockSizeEnumArray),
+);
 /**
  * Byte count to express memory or storage capacity.
  */
-export const ByteCount = z.preprocess(processResponseBody, z.number().min(0))
+export const ByteCount = z.preprocess(processResponseBody, z.number().min(0));
 
 /**
  * The service intended to use this certificate.
  */
 export const ServiceUsingCertificate = z.preprocess(
   processResponseBody,
-  z.enum(['external_api'])
-)
+  z.enum(["external_api"]),
+);
 
 /**
  * View of a Certificate
@@ -755,8 +798,8 @@ export const Certificate = z.preprocess(
     service: ServiceUsingCertificate,
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
-  })
-)
+  }),
+);
 
 /**
  * Create-time parameters for a `Certificate`
@@ -769,48 +812,48 @@ export const CertificateCreate = z.preprocess(
     key: z.string(),
     name: Name,
     service: ServiceUsingCertificate,
-  })
-)
+  }),
+);
 
 /**
  * A single page of results
  */
 export const CertificateResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: Certificate.array(), nextPage: z.string().optional() })
-)
+  z.object({ items: Certificate.array(), nextPage: z.string().optional() }),
+);
 
 /**
  * A cumulative or counter data type.
  */
 export const Cumulativedouble = z.preprocess(
   processResponseBody,
-  z.object({ startTime: z.coerce.date(), value: z.number() })
-)
+  z.object({ startTime: z.coerce.date(), value: z.number() }),
+);
 
 /**
  * A cumulative or counter data type.
  */
 export const Cumulativefloat = z.preprocess(
   processResponseBody,
-  z.object({ startTime: z.coerce.date(), value: z.number() })
-)
+  z.object({ startTime: z.coerce.date(), value: z.number() }),
+);
 
 /**
  * A cumulative or counter data type.
  */
 export const Cumulativeint64 = z.preprocess(
   processResponseBody,
-  z.object({ startTime: z.coerce.date(), value: z.number() })
-)
+  z.object({ startTime: z.coerce.date(), value: z.number() }),
+);
 
 /**
  * A cumulative or counter data type.
  */
 export const Cumulativeuint64 = z.preprocess(
   processResponseBody,
-  z.object({ startTime: z.coerce.date(), value: z.number().min(0) })
-)
+  z.object({ startTime: z.coerce.date(), value: z.number().min(0) }),
+);
 
 /**
  * Info about the current user
@@ -822,8 +865,8 @@ export const CurrentUser = z.preprocess(
     id: z.string().uuid(),
     siloId: z.string().uuid(),
     siloName: Name,
-  })
-)
+  }),
+);
 
 /**
  * Structure for estimating the p-quantile of a population.
@@ -839,8 +882,8 @@ export const Quantile = z.preprocess(
     markerHeights: z.number().array(),
     markerPositions: z.number().min(0).array(),
     p: z.number(),
-  })
-)
+  }),
+);
 
 /**
  * Histogram metric
@@ -862,8 +905,8 @@ export const Histogramint8 = z.preprocess(
     squaredMean: z.number(),
     startTime: z.coerce.date(),
     sumOfSamples: z.number(),
-  })
-)
+  }),
+);
 
 /**
  * Histogram metric
@@ -885,8 +928,8 @@ export const Histogramuint8 = z.preprocess(
     squaredMean: z.number(),
     startTime: z.coerce.date(),
     sumOfSamples: z.number(),
-  })
-)
+  }),
+);
 
 /**
  * Histogram metric
@@ -908,8 +951,8 @@ export const Histogramint16 = z.preprocess(
     squaredMean: z.number(),
     startTime: z.coerce.date(),
     sumOfSamples: z.number(),
-  })
-)
+  }),
+);
 
 /**
  * Histogram metric
@@ -931,8 +974,8 @@ export const Histogramuint16 = z.preprocess(
     squaredMean: z.number(),
     startTime: z.coerce.date(),
     sumOfSamples: z.number(),
-  })
-)
+  }),
+);
 
 /**
  * Histogram metric
@@ -954,8 +997,8 @@ export const Histogramint32 = z.preprocess(
     squaredMean: z.number(),
     startTime: z.coerce.date(),
     sumOfSamples: z.number(),
-  })
-)
+  }),
+);
 
 /**
  * Histogram metric
@@ -977,8 +1020,8 @@ export const Histogramuint32 = z.preprocess(
     squaredMean: z.number(),
     startTime: z.coerce.date(),
     sumOfSamples: z.number(),
-  })
-)
+  }),
+);
 
 /**
  * Histogram metric
@@ -1000,8 +1043,8 @@ export const Histogramint64 = z.preprocess(
     squaredMean: z.number(),
     startTime: z.coerce.date(),
     sumOfSamples: z.number(),
-  })
-)
+  }),
+);
 
 /**
  * Histogram metric
@@ -1023,8 +1066,8 @@ export const Histogramuint64 = z.preprocess(
     squaredMean: z.number(),
     startTime: z.coerce.date(),
     sumOfSamples: z.number(),
-  })
-)
+  }),
+);
 
 /**
  * Histogram metric
@@ -1046,8 +1089,8 @@ export const Histogramfloat = z.preprocess(
     squaredMean: z.number(),
     startTime: z.coerce.date(),
     sumOfSamples: z.number(),
-  })
-)
+  }),
+);
 
 /**
  * Histogram metric
@@ -1069,49 +1112,49 @@ export const Histogramdouble = z.preprocess(
     squaredMean: z.number(),
     startTime: z.coerce.date(),
     sumOfSamples: z.number(),
-  })
-)
+  }),
+);
 
 /**
  * The type of an individual datum of a metric.
  */
+export const DatumTypeEnumArray = [
+  "bool",
+  "i8",
+  "u8",
+  "i16",
+  "u16",
+  "i32",
+  "u32",
+  "i64",
+  "u64",
+  "f32",
+  "f64",
+  "string",
+  "bytes",
+  "cumulative_i64",
+  "cumulative_u64",
+  "cumulative_f32",
+  "cumulative_f64",
+  "histogram_i8",
+  "histogram_u8",
+  "histogram_i16",
+  "histogram_u16",
+  "histogram_i32",
+  "histogram_u32",
+  "histogram_i64",
+  "histogram_u64",
+  "histogram_f32",
+  "histogram_f64",
+] as const;
 export const DatumType = z.preprocess(
   processResponseBody,
-  z.enum([
-    'bool',
-    'i8',
-    'u8',
-    'i16',
-    'u16',
-    'i32',
-    'u32',
-    'i64',
-    'u64',
-    'f32',
-    'f64',
-    'string',
-    'bytes',
-    'cumulative_i64',
-    'cumulative_u64',
-    'cumulative_f32',
-    'cumulative_f64',
-    'histogram_i8',
-    'histogram_u8',
-    'histogram_i16',
-    'histogram_u16',
-    'histogram_i32',
-    'histogram_u32',
-    'histogram_i64',
-    'histogram_u64',
-    'histogram_f32',
-    'histogram_f64',
-  ])
-)
-
+  z.enum(DatumTypeEnumArray),
+);
 export const MissingDatum = z.preprocess(
   processResponseBody,
-  z.object({ datumType: DatumType, startTime: z.coerce.date().optional() })
-)
+  z.object({ datumType: DatumType, startTime: z.coerce.date().optional() }),
+);
 
 /**
  * A `Datum` is a single sampled data point from a metric.
@@ -1119,61 +1162,77 @@ export const MissingDatum = z.preprocess(
 export const Datum = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ datum: SafeBoolean, type: z.enum(['bool']) }),
-    z.object({ datum: z.number().min(-127).max(127), type: z.enum(['i8']) }),
-    z.object({ datum: z.number().min(0).max(255), type: z.enum(['u8']) }),
-    z.object({ datum: z.number().min(-32767).max(32767), type: z.enum(['i16']) }),
-    z.object({ datum: z.number().min(0).max(65535), type: z.enum(['u16']) }),
-    z.object({ datum: z.number().min(-2147483647).max(2147483647), type: z.enum(['i32']) }),
-    z.object({ datum: z.number().min(0).max(4294967295), type: z.enum(['u32']) }),
-    z.object({ datum: z.number(), type: z.enum(['i64']) }),
-    z.object({ datum: z.number().min(0), type: z.enum(['u64']) }),
-    z.object({ datum: z.number(), type: z.enum(['f32']) }),
-    z.object({ datum: z.number(), type: z.enum(['f64']) }),
-    z.object({ datum: z.string(), type: z.enum(['string']) }),
-    z.object({ datum: z.number().min(0).max(255).array(), type: z.enum(['bytes']) }),
-    z.object({ datum: Cumulativeint64, type: z.enum(['cumulative_i64']) }),
-    z.object({ datum: Cumulativeuint64, type: z.enum(['cumulative_u64']) }),
-    z.object({ datum: Cumulativefloat, type: z.enum(['cumulative_f32']) }),
-    z.object({ datum: Cumulativedouble, type: z.enum(['cumulative_f64']) }),
-    z.object({ datum: Histogramint8, type: z.enum(['histogram_i8']) }),
-    z.object({ datum: Histogramuint8, type: z.enum(['histogram_u8']) }),
-    z.object({ datum: Histogramint16, type: z.enum(['histogram_i16']) }),
-    z.object({ datum: Histogramuint16, type: z.enum(['histogram_u16']) }),
-    z.object({ datum: Histogramint32, type: z.enum(['histogram_i32']) }),
-    z.object({ datum: Histogramuint32, type: z.enum(['histogram_u32']) }),
-    z.object({ datum: Histogramint64, type: z.enum(['histogram_i64']) }),
-    z.object({ datum: Histogramuint64, type: z.enum(['histogram_u64']) }),
-    z.object({ datum: Histogramfloat, type: z.enum(['histogram_f32']) }),
-    z.object({ datum: Histogramdouble, type: z.enum(['histogram_f64']) }),
-    z.object({ datum: MissingDatum, type: z.enum(['missing']) }),
-  ])
-)
+    z.object({ datum: SafeBoolean, type: z.enum(["bool"]) }),
+    z.object({ datum: z.number().min(-127).max(127), type: z.enum(["i8"]) }),
+    z.object({ datum: z.number().min(0).max(255), type: z.enum(["u8"]) }),
+    z.object({
+      datum: z.number().min(-32767).max(32767),
+      type: z.enum(["i16"]),
+    }),
+    z.object({ datum: z.number().min(0).max(65535), type: z.enum(["u16"]) }),
+    z.object({
+      datum: z.number().min(-2147483647).max(2147483647),
+      type: z.enum(["i32"]),
+    }),
+    z.object({
+      datum: z.number().min(0).max(4294967295),
+      type: z.enum(["u32"]),
+    }),
+    z.object({ datum: z.number(), type: z.enum(["i64"]) }),
+    z.object({ datum: z.number().min(0), type: z.enum(["u64"]) }),
+    z.object({ datum: z.number(), type: z.enum(["f32"]) }),
+    z.object({ datum: z.number(), type: z.enum(["f64"]) }),
+    z.object({ datum: z.string(), type: z.enum(["string"]) }),
+    z.object({
+      datum: z.number().min(0).max(255).array(),
+      type: z.enum(["bytes"]),
+    }),
+    z.object({ datum: Cumulativeint64, type: z.enum(["cumulative_i64"]) }),
+    z.object({ datum: Cumulativeuint64, type: z.enum(["cumulative_u64"]) }),
+    z.object({ datum: Cumulativefloat, type: z.enum(["cumulative_f32"]) }),
+    z.object({ datum: Cumulativedouble, type: z.enum(["cumulative_f64"]) }),
+    z.object({ datum: Histogramint8, type: z.enum(["histogram_i8"]) }),
+    z.object({ datum: Histogramuint8, type: z.enum(["histogram_u8"]) }),
+    z.object({ datum: Histogramint16, type: z.enum(["histogram_i16"]) }),
+    z.object({ datum: Histogramuint16, type: z.enum(["histogram_u16"]) }),
+    z.object({ datum: Histogramint32, type: z.enum(["histogram_i32"]) }),
+    z.object({ datum: Histogramuint32, type: z.enum(["histogram_u32"]) }),
+    z.object({ datum: Histogramint64, type: z.enum(["histogram_i64"]) }),
+    z.object({ datum: Histogramuint64, type: z.enum(["histogram_u64"]) }),
+    z.object({ datum: Histogramfloat, type: z.enum(["histogram_f32"]) }),
+    z.object({ datum: Histogramdouble, type: z.enum(["histogram_f64"]) }),
+    z.object({ datum: MissingDatum, type: z.enum(["missing"]) }),
+  ]),
+);
 
 export const DerEncodedKeyPair = z.preprocess(
   processResponseBody,
-  z.object({ privateKey: z.string(), publicCert: z.string() })
-)
+  z.object({ privateKey: z.string(), publicCert: z.string() }),
+);
 
 export const DeviceAccessTokenRequest = z.preprocess(
   processResponseBody,
-  z.object({ clientId: z.string().uuid(), deviceCode: z.string(), grantType: z.string() })
-)
+  z.object({
+    clientId: z.string().uuid(),
+    deviceCode: z.string(),
+    grantType: z.string(),
+  }),
+);
 
 export const DeviceAuthRequest = z.preprocess(
   processResponseBody,
-  z.object({ clientId: z.string().uuid() })
-)
+  z.object({ clientId: z.string().uuid() }),
+);
 
 export const DeviceAuthVerify = z.preprocess(
   processResponseBody,
-  z.object({ userCode: z.string() })
-)
+  z.object({ userCode: z.string() }),
+);
 
 export const Digest = z.preprocess(
   processResponseBody,
-  z.object({ type: z.enum(['sha256']), value: z.string() })
-)
+  z.object({ type: z.enum(["sha256"]), value: z.string() }),
+);
 
 /**
  * State of a Disk
@@ -1181,20 +1240,20 @@ export const Digest = z.preprocess(
 export const DiskState = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ state: z.enum(['creating']) }),
-    z.object({ state: z.enum(['detached']) }),
-    z.object({ state: z.enum(['import_ready']) }),
-    z.object({ state: z.enum(['importing_from_url']) }),
-    z.object({ state: z.enum(['importing_from_bulk_writes']) }),
-    z.object({ state: z.enum(['finalizing']) }),
-    z.object({ state: z.enum(['maintenance']) }),
-    z.object({ instance: z.string().uuid(), state: z.enum(['attaching']) }),
-    z.object({ instance: z.string().uuid(), state: z.enum(['attached']) }),
-    z.object({ instance: z.string().uuid(), state: z.enum(['detaching']) }),
-    z.object({ state: z.enum(['destroyed']) }),
-    z.object({ state: z.enum(['faulted']) }),
-  ])
-)
+    z.object({ state: z.enum(["creating"]) }),
+    z.object({ state: z.enum(["detached"]) }),
+    z.object({ state: z.enum(["import_ready"]) }),
+    z.object({ state: z.enum(["importing_from_url"]) }),
+    z.object({ state: z.enum(["importing_from_bulk_writes"]) }),
+    z.object({ state: z.enum(["finalizing"]) }),
+    z.object({ state: z.enum(["maintenance"]) }),
+    z.object({ instance: z.string().uuid(), state: z.enum(["attaching"]) }),
+    z.object({ instance: z.string().uuid(), state: z.enum(["attached"]) }),
+    z.object({ instance: z.string().uuid(), state: z.enum(["detaching"]) }),
+    z.object({ state: z.enum(["destroyed"]) }),
+    z.object({ state: z.enum(["faulted"]) }),
+  ]),
+);
 
 /**
  * View of a Disk
@@ -1214,8 +1273,8 @@ export const Disk = z.preprocess(
     state: DiskState,
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
-  })
-)
+  }),
+);
 
 /**
  * Different sources for a disk
@@ -1223,30 +1282,38 @@ export const Disk = z.preprocess(
 export const DiskSource = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ blockSize: BlockSize, type: z.enum(['blank']) }),
-    z.object({ snapshotId: z.string().uuid(), type: z.enum(['snapshot']) }),
-    z.object({ imageId: z.string().uuid(), type: z.enum(['image']) }),
-    z.object({ blockSize: BlockSize, type: z.enum(['importing_blocks']) }),
-  ])
-)
+    z.object({ blockSize: BlockSize, type: z.enum(["blank"]) }),
+    z.object({ snapshotId: z.string().uuid(), type: z.enum(["snapshot"]) }),
+    z.object({ imageId: z.string().uuid(), type: z.enum(["image"]) }),
+    z.object({ blockSize: BlockSize, type: z.enum(["importing_blocks"]) }),
+  ]),
+);
 
 /**
  * Create-time parameters for a `Disk`
  */
 export const DiskCreate = z.preprocess(
   processResponseBody,
-  z.object({ description: z.string(), diskSource: DiskSource, name: Name, size: ByteCount })
-)
+  z.object({
+    description: z.string(),
+    diskSource: DiskSource,
+    name: Name,
+    size: ByteCount,
+  }),
+);
 
-export const DiskPath = z.preprocess(processResponseBody, z.object({ disk: NameOrId }))
+export const DiskPath = z.preprocess(
+  processResponseBody,
+  z.object({ disk: NameOrId }),
+);
 
 /**
  * A single page of results
  */
 export const DiskResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: Disk.array(), nextPage: z.string().optional() })
-)
+  z.object({ items: Disk.array(), nextPage: z.string().optional() }),
+);
 
 /**
  * A distribution is a sequence of bins and counts in those bins, and some statistical information tracked to compute the mean, standard deviation, and quantile estimates.
@@ -1265,8 +1332,8 @@ export const Distributiondouble = z.preprocess(
     p99: Quantile.optional(),
     squaredMean: z.number(),
     sumOfSamples: z.number(),
-  })
-)
+  }),
+);
 
 /**
  * A distribution is a sequence of bins and counts in those bins, and some statistical information tracked to compute the mean, standard deviation, and quantile estimates.
@@ -1285,43 +1352,47 @@ export const Distributionint64 = z.preprocess(
     p99: Quantile.optional(),
     squaredMean: z.number(),
     sumOfSamples: z.number(),
-  })
-)
+  }),
+);
 
 /**
  * Parameters for creating an ephemeral IP address for an instance.
  */
 export const EphemeralIpCreate = z.preprocess(
   processResponseBody,
-  z.object({ pool: NameOrId.optional() })
-)
+  z.object({ pool: NameOrId.optional() }),
+);
 
 /**
  * Error information from a response.
  */
 export const Error = z.preprocess(
   processResponseBody,
-  z.object({ errorCode: z.string().optional(), message: z.string(), requestId: z.string() })
-)
+  z.object({
+    errorCode: z.string().optional(),
+    message: z.string(),
+    requestId: z.string(),
+  }),
+);
 
 export const ExternalIp = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ ip: z.string().ip(), kind: z.enum(['ephemeral']) }),
+    z.object({ ip: z.string().ip(), kind: z.enum(["ephemeral"]) }),
     z.object({
       description: z.string(),
       id: z.string().uuid(),
       instanceId: z.string().uuid().optional(),
       ip: z.string().ip(),
       ipPoolId: z.string().uuid(),
-      kind: z.enum(['floating']),
+      kind: z.enum(["floating"]),
       name: Name,
       projectId: z.string().uuid(),
       timeCreated: z.coerce.date(),
       timeModified: z.coerce.date(),
     }),
-  ])
-)
+  ]),
+);
 
 /**
  * Parameters for creating an external IP address for instances.
@@ -1329,45 +1400,48 @@ export const ExternalIp = z.preprocess(
 export const ExternalIpCreate = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ pool: NameOrId.optional(), type: z.enum(['ephemeral']) }),
-    z.object({ floatingIp: NameOrId, type: z.enum(['floating']) }),
-  ])
-)
+    z.object({ pool: NameOrId.optional(), type: z.enum(["ephemeral"]) }),
+    z.object({ floatingIp: NameOrId, type: z.enum(["floating"]) }),
+  ]),
+);
 
 /**
  * A single page of results
  */
 export const ExternalIpResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: ExternalIp.array(), nextPage: z.string().optional() })
-)
+  z.object({ items: ExternalIp.array(), nextPage: z.string().optional() }),
+);
 
 /**
  * The `FieldType` identifies the data type of a target or metric field.
  */
+export const FieldTypeEnumArray = [
+  "string",
+  "i8",
+  "u8",
+  "i16",
+  "u16",
+  "i32",
+  "u32",
+  "i64",
+  "u64",
+  "ip_addr",
+  "uuid",
+  "bool",
+] as const;
 export const FieldType = z.preprocess(
   processResponseBody,
-  z.enum([
-    'string',
-    'i8',
-    'u8',
-    'i16',
-    'u16',
-    'i32',
-    'u32',
-    'i64',
-    'u64',
-    'ip_addr',
-    'uuid',
-    'bool',
-  ])
-)
-
+  z.enum(FieldTypeEnumArray),
+);
 /**
  * The source from which a field is derived, the target or metric.
  */
-export const FieldSource = z.preprocess(processResponseBody, z.enum(['target', 'metric']))
-
+export const FieldSourceEnumArray = ["target", "metric"] as const;
+export const FieldSource = z.preprocess(
+  processResponseBody,
+  z.enum(FieldSourceEnumArray),
+);
 /**
  * The name and type information for a field of a timeseries schema.
  */
@@ -1378,8 +1452,8 @@ export const FieldSchema = z.preprocess(
     fieldType: FieldType,
     name: z.string(),
     source: FieldSource,
-  })
-)
+  }),
+);
 
 /**
  * The `FieldValue` contains the value of a target or metric field.
@@ -1387,42 +1461,51 @@ export const FieldSchema = z.preprocess(
 export const FieldValue = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ type: z.enum(['string']), value: z.string() }),
-    z.object({ type: z.enum(['i8']), value: z.number().min(-127).max(127) }),
-    z.object({ type: z.enum(['u8']), value: z.number().min(0).max(255) }),
-    z.object({ type: z.enum(['i16']), value: z.number().min(-32767).max(32767) }),
-    z.object({ type: z.enum(['u16']), value: z.number().min(0).max(65535) }),
-    z.object({ type: z.enum(['i32']), value: z.number().min(-2147483647).max(2147483647) }),
-    z.object({ type: z.enum(['u32']), value: z.number().min(0).max(4294967295) }),
-    z.object({ type: z.enum(['i64']), value: z.number() }),
-    z.object({ type: z.enum(['u64']), value: z.number().min(0) }),
-    z.object({ type: z.enum(['ip_addr']), value: z.string().ip() }),
-    z.object({ type: z.enum(['uuid']), value: z.string().uuid() }),
-    z.object({ type: z.enum(['bool']), value: SafeBoolean }),
-  ])
-)
+    z.object({ type: z.enum(["string"]), value: z.string() }),
+    z.object({ type: z.enum(["i8"]), value: z.number().min(-127).max(127) }),
+    z.object({ type: z.enum(["u8"]), value: z.number().min(0).max(255) }),
+    z.object({
+      type: z.enum(["i16"]),
+      value: z.number().min(-32767).max(32767),
+    }),
+    z.object({ type: z.enum(["u16"]), value: z.number().min(0).max(65535) }),
+    z.object({
+      type: z.enum(["i32"]),
+      value: z.number().min(-2147483647).max(2147483647),
+    }),
+    z.object({
+      type: z.enum(["u32"]),
+      value: z.number().min(0).max(4294967295),
+    }),
+    z.object({ type: z.enum(["i64"]), value: z.number() }),
+    z.object({ type: z.enum(["u64"]), value: z.number().min(0) }),
+    z.object({ type: z.enum(["ip_addr"]), value: z.string().ip() }),
+    z.object({ type: z.enum(["uuid"]), value: z.string().uuid() }),
+    z.object({ type: z.enum(["bool"]), value: SafeBoolean }),
+  ]),
+);
 
 /**
  * Parameters for finalizing a disk
  */
 export const FinalizeDisk = z.preprocess(
   processResponseBody,
-  z.object({ snapshotName: Name.optional() })
-)
+  z.object({ snapshotName: Name.optional() }),
+);
 
+export const FleetRoleEnumArray = ["admin", "collaborator", "viewer"] as const;
 export const FleetRole = z.preprocess(
   processResponseBody,
-  z.enum(['admin', 'collaborator', 'viewer'])
-)
-
+  z.enum(FleetRoleEnumArray),
+);
 /**
  * Describes what kind of identity is described by an id
  */
+export const IdentityTypeEnumArray = ["silo_user", "silo_group"] as const;
 export const IdentityType = z.preprocess(
   processResponseBody,
-  z.enum(['silo_user', 'silo_group'])
-)
-
+  z.enum(IdentityTypeEnumArray),
+);
 /**
  * Describes the assignment of a particular role on a particular resource to a particular identity (user, group, etc.)
  *
@@ -1434,8 +1517,8 @@ export const FleetRoleRoleAssignment = z.preprocess(
     identityId: z.string().uuid(),
     identityType: IdentityType,
     roleName: FleetRole,
-  })
-)
+  }),
+);
 
 /**
  * Policy for a particular resource
@@ -1444,8 +1527,8 @@ export const FleetRoleRoleAssignment = z.preprocess(
  */
 export const FleetRolePolicy = z.preprocess(
   processResponseBody,
-  z.object({ roleAssignments: FleetRoleRoleAssignment.array() })
-)
+  z.object({ roleAssignments: FleetRoleRoleAssignment.array() }),
+);
 
 /**
  * A Floating IP is a well-known IP address which can be attached and detached from instances.
@@ -1462,21 +1545,24 @@ export const FloatingIp = z.preprocess(
     projectId: z.string().uuid(),
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
-  })
-)
+  }),
+);
 
 /**
  * The type of resource that a floating IP is attached to
  */
-export const FloatingIpParentKind = z.preprocess(processResponseBody, z.enum(['instance']))
-
+export const FloatingIpParentKindEnumArray = ["instance"] as const;
+export const FloatingIpParentKind = z.preprocess(
+  processResponseBody,
+  z.enum(FloatingIpParentKindEnumArray),
+);
 /**
  * Parameters for attaching a floating IP address to another resource
  */
 export const FloatingIpAttach = z.preprocess(
   processResponseBody,
-  z.object({ kind: FloatingIpParentKind, parent: NameOrId })
-)
+  z.object({ kind: FloatingIpParentKind, parent: NameOrId }),
+);
 
 /**
  * Parameters for creating a new floating IP address for instances.
@@ -1488,40 +1574,44 @@ export const FloatingIpCreate = z.preprocess(
     ip: z.string().ip().optional(),
     name: Name,
     pool: NameOrId.optional(),
-  })
-)
+  }),
+);
 
 /**
  * A single page of results
  */
 export const FloatingIpResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: FloatingIp.array(), nextPage: z.string().optional() })
-)
+  z.object({ items: FloatingIp.array(), nextPage: z.string().optional() }),
+);
 
 /**
  * Updateable identity-related parameters
  */
 export const FloatingIpUpdate = z.preprocess(
   processResponseBody,
-  z.object({ description: z.string().optional(), name: Name.optional() })
-)
+  z.object({ description: z.string().optional(), name: Name.optional() }),
+);
 
 /**
  * View of a Group
  */
 export const Group = z.preprocess(
   processResponseBody,
-  z.object({ displayName: z.string(), id: z.string().uuid(), siloId: z.string().uuid() })
-)
+  z.object({
+    displayName: z.string(),
+    id: z.string().uuid(),
+    siloId: z.string().uuid(),
+  }),
+);
 
 /**
  * A single page of results
  */
 export const GroupResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: Group.array(), nextPage: z.string().optional() })
-)
+  z.object({ items: Group.array(), nextPage: z.string().optional() }),
+);
 
 /**
  * An RFC-1035-compliant hostname
@@ -1534,10 +1624,15 @@ export const Hostname = z.preprocess(
     .string()
     .min(1)
     .max(253)
-    .regex(/^([a-zA-Z0-9]+[a-zA-Z0-9\-]*(?<!-))(\.[a-zA-Z0-9]+[a-zA-Z0-9\-]*(?<!-))*$/)
-)
+    .regex(
+      /^([a-zA-Z0-9]+[a-zA-Z0-9\-]*(?<!-))(\.[a-zA-Z0-9]+[a-zA-Z0-9\-]*(?<!-))*$/,
+    ),
+);
 
-export const IdentityProviderType = z.preprocess(processResponseBody, z.enum(['saml']))
+export const IdentityProviderType = z.preprocess(
+  processResponseBody,
+  z.enum(["saml"]),
+);
 
 /**
  * View of an Identity Provider
@@ -1551,24 +1646,27 @@ export const IdentityProvider = z.preprocess(
     providerType: IdentityProviderType,
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
-  })
-)
+  }),
+);
 
 /**
  * A single page of results
  */
 export const IdentityProviderResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: IdentityProvider.array(), nextPage: z.string().optional() })
-)
+  z.object({
+    items: IdentityProvider.array(),
+    nextPage: z.string().optional(),
+  }),
+);
 
 export const IdpMetadataSource = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ type: z.enum(['url']), url: z.string() }),
-    z.object({ data: z.string(), type: z.enum(['base64_encoded_xml']) }),
-  ])
-)
+    z.object({ type: z.enum(["url"]), url: z.string() }),
+    z.object({ data: z.string(), type: z.enum(["base64_encoded_xml"]) }),
+  ]),
+);
 
 /**
  * View of an image
@@ -1589,8 +1687,8 @@ export const Image = z.preprocess(
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
     version: z.string(),
-  })
-)
+  }),
+);
 
 /**
  * The source of the underlying image.
@@ -1598,10 +1696,10 @@ export const Image = z.preprocess(
 export const ImageSource = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ id: z.string().uuid(), type: z.enum(['snapshot']) }),
-    z.object({ type: z.enum(['you_can_boot_anything_as_long_as_its_alpine']) }),
-  ])
-)
+    z.object({ id: z.string().uuid(), type: z.enum(["snapshot"]) }),
+    z.object({ type: z.enum(["you_can_boot_anything_as_long_as_its_alpine"]) }),
+  ]),
+);
 
 /**
  * Create-time parameters for an `Image`
@@ -1614,32 +1712,32 @@ export const ImageCreate = z.preprocess(
     os: z.string(),
     source: ImageSource,
     version: z.string(),
-  })
-)
+  }),
+);
 
 /**
  * A single page of results
  */
 export const ImageResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: Image.array(), nextPage: z.string().optional() })
-)
+  z.object({ items: Image.array(), nextPage: z.string().optional() }),
+);
 
 /**
  * Parameters for importing blocks with a bulk write
  */
 export const ImportBlocksBulkWrite = z.preprocess(
   processResponseBody,
-  z.object({ base64EncodedData: z.string(), offset: z.number().min(0) })
-)
+  z.object({ base64EncodedData: z.string(), offset: z.number().min(0) }),
+);
 
 /**
  * The number of CPUs in an Instance
  */
 export const InstanceCpuCount = z.preprocess(
   processResponseBody,
-  z.number().min(0).max(65535)
-)
+  z.number().min(0).max(65535),
+);
 
 /**
  * Running state of an Instance (primarily: booted or stopped)
@@ -1649,18 +1747,18 @@ export const InstanceCpuCount = z.preprocess(
 export const InstanceState = z.preprocess(
   processResponseBody,
   z.enum([
-    'creating',
-    'starting',
-    'running',
-    'stopping',
-    'stopped',
-    'rebooting',
-    'migrating',
-    'repairing',
-    'failed',
-    'destroyed',
-  ])
-)
+    "creating",
+    "starting",
+    "running",
+    "stopping",
+    "stopped",
+    "rebooting",
+    "migrating",
+    "repairing",
+    "failed",
+    "destroyed",
+  ]),
+);
 
 /**
  * View of an Instance
@@ -1679,8 +1777,8 @@ export const Instance = z.preprocess(
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
     timeRunStateUpdated: z.coerce.date(),
-  })
-)
+  }),
+);
 
 /**
  * Describe the instance's disks at creation time
@@ -1693,11 +1791,11 @@ export const InstanceDiskAttachment = z.preprocess(
       diskSource: DiskSource,
       name: Name,
       size: ByteCount,
-      type: z.enum(['create']),
+      type: z.enum(["create"]),
     }),
-    z.object({ name: Name, type: z.enum(['attach']) }),
-  ])
-)
+    z.object({ name: Name, type: z.enum(["attach"]) }),
+  ]),
+);
 
 /**
  * Create-time parameters for an `InstanceNetworkInterface`
@@ -1710,8 +1808,8 @@ export const InstanceNetworkInterfaceCreate = z.preprocess(
     name: Name,
     subnetName: Name,
     vpcName: Name,
-  })
-)
+  }),
+);
 
 /**
  * Describes an attachment of an `InstanceNetworkInterface` to an `Instance`, at the time the instance is created.
@@ -1719,11 +1817,14 @@ export const InstanceNetworkInterfaceCreate = z.preprocess(
 export const InstanceNetworkInterfaceAttachment = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ params: InstanceNetworkInterfaceCreate.array(), type: z.enum(['create']) }),
-    z.object({ type: z.enum(['default']) }),
-    z.object({ type: z.enum(['none']) }),
-  ])
-)
+    z.object({
+      params: InstanceNetworkInterfaceCreate.array(),
+      type: z.enum(["create"]),
+    }),
+    z.object({ type: z.enum(["default"]) }),
+    z.object({ type: z.enum(["none"]) }),
+  ]),
+);
 
 /**
  * Create-time parameters for an `Instance`
@@ -1739,21 +1840,21 @@ export const InstanceCreate = z.preprocess(
     name: Name,
     ncpus: InstanceCpuCount,
     networkInterfaces: InstanceNetworkInterfaceAttachment.default({
-      type: 'default',
+      type: "default",
     }).optional(),
     sshPublicKeys: NameOrId.array().optional(),
     start: SafeBoolean.default(true).optional(),
-    userData: z.string().default('').optional(),
-  })
-)
+    userData: z.string().default("").optional(),
+  }),
+);
 
 /**
  * Migration parameters for an `Instance`
  */
 export const InstanceMigrate = z.preprocess(
   processResponseBody,
-  z.object({ dstSledId: z.string().uuid() })
-)
+  z.object({ dstSledId: z.string().uuid() }),
+);
 
 /**
  * A MAC address
@@ -1766,8 +1867,8 @@ export const MacAddr = z.preprocess(
     .string()
     .min(5)
     .max(17)
-    .regex(/^([0-9a-fA-F]{0,2}:){5}[0-9a-fA-F]{0,2}$/)
-)
+    .regex(/^([0-9a-fA-F]{0,2}:){5}[0-9a-fA-F]{0,2}$/),
+);
 
 /**
  * An `InstanceNetworkInterface` represents a virtual network interface device attached to an instance.
@@ -1787,16 +1888,19 @@ export const InstanceNetworkInterface = z.preprocess(
     timeModified: z.coerce.date(),
     transitIps: IpNet.array().default([]).optional(),
     vpcId: z.string().uuid(),
-  })
-)
+  }),
+);
 
 /**
  * A single page of results
  */
 export const InstanceNetworkInterfaceResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: InstanceNetworkInterface.array(), nextPage: z.string().optional() })
-)
+  z.object({
+    items: InstanceNetworkInterface.array(),
+    nextPage: z.string().optional(),
+  }),
+);
 
 /**
  * Parameters for updating an `InstanceNetworkInterface`
@@ -1810,29 +1914,27 @@ export const InstanceNetworkInterfaceUpdate = z.preprocess(
     name: Name.optional(),
     primary: SafeBoolean.default(false).optional(),
     transitIps: IpNet.array().default([]).optional(),
-  })
-)
+  }),
+);
 
 /**
  * A single page of results
  */
 export const InstanceResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: Instance.array(), nextPage: z.string().optional() })
-)
+  z.object({ items: Instance.array(), nextPage: z.string().optional() }),
+);
 
 /**
  * Contents of an Instance's serial console buffer.
  */
 export const InstanceSerialConsoleData = z.preprocess(
   processResponseBody,
-  z.object({ data: z.number().min(0).max(255).array(), lastByteOffset: z.number().min(0) })
-)
-
-export const IpKind = z.preprocess(
-  processResponseBody,
-  z.enum(['snat', 'floating', 'ephemeral'])
-)
+  z.object({
+    data: z.number().min(0).max(255).array(),
+    lastByteOffset: z.number().min(0),
+  }),
+);
 
 /**
  * A collection of IP ranges. If a pool is linked to a silo, IP addresses from the pool can be allocated within that silo
@@ -1845,21 +1947,21 @@ export const IpPool = z.preprocess(
     name: Name,
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
-  })
-)
+  }),
+);
 
 /**
  * Create-time parameters for an `IpPool`
  */
 export const IpPoolCreate = z.preprocess(
   processResponseBody,
-  z.object({ description: z.string(), name: Name })
-)
+  z.object({ description: z.string(), name: Name }),
+);
 
 export const IpPoolLinkSilo = z.preprocess(
   processResponseBody,
-  z.object({ isDefault: SafeBoolean, silo: NameOrId })
-)
+  z.object({ isDefault: SafeBoolean, silo: NameOrId }),
+);
 
 /**
  * A non-decreasing IPv4 address range, inclusive of both ends.
@@ -1869,10 +1971,10 @@ export const IpPoolLinkSilo = z.preprocess(
 export const Ipv4Range = z.preprocess(
   processResponseBody,
   z.object({
-    first: z.string().ip({ version: 'v4' }),
-    last: z.string().ip({ version: 'v4' }),
-  })
-)
+    first: z.string().ip({ version: "v4" }),
+    last: z.string().ip({ version: "v4" }),
+  }),
+);
 
 /**
  * A non-decreasing IPv6 address range, inclusive of both ends.
@@ -1882,12 +1984,15 @@ export const Ipv4Range = z.preprocess(
 export const Ipv6Range = z.preprocess(
   processResponseBody,
   z.object({
-    first: z.string().ip({ version: 'v6' }),
-    last: z.string().ip({ version: 'v6' }),
-  })
-)
+    first: z.string().ip({ version: "v6" }),
+    last: z.string().ip({ version: "v6" }),
+  }),
+);
 
-export const IpRange = z.preprocess(processResponseBody, z.union([Ipv4Range, Ipv6Range]))
+export const IpRange = z.preprocess(
+  processResponseBody,
+  z.union([Ipv4Range, Ipv6Range]),
+);
 
 export const IpPoolRange = z.preprocess(
   processResponseBody,
@@ -1896,24 +2001,24 @@ export const IpPoolRange = z.preprocess(
     ipPoolId: z.string().uuid(),
     range: IpRange,
     timeCreated: z.coerce.date(),
-  })
-)
+  }),
+);
 
 /**
  * A single page of results
  */
 export const IpPoolRangeResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: IpPoolRange.array(), nextPage: z.string().optional() })
-)
+  z.object({ items: IpPoolRange.array(), nextPage: z.string().optional() }),
+);
 
 /**
  * A single page of results
  */
 export const IpPoolResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: IpPool.array(), nextPage: z.string().optional() })
-)
+  z.object({ items: IpPool.array(), nextPage: z.string().optional() }),
+);
 
 /**
  * A link between an IP pool and a silo that allows one to allocate IPs from the pool within the silo
@@ -1924,52 +2029,52 @@ export const IpPoolSiloLink = z.preprocess(
     ipPoolId: z.string().uuid(),
     isDefault: SafeBoolean,
     siloId: z.string().uuid(),
-  })
-)
+  }),
+);
 
 /**
  * A single page of results
  */
 export const IpPoolSiloLinkResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: IpPoolSiloLink.array(), nextPage: z.string().optional() })
-)
+  z.object({ items: IpPoolSiloLink.array(), nextPage: z.string().optional() }),
+);
 
 export const IpPoolSiloUpdate = z.preprocess(
   processResponseBody,
-  z.object({ isDefault: SafeBoolean })
-)
+  z.object({ isDefault: SafeBoolean }),
+);
 
 /**
  * Parameters for updating an IP Pool
  */
 export const IpPoolUpdate = z.preprocess(
   processResponseBody,
-  z.object({ description: z.string().optional(), name: Name.optional() })
-)
+  z.object({ description: z.string().optional(), name: Name.optional() }),
+);
 
 export const Ipv4Utilization = z.preprocess(
   processResponseBody,
   z.object({
     allocated: z.number().min(0).max(4294967295),
     capacity: z.number().min(0).max(4294967295),
-  })
-)
+  }),
+);
 
 export const Ipv6Utilization = z.preprocess(
   processResponseBody,
-  z.object({ allocated: z.string(), capacity: z.string() })
-)
+  z.object({ allocated: z.string(), capacity: z.string() }),
+);
 
 export const IpPoolUtilization = z.preprocess(
   processResponseBody,
-  z.object({ ipv4: Ipv4Utilization, ipv6: Ipv6Utilization })
-)
+  z.object({ ipv4: Ipv4Utilization, ipv6: Ipv6Utilization }),
+);
 
 /**
  * A range of IP ports
  *
- * An inclusive-inclusive range of IP ports. The second port may be omitted to represent a single port
+ * An inclusive-inclusive range of IP ports. The second port may be omitted to represent a single port.
  */
 export const L4PortRange = z.preprocess(
   processResponseBody,
@@ -1977,21 +2082,24 @@ export const L4PortRange = z.preprocess(
     .string()
     .min(1)
     .max(11)
-    .regex(/^[0-9]{1,5}(-[0-9]{1,5})?$/)
-)
+    .regex(/^[0-9]{1,5}(-[0-9]{1,5})?$/),
+);
 
 /**
  * The forward error correction mode of a link.
  */
-export const LinkFec = z.preprocess(processResponseBody, z.enum(['firecode', 'none', 'rs']))
+export const LinkFec = z.preprocess(
+  processResponseBody,
+  z.enum(["firecode", "none", "rs"]),
+);
 
 /**
  * The LLDP configuration associated with a port. LLDP may be either enabled or disabled, if enabled, an LLDP configuration must be provided by name or id.
  */
 export const LldpServiceConfigCreate = z.preprocess(
   processResponseBody,
-  z.object({ enabled: SafeBoolean, lldpConfig: NameOrId.optional() })
-)
+  z.object({ enabled: SafeBoolean, lldpConfig: NameOrId.optional() }),
+);
 
 /**
  * The speed of a link.
@@ -1999,17 +2107,17 @@ export const LldpServiceConfigCreate = z.preprocess(
 export const LinkSpeed = z.preprocess(
   processResponseBody,
   z.enum([
-    'speed0_g',
-    'speed1_g',
-    'speed10_g',
-    'speed25_g',
-    'speed40_g',
-    'speed50_g',
-    'speed100_g',
-    'speed200_g',
-    'speed400_g',
-  ])
-)
+    "speed0_g",
+    "speed1_g",
+    "speed10_g",
+    "speed25_g",
+    "speed40_g",
+    "speed50_g",
+    "speed100_g",
+    "speed200_g",
+    "speed400_g",
+  ]),
+);
 
 /**
  * Switch link configuration.
@@ -2022,8 +2130,8 @@ export const LinkConfigCreate = z.preprocess(
     lldp: LldpServiceConfigCreate,
     mtu: z.number().min(0).max(65535),
     speed: LinkSpeed,
-  })
-)
+  }),
+);
 
 /**
  * A link layer discovery protocol (LLDP) service configuration.
@@ -2034,8 +2142,8 @@ export const LldpServiceConfig = z.preprocess(
     enabled: SafeBoolean,
     id: z.string().uuid(),
     lldpConfigId: z.string().uuid().optional(),
-  })
-)
+  }),
+);
 
 /**
  * A loopback address is an address that is assigned to a rack switch but is not associated with any particular port.
@@ -2048,8 +2156,8 @@ export const LoopbackAddress = z.preprocess(
     id: z.string().uuid(),
     rackId: z.string().uuid(),
     switchLocation: z.string(),
-  })
-)
+  }),
+);
 
 /**
  * Parameters for creating a loopback address on a particular rack switch.
@@ -2063,40 +2171,40 @@ export const LoopbackAddressCreate = z.preprocess(
     mask: z.number().min(0).max(255),
     rackId: z.string().uuid(),
     switchLocation: Name,
-  })
-)
+  }),
+);
 
 /**
  * A single page of results
  */
 export const LoopbackAddressResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: LoopbackAddress.array(), nextPage: z.string().optional() })
-)
+  z.object({ items: LoopbackAddress.array(), nextPage: z.string().optional() }),
+);
 
 /**
  * A `Measurement` is a timestamped datum from a single metric
  */
 export const Measurement = z.preprocess(
   processResponseBody,
-  z.object({ datum: Datum, timestamp: z.coerce.date() })
-)
+  z.object({ datum: Datum, timestamp: z.coerce.date() }),
+);
 
 /**
  * A single page of results
  */
 export const MeasurementResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: Measurement.array(), nextPage: z.string().optional() })
-)
+  z.object({ items: Measurement.array(), nextPage: z.string().optional() }),
+);
 
 /**
  * The type of the metric itself, indicating what its values represent.
  */
 export const MetricType = z.preprocess(
   processResponseBody,
-  z.enum(['gauge', 'delta', 'cumulative'])
-)
+  z.enum(["gauge", "delta", "cumulative"]),
+);
 
 /**
  * The type of network interface
@@ -2104,16 +2212,19 @@ export const MetricType = z.preprocess(
 export const NetworkInterfaceKind = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ id: z.string().uuid(), type: z.enum(['instance']) }),
-    z.object({ id: z.string().uuid(), type: z.enum(['service']) }),
-    z.object({ id: z.string().uuid(), type: z.enum(['probe']) }),
-  ])
-)
+    z.object({ id: z.string().uuid(), type: z.enum(["instance"]) }),
+    z.object({ id: z.string().uuid(), type: z.enum(["service"]) }),
+    z.object({ id: z.string().uuid(), type: z.enum(["probe"]) }),
+  ]),
+);
 
 /**
  * A Geneve Virtual Network Identifier
  */
-export const Vni = z.preprocess(processResponseBody, z.number().min(0).max(4294967295))
+export const Vni = z.preprocess(
+  processResponseBody,
+  z.number().min(0).max(4294967295),
+);
 
 /**
  * Information required to construct a virtual network interface
@@ -2131,39 +2242,42 @@ export const NetworkInterface = z.preprocess(
     subnet: IpNet,
     transitIps: IpNet.array().default([]).optional(),
     vni: Vni,
-  })
-)
+  }),
+);
 
 /**
  * A password used to authenticate a user
  *
  * Passwords may be subject to additional constraints.
  */
-export const Password = z.preprocess(processResponseBody, z.string().max(512))
+export const Password = z.preprocess(processResponseBody, z.string().max(512));
 
 /**
  * Describes the form factor of physical disks.
  */
-export const PhysicalDiskKind = z.preprocess(processResponseBody, z.enum(['m2', 'u2']))
-
+export const PhysicalDiskKindEnumArray = ["m2", "u2"] as const;
+export const PhysicalDiskKind = z.preprocess(
+  processResponseBody,
+  z.enum(PhysicalDiskKindEnumArray),
+);
 /**
  * The operator-defined policy of a physical disk.
  */
 export const PhysicalDiskPolicy = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ kind: z.enum(['in_service']) }),
-    z.object({ kind: z.enum(['expunged']) }),
-  ])
-)
+    z.object({ kind: z.enum(["in_service"]) }),
+    z.object({ kind: z.enum(["expunged"]) }),
+  ]),
+);
 
 /**
  * The current state of the disk, as determined by Nexus.
  */
 export const PhysicalDiskState = z.preprocess(
   processResponseBody,
-  z.enum(['active', 'decommissioned'])
-)
+  z.enum(["active", "decommissioned"]),
+);
 
 /**
  * View of a Physical Disk
@@ -2183,20 +2297,26 @@ export const PhysicalDisk = z.preprocess(
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
     vendor: z.string(),
-  })
-)
+  }),
+);
 
 /**
  * A single page of results
  */
 export const PhysicalDiskResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: PhysicalDisk.array(), nextPage: z.string().optional() })
-)
+  z.object({ items: PhysicalDisk.array(), nextPage: z.string().optional() }),
+);
 
-export const PingStatus = z.preprocess(processResponseBody, z.enum(['ok']))
-
-export const Ping = z.preprocess(processResponseBody, z.object({ status: PingStatus }))
+export const PingStatusEnumArray = ["ok"] as const;
+export const PingStatus = z.preprocess(
+  processResponseBody,
+  z.enum(PingStatusEnumArray),
+);
+export const Ping = z.preprocess(
+  processResponseBody,
+  z.object({ status: PingStatus }),
+);
 
 /**
  * List of data values for one timeseries.
@@ -2206,22 +2326,28 @@ export const Ping = z.preprocess(processResponseBody, z.object({ status: PingSta
 export const ValueArray = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ type: z.enum(['integer']), values: z.number().array() }),
-    z.object({ type: z.enum(['double']), values: z.number().array() }),
-    z.object({ type: z.enum(['boolean']), values: SafeBoolean.array() }),
-    z.object({ type: z.enum(['string']), values: z.string().array() }),
-    z.object({ type: z.enum(['integer_distribution']), values: Distributionint64.array() }),
-    z.object({ type: z.enum(['double_distribution']), values: Distributiondouble.array() }),
-  ])
-)
+    z.object({ type: z.enum(["integer"]), values: z.number().array() }),
+    z.object({ type: z.enum(["double"]), values: z.number().array() }),
+    z.object({ type: z.enum(["boolean"]), values: SafeBoolean.array() }),
+    z.object({ type: z.enum(["string"]), values: z.string().array() }),
+    z.object({
+      type: z.enum(["integer_distribution"]),
+      values: Distributionint64.array(),
+    }),
+    z.object({
+      type: z.enum(["double_distribution"]),
+      values: Distributiondouble.array(),
+    }),
+  ]),
+);
 
 /**
  * A single list of values, for one dimension of a timeseries.
  */
 export const Values = z.preprocess(
   processResponseBody,
-  z.object({ metricType: MetricType, values: ValueArray })
-)
+  z.object({ metricType: MetricType, values: ValueArray }),
+);
 
 /**
  * Timepoints and values for one timeseries.
@@ -2232,8 +2358,8 @@ export const Points = z.preprocess(
     startTimes: z.coerce.date().array().optional(),
     timestamps: z.coerce.date().array(),
     values: Values.array(),
-  })
-)
+  }),
+);
 
 /**
  * Identity-related metadata that's included in nearly all public API objects
@@ -2247,8 +2373,8 @@ export const Probe = z.preprocess(
     sled: z.string().uuid(),
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
-  })
-)
+  }),
+);
 
 /**
  * Create time parameters for probes.
@@ -2260,18 +2386,27 @@ export const ProbeCreate = z.preprocess(
     ipPool: NameOrId.optional(),
     name: Name,
     sled: z.string().uuid(),
-  })
-)
+  }),
+);
 
+export const ProbeExternalIpKindEnumArray = [
+  "snat",
+  "floating",
+  "ephemeral",
+] as const;
+export const ProbeExternalIpKind = z.preprocess(
+  processResponseBody,
+  z.enum(ProbeExternalIpKindEnumArray),
+);
 export const ProbeExternalIp = z.preprocess(
   processResponseBody,
   z.object({
     firstPort: z.number().min(0).max(65535),
     ip: z.string().ip(),
-    kind: IpKind,
+    kind: ProbeExternalIpKind,
     lastPort: z.number().min(0).max(65535),
-  })
-)
+  }),
+);
 
 export const ProbeInfo = z.preprocess(
   processResponseBody,
@@ -2281,16 +2416,16 @@ export const ProbeInfo = z.preprocess(
     interface: NetworkInterface,
     name: Name,
     sled: z.string().uuid(),
-  })
-)
+  }),
+);
 
 /**
  * A single page of results
  */
 export const ProbeInfoResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: ProbeInfo.array(), nextPage: z.string().optional() })
-)
+  z.object({ items: ProbeInfo.array(), nextPage: z.string().optional() }),
+);
 
 /**
  * View of a Project
@@ -2303,30 +2438,34 @@ export const Project = z.preprocess(
     name: Name,
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
-  })
-)
+  }),
+);
 
 /**
  * Create-time parameters for a `Project`
  */
 export const ProjectCreate = z.preprocess(
   processResponseBody,
-  z.object({ description: z.string(), name: Name })
-)
+  z.object({ description: z.string(), name: Name }),
+);
 
 /**
  * A single page of results
  */
 export const ProjectResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: Project.array(), nextPage: z.string().optional() })
-)
+  z.object({ items: Project.array(), nextPage: z.string().optional() }),
+);
 
+export const ProjectRoleEnumArray = [
+  "admin",
+  "collaborator",
+  "viewer",
+] as const;
 export const ProjectRole = z.preprocess(
   processResponseBody,
-  z.enum(['admin', 'collaborator', 'viewer'])
-)
-
+  z.enum(ProjectRoleEnumArray),
+);
 /**
  * Describes the assignment of a particular role on a particular resource to a particular identity (user, group, etc.)
  *
@@ -2338,8 +2477,8 @@ export const ProjectRoleRoleAssignment = z.preprocess(
     identityId: z.string().uuid(),
     identityType: IdentityType,
     roleName: ProjectRole,
-  })
-)
+  }),
+);
 
 /**
  * Policy for a particular resource
@@ -2348,16 +2487,16 @@ export const ProjectRoleRoleAssignment = z.preprocess(
  */
 export const ProjectRolePolicy = z.preprocess(
   processResponseBody,
-  z.object({ roleAssignments: ProjectRoleRoleAssignment.array() })
-)
+  z.object({ roleAssignments: ProjectRoleRoleAssignment.array() }),
+);
 
 /**
  * Updateable properties of a `Project`
  */
 export const ProjectUpdate = z.preprocess(
   processResponseBody,
-  z.object({ description: z.string().optional(), name: Name.optional() })
-)
+  z.object({ description: z.string().optional(), name: Name.optional() }),
+);
 
 /**
  * View of an Rack
@@ -2368,16 +2507,16 @@ export const Rack = z.preprocess(
     id: z.string().uuid(),
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
-  })
-)
+  }),
+);
 
 /**
  * A single page of results
  */
 export const RackResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: Rack.array(), nextPage: z.string().optional() })
-)
+  z.object({ items: Rack.array(), nextPage: z.string().optional() }),
+);
 
 /**
  * A name for a built-in role
@@ -2389,24 +2528,24 @@ export const RoleName = z.preprocess(
   z
     .string()
     .max(63)
-    .regex(/[a-z-]+\.[a-z-]+/)
-)
+    .regex(/[a-z-]+\.[a-z-]+/),
+);
 
 /**
  * View of a Role
  */
 export const Role = z.preprocess(
   processResponseBody,
-  z.object({ description: z.string(), name: RoleName })
-)
+  z.object({ description: z.string(), name: RoleName }),
+);
 
 /**
  * A single page of results
  */
 export const RoleResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: Role.array(), nextPage: z.string().optional() })
-)
+  z.object({ items: Role.array(), nextPage: z.string().optional() }),
+);
 
 /**
  * A route to a destination network through a gateway address.
@@ -2417,16 +2556,16 @@ export const Route = z.preprocess(
     dst: IpNet,
     gw: z.string().ip(),
     vid: z.number().min(0).max(65535).optional(),
-  })
-)
+  }),
+);
 
 /**
  * Route configuration data associated with a switch port configuration.
  */
 export const RouteConfig = z.preprocess(
   processResponseBody,
-  z.object({ routes: Route.array() })
-)
+  z.object({ routes: Route.array() }),
+);
 
 /**
  * A `RouteDestination` is used to match traffic with a routing rule, on the destination of that traffic.
@@ -2436,12 +2575,12 @@ export const RouteConfig = z.preprocess(
 export const RouteDestination = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ type: z.enum(['ip']), value: z.string().ip() }),
-    z.object({ type: z.enum(['ip_net']), value: IpNet }),
-    z.object({ type: z.enum(['vpc']), value: Name }),
-    z.object({ type: z.enum(['subnet']), value: Name }),
-  ])
-)
+    z.object({ type: z.enum(["ip"]), value: z.string().ip() }),
+    z.object({ type: z.enum(["ip_net"]), value: IpNet }),
+    z.object({ type: z.enum(["vpc"]), value: Name }),
+    z.object({ type: z.enum(["subnet"]), value: Name }),
+  ]),
+);
 
 /**
  * A `RouteTarget` describes the possible locations that traffic matching a route destination can be sent.
@@ -2449,14 +2588,14 @@ export const RouteDestination = z.preprocess(
 export const RouteTarget = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ type: z.enum(['ip']), value: z.string().ip() }),
-    z.object({ type: z.enum(['vpc']), value: Name }),
-    z.object({ type: z.enum(['subnet']), value: Name }),
-    z.object({ type: z.enum(['instance']), value: Name }),
-    z.object({ type: z.enum(['internet_gateway']), value: Name }),
-    z.object({ type: z.enum(['drop']) }),
-  ])
-)
+    z.object({ type: z.enum(["ip"]), value: z.string().ip() }),
+    z.object({ type: z.enum(["vpc"]), value: Name }),
+    z.object({ type: z.enum(["subnet"]), value: Name }),
+    z.object({ type: z.enum(["instance"]), value: Name }),
+    z.object({ type: z.enum(["internet_gateway"]), value: Name }),
+    z.object({ type: z.enum(["drop"]) }),
+  ]),
+);
 
 /**
  * The kind of a `RouterRoute`
@@ -2465,8 +2604,8 @@ export const RouteTarget = z.preprocess(
  */
 export const RouterRouteKind = z.preprocess(
   processResponseBody,
-  z.enum(['default', 'vpc_subnet', 'vpc_peering', 'custom'])
-)
+  z.enum(["default", "vpc_subnet", "vpc_peering", "custom"]),
+);
 
 /**
  * A route defines a rule that governs where traffic should be sent based on its destination.
@@ -2483,8 +2622,8 @@ export const RouterRoute = z.preprocess(
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
     vpcRouterId: z.string().uuid(),
-  })
-)
+  }),
+);
 
 /**
  * Create-time parameters for a `RouterRoute`
@@ -2496,16 +2635,16 @@ export const RouterRouteCreate = z.preprocess(
     destination: RouteDestination,
     name: Name,
     target: RouteTarget,
-  })
-)
+  }),
+);
 
 /**
  * A single page of results
  */
 export const RouterRouteResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: RouterRoute.array(), nextPage: z.string().optional() })
-)
+  z.object({ items: RouterRoute.array(), nextPage: z.string().optional() }),
+);
 
 /**
  * Updateable properties of a `RouterRoute`
@@ -2517,8 +2656,8 @@ export const RouterRouteUpdate = z.preprocess(
     destination: RouteDestination,
     name: Name.optional(),
     target: RouteTarget,
-  })
-)
+  }),
+);
 
 /**
  * Identity-related metadata that's included in nearly all public API objects
@@ -2538,8 +2677,8 @@ export const SamlIdentityProvider = z.preprocess(
     technicalContactEmail: z.string(),
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
-  })
-)
+  }),
+);
 
 /**
  * Create-time identity-related parameters
@@ -2557,16 +2696,16 @@ export const SamlIdentityProviderCreate = z.preprocess(
     sloUrl: z.string(),
     spClientId: z.string(),
     technicalContactEmail: z.string(),
-  })
-)
+  }),
+);
 
 /**
  * Describes how identities are managed and users are authenticated in this Silo
  */
 export const SiloIdentityMode = z.preprocess(
   processResponseBody,
-  z.enum(['saml_jit', 'local_only'])
-)
+  z.enum(["saml_jit", "local_only"]),
+);
 
 /**
  * View of a Silo
@@ -2580,20 +2719,23 @@ export const Silo = z.preprocess(
     discoverable: SafeBoolean,
     id: z.string().uuid(),
     identityMode: SiloIdentityMode,
-    mappedFleetRoles: z.record(z.string().min(1), FleetRole.array().refine(...uniqueItems)),
+    mappedFleetRoles: z.record(
+      z.string().min(1),
+      FleetRole.array().refine(...uniqueItems),
+    ),
     name: Name,
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
-  })
-)
+  }),
+);
 
 /**
  * The amount of provisionable resources for a Silo
  */
 export const SiloQuotasCreate = z.preprocess(
   processResponseBody,
-  z.object({ cpus: z.number(), memory: ByteCount, storage: ByteCount })
-)
+  z.object({ cpus: z.number(), memory: ByteCount, storage: ByteCount }),
+);
 
 /**
  * Create-time parameters for a `Silo`
@@ -2611,8 +2753,8 @@ export const SiloCreate = z.preprocess(
     name: Name,
     quotas: SiloQuotasCreate,
     tlsCertificates: CertificateCreate.array(),
-  })
-)
+  }),
+);
 
 /**
  * An IP pool in the context of a silo
@@ -2626,16 +2768,16 @@ export const SiloIpPool = z.preprocess(
     name: Name,
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
-  })
-)
+  }),
+);
 
 /**
  * A single page of results
  */
 export const SiloIpPoolResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: SiloIpPool.array(), nextPage: z.string().optional() })
-)
+  z.object({ items: SiloIpPool.array(), nextPage: z.string().optional() }),
+);
 
 /**
  * A collection of resource counts used to set the virtual capacity of a silo
@@ -2647,16 +2789,16 @@ export const SiloQuotas = z.preprocess(
     memory: ByteCount,
     siloId: z.string().uuid(),
     storage: ByteCount,
-  })
-)
+  }),
+);
 
 /**
  * A single page of results
  */
 export const SiloQuotasResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: SiloQuotas.array(), nextPage: z.string().optional() })
-)
+  z.object({ items: SiloQuotas.array(), nextPage: z.string().optional() }),
+);
 
 /**
  * Updateable properties of a Silo's resource limits. If a value is omitted it will not be updated.
@@ -2667,22 +2809,22 @@ export const SiloQuotasUpdate = z.preprocess(
     cpus: z.number().optional(),
     memory: ByteCount.optional(),
     storage: ByteCount.optional(),
-  })
-)
+  }),
+);
 
 /**
  * A single page of results
  */
 export const SiloResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: Silo.array(), nextPage: z.string().optional() })
-)
+  z.object({ items: Silo.array(), nextPage: z.string().optional() }),
+);
 
+export const SiloRoleEnumArray = ["admin", "collaborator", "viewer"] as const;
 export const SiloRole = z.preprocess(
   processResponseBody,
-  z.enum(['admin', 'collaborator', 'viewer'])
-)
-
+  z.enum(SiloRoleEnumArray),
+);
 /**
  * Describes the assignment of a particular role on a particular resource to a particular identity (user, group, etc.)
  *
@@ -2694,8 +2836,8 @@ export const SiloRoleRoleAssignment = z.preprocess(
     identityId: z.string().uuid(),
     identityType: IdentityType,
     roleName: SiloRole,
-  })
-)
+  }),
+);
 
 /**
  * Policy for a particular resource
@@ -2704,16 +2846,16 @@ export const SiloRoleRoleAssignment = z.preprocess(
  */
 export const SiloRolePolicy = z.preprocess(
   processResponseBody,
-  z.object({ roleAssignments: SiloRoleRoleAssignment.array() })
-)
+  z.object({ roleAssignments: SiloRoleRoleAssignment.array() }),
+);
 
 /**
  * A collection of resource counts used to describe capacity and utilization
  */
 export const VirtualResourceCounts = z.preprocess(
   processResponseBody,
-  z.object({ cpus: z.number(), memory: ByteCount, storage: ByteCount })
-)
+  z.object({ cpus: z.number(), memory: ByteCount, storage: ByteCount }),
+);
 
 /**
  * View of a silo's resource utilization and capacity
@@ -2725,16 +2867,16 @@ export const SiloUtilization = z.preprocess(
     provisioned: VirtualResourceCounts,
     siloId: z.string().uuid(),
     siloName: Name,
-  })
-)
+  }),
+);
 
 /**
  * A single page of results
  */
 export const SiloUtilizationResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: SiloUtilization.array(), nextPage: z.string().optional() })
-)
+  z.object({ items: SiloUtilization.array(), nextPage: z.string().optional() }),
+);
 
 /**
  * The operator-defined provision policy of a sled.
@@ -2743,8 +2885,8 @@ export const SiloUtilizationResultsPage = z.preprocess(
  */
 export const SledProvisionPolicy = z.preprocess(
   processResponseBody,
-  z.enum(['provisionable', 'non_provisionable'])
-)
+  z.enum(["provisionable", "non_provisionable"]),
+);
 
 /**
  * The operator-defined policy of a sled.
@@ -2752,18 +2894,21 @@ export const SledProvisionPolicy = z.preprocess(
 export const SledPolicy = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ kind: z.enum(['in_service']), provisionPolicy: SledProvisionPolicy }),
-    z.object({ kind: z.enum(['expunged']) }),
-  ])
-)
+    z.object({
+      kind: z.enum(["in_service"]),
+      provisionPolicy: SledProvisionPolicy,
+    }),
+    z.object({ kind: z.enum(["expunged"]) }),
+  ]),
+);
 
 /**
  * The current state of the sled, as determined by Nexus.
  */
 export const SledState = z.preprocess(
   processResponseBody,
-  z.enum(['active', 'decommissioned'])
-)
+  z.enum(["active", "decommissioned"]),
+);
 
 /**
  * An operator's view of a Sled.
@@ -2780,13 +2925,16 @@ export const Sled = z.preprocess(
     timeModified: z.coerce.date(),
     usableHardwareThreads: z.number().min(0).max(4294967295),
     usablePhysicalRam: ByteCount,
-  })
-)
+  }),
+);
 
 /**
  * The unique ID of a sled.
  */
-export const SledId = z.preprocess(processResponseBody, z.object({ id: z.string().uuid() }))
+export const SledId = z.preprocess(
+  processResponseBody,
+  z.object({ id: z.string().uuid() }),
+);
 
 /**
  * An operator's view of an instance running on a given sled
@@ -2805,46 +2953,51 @@ export const SledInstance = z.preprocess(
     state: InstanceState,
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
-  })
-)
+  }),
+);
 
 /**
  * A single page of results
  */
 export const SledInstanceResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: SledInstance.array(), nextPage: z.string().optional() })
-)
+  z.object({ items: SledInstance.array(), nextPage: z.string().optional() }),
+);
 
 /**
  * Parameters for `sled_set_provision_policy`.
  */
 export const SledProvisionPolicyParams = z.preprocess(
   processResponseBody,
-  z.object({ state: SledProvisionPolicy })
-)
+  z.object({ state: SledProvisionPolicy }),
+);
 
 /**
  * Response to `sled_set_provision_policy`.
  */
 export const SledProvisionPolicyResponse = z.preprocess(
   processResponseBody,
-  z.object({ newState: SledProvisionPolicy, oldState: SledProvisionPolicy })
-)
+  z.object({ newState: SledProvisionPolicy, oldState: SledProvisionPolicy }),
+);
 
 /**
  * A single page of results
  */
 export const SledResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: Sled.array(), nextPage: z.string().optional() })
-)
+  z.object({ items: Sled.array(), nextPage: z.string().optional() }),
+);
 
+export const SnapshotStateEnumArray = [
+  "creating",
+  "ready",
+  "faulted",
+  "destroyed",
+] as const;
 export const SnapshotState = z.preprocess(
   processResponseBody,
-  z.enum(['creating', 'ready', 'faulted', 'destroyed'])
-)
-
+  z.enum(SnapshotStateEnumArray),
+);
 /**
  * View of a Snapshot
  */
@@ -2860,24 +3013,24 @@ export const Snapshot = z.preprocess(
     state: SnapshotState,
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
-  })
-)
+  }),
+);
 
 /**
  * Create-time parameters for a `Snapshot`
  */
 export const SnapshotCreate = z.preprocess(
   processResponseBody,
-  z.object({ description: z.string(), disk: NameOrId, name: Name })
-)
+  z.object({ description: z.string(), disk: NameOrId, name: Name }),
+);
 
 /**
  * A single page of results
  */
 export const SnapshotResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: Snapshot.array(), nextPage: z.string().optional() })
-)
+  z.object({ items: Snapshot.array(), nextPage: z.string().optional() }),
+);
 
 /**
  * View of an SSH Key
@@ -2892,24 +3045,24 @@ export const SshKey = z.preprocess(
     siloUserId: z.string().uuid(),
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
-  })
-)
+  }),
+);
 
 /**
  * Create-time parameters for an `SshKey`
  */
 export const SshKeyCreate = z.preprocess(
   processResponseBody,
-  z.object({ description: z.string(), name: Name, publicKey: z.string() })
-)
+  z.object({ description: z.string(), name: Name, publicKey: z.string() }),
+);
 
 /**
  * A single page of results
  */
 export const SshKeyResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: SshKey.array(), nextPage: z.string().optional() })
-)
+  z.object({ items: SshKey.array(), nextPage: z.string().optional() }),
+);
 
 /**
  * An operator's view of a Switch.
@@ -2922,16 +3075,16 @@ export const Switch = z.preprocess(
     rackId: z.string().uuid(),
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
-  })
-)
+  }),
+);
 
 /**
  * Describes the kind of an switch interface.
  */
 export const SwitchInterfaceKind2 = z.preprocess(
   processResponseBody,
-  z.enum(['primary', 'vlan', 'loopback'])
-)
+  z.enum(["primary", "vlan", "loopback"]),
+);
 
 /**
  * A switch port interface configuration for a port settings object.
@@ -2944,8 +3097,8 @@ export const SwitchInterfaceConfig = z.preprocess(
     kind: SwitchInterfaceKind2,
     portSettingsId: z.string().uuid(),
     v6Enabled: SafeBoolean,
-  })
-)
+  }),
+);
 
 /**
  * Indicates the kind for a switch interface.
@@ -2953,21 +3106,24 @@ export const SwitchInterfaceConfig = z.preprocess(
 export const SwitchInterfaceKind = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ type: z.enum(['primary']) }),
-    z.object({ type: z.enum(['vlan']), vid: z.number().min(0).max(65535) }),
-    z.object({ type: z.enum(['loopback']) }),
-  ])
-)
+    z.object({ type: z.enum(["primary"]) }),
+    z.object({ type: z.enum(["vlan"]), vid: z.number().min(0).max(65535) }),
+    z.object({ type: z.enum(["loopback"]) }),
+  ]),
+);
 
 /**
  * A layer-3 switch interface configuration. When IPv6 is enabled, a link local address will be created for the interface.
  */
 export const SwitchInterfaceConfigCreate = z.preprocess(
   processResponseBody,
-  z.object({ kind: SwitchInterfaceKind, v6Enabled: SafeBoolean })
-)
+  z.object({ kind: SwitchInterfaceKind, v6Enabled: SafeBoolean }),
+);
 
-export const SwitchLinkState = z.preprocess(processResponseBody, z.record(z.unknown()))
+export const SwitchLinkState = z.preprocess(
+  processResponseBody,
+  z.record(z.unknown()),
+);
 
 /**
  * A switch port represents a physical external port on a rack switch.
@@ -2980,8 +3136,8 @@ export const SwitchPort = z.preprocess(
     portSettingsId: z.string().uuid().optional(),
     rackId: z.string().uuid(),
     switchLocation: z.string(),
-  })
-)
+  }),
+);
 
 /**
  * An IP address configuration for a port settings object.
@@ -2994,48 +3150,51 @@ export const SwitchPortAddressConfig = z.preprocess(
     interfaceName: z.string(),
     portSettingsId: z.string().uuid(),
     vlanId: z.number().min(0).max(65535).optional(),
-  })
-)
+  }),
+);
 
 /**
  * Parameters for applying settings to switch ports.
  */
 export const SwitchPortApplySettings = z.preprocess(
   processResponseBody,
-  z.object({ portSettings: NameOrId })
-)
+  z.object({ portSettings: NameOrId }),
+);
 
 /**
  * The link geometry associated with a switch port.
  */
 export const SwitchPortGeometry2 = z.preprocess(
   processResponseBody,
-  z.enum(['qsfp28x1', 'qsfp28x2', 'sfp28x4'])
-)
+  z.enum(["qsfp28x1", "qsfp28x2", "sfp28x4"]),
+);
 
 /**
  * A physical port configuration for a port settings object.
  */
 export const SwitchPortConfig = z.preprocess(
   processResponseBody,
-  z.object({ geometry: SwitchPortGeometry2, portSettingsId: z.string().uuid() })
-)
+  z.object({
+    geometry: SwitchPortGeometry2,
+    portSettingsId: z.string().uuid(),
+  }),
+);
 
 /**
  * The link geometry associated with a switch port.
  */
 export const SwitchPortGeometry = z.preprocess(
   processResponseBody,
-  z.enum(['qsfp28x1', 'qsfp28x2', 'sfp28x4'])
-)
+  z.enum(["qsfp28x1", "qsfp28x2", "sfp28x4"]),
+);
 
 /**
  * Physical switch port configuration.
  */
 export const SwitchPortConfigCreate = z.preprocess(
   processResponseBody,
-  z.object({ geometry: SwitchPortGeometry })
-)
+  z.object({ geometry: SwitchPortGeometry }),
+);
 
 /**
  * A link configuration for a port settings object.
@@ -3050,16 +3209,16 @@ export const SwitchPortLinkConfig = z.preprocess(
     mtu: z.number().min(0).max(65535),
     portSettingsId: z.string().uuid(),
     speed: LinkSpeed,
-  })
-)
+  }),
+);
 
 /**
  * A single page of results
  */
 export const SwitchPortResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: SwitchPort.array(), nextPage: z.string().optional() })
-)
+  z.object({ items: SwitchPort.array(), nextPage: z.string().optional() }),
+);
 
 /**
  * A route configuration for a port settings object.
@@ -3072,8 +3231,8 @@ export const SwitchPortRouteConfig = z.preprocess(
     interfaceName: z.string(),
     portSettingsId: z.string().uuid(),
     vlanId: z.number().min(0).max(65535).optional(),
-  })
-)
+  }),
+);
 
 /**
  * A switch port settings identity whose id may be used to view additional details.
@@ -3086,8 +3245,8 @@ export const SwitchPortSettings = z.preprocess(
     name: Name,
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
-  })
-)
+  }),
+);
 
 /**
  * Parameters for creating switch port settings. Switch port settings are the central data structure for setting up external networking. Switch port settings include link, interface, route, address and dynamic network protocol configuration.
@@ -3104,32 +3263,41 @@ export const SwitchPortSettingsCreate = z.preprocess(
     name: Name,
     portConfig: SwitchPortConfigCreate,
     routes: z.record(z.string().min(1), RouteConfig),
-  })
-)
+  }),
+);
 
 /**
  * This structure maps a port settings object to a port settings groups. Port settings objects may inherit settings from groups. This mapping defines the relationship between settings objects and the groups they reference.
  */
 export const SwitchPortSettingsGroups = z.preprocess(
   processResponseBody,
-  z.object({ portSettingsGroupId: z.string().uuid(), portSettingsId: z.string().uuid() })
-)
+  z.object({
+    portSettingsGroupId: z.string().uuid(),
+    portSettingsId: z.string().uuid(),
+  }),
+);
 
 /**
  * A single page of results
  */
 export const SwitchPortSettingsResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: SwitchPortSettings.array(), nextPage: z.string().optional() })
-)
+  z.object({
+    items: SwitchPortSettings.array(),
+    nextPage: z.string().optional(),
+  }),
+);
 
 /**
  * A switch port VLAN interface configuration for a port settings object.
  */
 export const SwitchVlanInterfaceConfig = z.preprocess(
   processResponseBody,
-  z.object({ interfaceConfigId: z.string().uuid(), vlanId: z.number().min(0).max(65535) })
-)
+  z.object({
+    interfaceConfigId: z.string().uuid(),
+    vlanId: z.number().min(0).max(65535),
+  }),
+);
 
 /**
  * This structure contains all port settings information in one place. It's a convenience data structure for getting a complete view of a particular port's settings.
@@ -3147,16 +3315,16 @@ export const SwitchPortSettingsView = z.preprocess(
     routes: SwitchPortRouteConfig.array(),
     settings: SwitchPortSettings,
     vlanInterfaces: SwitchVlanInterfaceConfig.array(),
-  })
-)
+  }),
+);
 
 /**
  * A single page of results
  */
 export const SwitchResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: Switch.array(), nextPage: z.string().optional() })
-)
+  z.object({ items: Switch.array(), nextPage: z.string().optional() }),
+);
 
 /**
  * A timeseries contains a timestamped set of values from one source.
@@ -3165,8 +3333,8 @@ export const SwitchResultsPage = z.preprocess(
  */
 export const Timeseries = z.preprocess(
   processResponseBody,
-  z.object({ fields: z.record(z.string().min(1), FieldValue), points: Points })
-)
+  z.object({ fields: z.record(z.string().min(1), FieldValue), points: Points }),
+);
 
 /**
  * A table represents one or more timeseries with the same schema.
@@ -3175,16 +3343,19 @@ export const Timeseries = z.preprocess(
  */
 export const Table = z.preprocess(
   processResponseBody,
-  z.object({ name: z.string(), timeseries: z.record(z.string().min(1), Timeseries) })
-)
+  z.object({
+    name: z.string(),
+    timeseries: z.record(z.string().min(1), Timeseries),
+  }),
+);
 
 /**
  * Text descriptions for the target and metric of a timeseries.
  */
 export const TimeseriesDescription = z.preprocess(
   processResponseBody,
-  z.object({ metric: z.string(), target: z.string() })
-)
+  z.object({ metric: z.string(), target: z.string() }),
+);
 
 /**
  * The name of a timeseries
@@ -3195,21 +3366,29 @@ export const TimeseriesName = z.preprocess(
   processResponseBody,
   z
     .string()
-    .regex(/^(([a-z]+[a-z0-9]*)(_([a-z0-9]+))*):(([a-z]+[a-z0-9]*)(_([a-z0-9]+))*)$/)
-)
+    .regex(
+      /^(([a-z]+[a-z0-9]*)(_([a-z0-9]+))*):(([a-z]+[a-z0-9]*)(_([a-z0-9]+))*)$/,
+    ),
+);
 
 /**
  * A timeseries query string, written in the Oximeter query language.
  */
 export const TimeseriesQuery = z.preprocess(
   processResponseBody,
-  z.object({ query: z.string() })
-)
+  z.object({ query: z.string() }),
+);
 
 /**
  * Measurement units for timeseries samples.
  */
-export const Units = z.preprocess(processResponseBody, z.enum(['count', 'bytes']))
+export const Units = z.preprocess(
+  processResponseBody,
+  z.union([
+    z.enum(["count", "bytes", "seconds", "nanoseconds"]),
+    z.enum(["none"]),
+  ]),
+);
 
 /**
  * The schema for a timeseries.
@@ -3227,16 +3406,19 @@ export const TimeseriesSchema = z.preprocess(
     timeseriesName: TimeseriesName,
     units: Units,
     version: z.number().min(1).max(255),
-  })
-)
+  }),
+);
 
 /**
  * A single page of results
  */
 export const TimeseriesSchemaResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: TimeseriesSchema.array(), nextPage: z.string().optional() })
-)
+  z.object({
+    items: TimeseriesSchema.array(),
+    nextPage: z.string().optional(),
+  }),
+);
 
 /**
  * A sled that has not been added to an initialized rack yet
@@ -3247,37 +3429,44 @@ export const UninitializedSled = z.preprocess(
     baseboard: Baseboard,
     cubby: z.number().min(0).max(65535),
     rackId: z.string().uuid(),
-  })
-)
+  }),
+);
 
 /**
  * The unique hardware ID for a sled
  */
 export const UninitializedSledId = z.preprocess(
   processResponseBody,
-  z.object({ part: z.string(), serial: z.string() })
-)
+  z.object({ part: z.string(), serial: z.string() }),
+);
 
 /**
  * A single page of results
  */
 export const UninitializedSledResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: UninitializedSled.array(), nextPage: z.string().optional() })
-)
+  z.object({
+    items: UninitializedSled.array(),
+    nextPage: z.string().optional(),
+  }),
+);
 
 /**
  * View of a User
  */
 export const User = z.preprocess(
   processResponseBody,
-  z.object({ displayName: z.string(), id: z.string().uuid(), siloId: z.string().uuid() })
-)
+  z.object({
+    displayName: z.string(),
+    id: z.string().uuid(),
+    siloId: z.string().uuid(),
+  }),
+);
 
 /**
  * View of a Built-in User
  *
- * A Built-in User is explicitly created as opposed to being derived from an Identify Provider.
+ * Built-in users are identities internal to the system, used when the control plane performs actions autonomously
  */
 export const UserBuiltin = z.preprocess(
   processResponseBody,
@@ -3287,21 +3476,21 @@ export const UserBuiltin = z.preprocess(
     name: Name,
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
-  })
-)
+  }),
+);
 
 /**
  * A single page of results
  */
 export const UserBuiltinResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: UserBuiltin.array(), nextPage: z.string().optional() })
-)
+  z.object({ items: UserBuiltin.array(), nextPage: z.string().optional() }),
+);
 
 /**
- * A name unique within the parent collection
+ * A username for a local-only user
  *
- * Names must begin with a lower case ASCII letter, be composed exclusively of lowercase ASCII, uppercase ASCII, numbers, and '-', and may not end with a '-'. Names cannot be a UUID, but they may contain a UUID. They can be at most 63 characters long.
+ * Usernames must begin with a lower case ASCII letter, be composed exclusively of lowercase ASCII, uppercase ASCII, numbers, and '-', and may not end with a '-'. Usernames cannot be a UUID, but they may contain a UUID. They can be at most 63 characters long.
  */
 export const UserId = z.preprocess(
   processResponseBody,
@@ -3310,9 +3499,9 @@ export const UserId = z.preprocess(
     .min(1)
     .max(63)
     .regex(
-      /^(?![0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)^[a-z]([a-zA-Z0-9-]*[a-zA-Z0-9]+)?$/
-    )
-)
+      /^(?![0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)^[a-z]([a-zA-Z0-9-]*[a-zA-Z0-9]+)?$/,
+    ),
+);
 
 /**
  * Parameters for setting a user's password
@@ -3320,42 +3509,45 @@ export const UserId = z.preprocess(
 export const UserPassword = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ mode: z.enum(['password']), value: Password }),
-    z.object({ mode: z.enum(['login_disallowed']) }),
-  ])
-)
+    z.object({ mode: z.enum(["password"]), value: Password }),
+    z.object({ mode: z.enum(["login_disallowed"]) }),
+  ]),
+);
 
 /**
  * Create-time parameters for a `User`
  */
 export const UserCreate = z.preprocess(
   processResponseBody,
-  z.object({ externalId: UserId, password: UserPassword })
-)
+  z.object({ externalId: UserId, password: UserPassword }),
+);
 
 /**
  * A single page of results
  */
 export const UserResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: User.array(), nextPage: z.string().optional() })
-)
+  z.object({ items: User.array(), nextPage: z.string().optional() }),
+);
 
 /**
  * Credentials for local user login
  */
 export const UsernamePasswordCredentials = z.preprocess(
   processResponseBody,
-  z.object({ password: Password, username: UserId })
-)
+  z.object({ password: Password, username: UserId }),
+);
 
 /**
  * View of the current silo's resource utilization and capacity
  */
 export const Utilization = z.preprocess(
   processResponseBody,
-  z.object({ capacity: VirtualResourceCounts, provisioned: VirtualResourceCounts })
-)
+  z.object({
+    capacity: VirtualResourceCounts,
+    provisioned: VirtualResourceCounts,
+  }),
+);
 
 /**
  * View of a VPC
@@ -3372,8 +3564,8 @@ export const Vpc = z.preprocess(
     systemRouterId: z.string().uuid(),
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
-  })
-)
+  }),
+);
 
 /**
  * Create-time parameters for a `Vpc`
@@ -3385,43 +3577,46 @@ export const VpcCreate = z.preprocess(
     dnsName: Name,
     ipv6Prefix: Ipv6Net.optional(),
     name: Name,
-  })
-)
+  }),
+);
 
+export const VpcFirewallRuleActionEnumArray = ["allow", "deny"] as const;
 export const VpcFirewallRuleAction = z.preprocess(
   processResponseBody,
-  z.enum(['allow', 'deny'])
-)
-
+  z.enum(VpcFirewallRuleActionEnumArray),
+);
+export const VpcFirewallRuleDirectionEnumArray = [
+  "inbound",
+  "outbound",
+] as const;
 export const VpcFirewallRuleDirection = z.preprocess(
   processResponseBody,
-  z.enum(['inbound', 'outbound'])
-)
-
+  z.enum(VpcFirewallRuleDirectionEnumArray),
+);
 /**
  * The `VpcFirewallRuleHostFilter` is used to filter traffic on the basis of its source or destination host.
  */
 export const VpcFirewallRuleHostFilter = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ type: z.enum(['vpc']), value: Name }),
-    z.object({ type: z.enum(['subnet']), value: Name }),
-    z.object({ type: z.enum(['instance']), value: Name }),
-    z.object({ type: z.enum(['ip']), value: z.string().ip() }),
-    z.object({ type: z.enum(['ip_net']), value: IpNet }),
-  ])
-)
+    z.object({ type: z.enum(["vpc"]), value: Name }),
+    z.object({ type: z.enum(["subnet"]), value: Name }),
+    z.object({ type: z.enum(["instance"]), value: Name }),
+    z.object({ type: z.enum(["ip"]), value: z.string().ip() }),
+    z.object({ type: z.enum(["ip_net"]), value: IpNet }),
+  ]),
+);
 
 /**
  * The protocols that may be specified in a firewall rule's filter
  */
+export const VpcFirewallRuleProtocolEnumArray = ["TCP", "UDP", "ICMP"] as const;
 export const VpcFirewallRuleProtocol = z.preprocess(
   processResponseBody,
-  z.enum(['TCP', 'UDP', 'ICMP'])
-)
-
+  z.enum(VpcFirewallRuleProtocolEnumArray),
+);
 /**
- * Filter for a firewall rule. A given packet must match every field that is present for the rule to apply to it. A packet matches a field if any entry in that field matches the packet.
+ * Filters reduce the scope of a firewall rule. Without filters, the rule applies to all packets to the targets (or from the targets, if it's an outbound rule). With multiple filters, the rule applies only to packets matching ALL filters. The maximum number of each type of filter is 256.
  */
 export const VpcFirewallRuleFilter = z.preprocess(
   processResponseBody,
@@ -3429,27 +3624,27 @@ export const VpcFirewallRuleFilter = z.preprocess(
     hosts: VpcFirewallRuleHostFilter.array().optional(),
     ports: L4PortRange.array().optional(),
     protocols: VpcFirewallRuleProtocol.array().optional(),
-  })
-)
+  }),
+);
 
+export const VpcFirewallRuleStatusEnumArray = ["disabled", "enabled"] as const;
 export const VpcFirewallRuleStatus = z.preprocess(
   processResponseBody,
-  z.enum(['disabled', 'enabled'])
-)
-
+  z.enum(VpcFirewallRuleStatusEnumArray),
+);
 /**
- * A `VpcFirewallRuleTarget` is used to specify the set of `Instance`s to which a firewall rule applies.
+ * A `VpcFirewallRuleTarget` is used to specify the set of instances to which a firewall rule applies. You can target instances directly by name, or specify a VPC, VPC subnet, IP, or IP subnet, which will apply the rule to traffic going to all matching instances. Targets are additive: the rule applies to instances matching ANY target.
  */
 export const VpcFirewallRuleTarget = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ type: z.enum(['vpc']), value: Name }),
-    z.object({ type: z.enum(['subnet']), value: Name }),
-    z.object({ type: z.enum(['instance']), value: Name }),
-    z.object({ type: z.enum(['ip']), value: z.string().ip() }),
-    z.object({ type: z.enum(['ip_net']), value: IpNet }),
-  ])
-)
+    z.object({ type: z.enum(["vpc"]), value: Name }),
+    z.object({ type: z.enum(["subnet"]), value: Name }),
+    z.object({ type: z.enum(["instance"]), value: Name }),
+    z.object({ type: z.enum(["ip"]), value: z.string().ip() }),
+    z.object({ type: z.enum(["ip_net"]), value: IpNet }),
+  ]),
+);
 
 /**
  * A single rule in a VPC firewall
@@ -3469,8 +3664,8 @@ export const VpcFirewallRule = z.preprocess(
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
     vpcId: z.string().uuid(),
-  })
-)
+  }),
+);
 
 /**
  * A single rule in a VPC firewall
@@ -3486,35 +3681,38 @@ export const VpcFirewallRuleUpdate = z.preprocess(
     priority: z.number().min(0).max(65535),
     status: VpcFirewallRuleStatus,
     targets: VpcFirewallRuleTarget.array(),
-  })
-)
+  }),
+);
 
 /**
- * Updateable properties of a `Vpc`'s firewall Note that VpcFirewallRules are implicitly created along with a Vpc, so there is no explicit creation.
+ * Updated list of firewall rules. Will replace all existing rules.
  */
 export const VpcFirewallRuleUpdateParams = z.preprocess(
   processResponseBody,
-  z.object({ rules: VpcFirewallRuleUpdate.array() })
-)
+  z.object({ rules: VpcFirewallRuleUpdate.array() }),
+);
 
 /**
  * Collection of a Vpc's firewall rules
  */
 export const VpcFirewallRules = z.preprocess(
   processResponseBody,
-  z.object({ rules: VpcFirewallRule.array() })
-)
+  z.object({ rules: VpcFirewallRule.array() }),
+);
 
 /**
  * A single page of results
  */
 export const VpcResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: Vpc.array(), nextPage: z.string().optional() })
-)
+  z.object({ items: Vpc.array(), nextPage: z.string().optional() }),
+);
 
-export const VpcRouterKind = z.preprocess(processResponseBody, z.enum(['system', 'custom']))
-
+export const VpcRouterKindEnumArray = ["system", "custom"] as const;
+export const VpcRouterKind = z.preprocess(
+  processResponseBody,
+  z.enum(VpcRouterKindEnumArray),
+);
 /**
  * A VPC router defines a series of rules that indicate where traffic should be sent depending on its destination.
  */
@@ -3528,32 +3726,32 @@ export const VpcRouter = z.preprocess(
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
     vpcId: z.string().uuid(),
-  })
-)
+  }),
+);
 
 /**
  * Create-time parameters for a `VpcRouter`
  */
 export const VpcRouterCreate = z.preprocess(
   processResponseBody,
-  z.object({ description: z.string(), name: Name })
-)
+  z.object({ description: z.string(), name: Name }),
+);
 
 /**
  * A single page of results
  */
 export const VpcRouterResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: VpcRouter.array(), nextPage: z.string().optional() })
-)
+  z.object({ items: VpcRouter.array(), nextPage: z.string().optional() }),
+);
 
 /**
  * Updateable properties of a `VpcRouter`
  */
 export const VpcRouterUpdate = z.preprocess(
   processResponseBody,
-  z.object({ description: z.string().optional(), name: Name.optional() })
-)
+  z.object({ description: z.string().optional(), name: Name.optional() }),
+);
 
 /**
  * A VPC subnet represents a logical grouping for instances that allows network traffic between them, within a IPv4 subnetwork or optionally an IPv6 subnetwork.
@@ -3570,8 +3768,8 @@ export const VpcSubnet = z.preprocess(
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
     vpcId: z.string().uuid(),
-  })
-)
+  }),
+);
 
 /**
  * Create-time parameters for a `VpcSubnet`
@@ -3584,16 +3782,16 @@ export const VpcSubnetCreate = z.preprocess(
     ipv4Block: Ipv4Net,
     ipv6Block: Ipv6Net.optional(),
     name: Name,
-  })
-)
+  }),
+);
 
 /**
  * A single page of results
  */
 export const VpcSubnetResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: VpcSubnet.array(), nextPage: z.string().optional() })
-)
+  z.object({ items: VpcSubnet.array(), nextPage: z.string().optional() }),
+);
 
 /**
  * Updateable properties of a `VpcSubnet`
@@ -3604,8 +3802,8 @@ export const VpcSubnetUpdate = z.preprocess(
     customRouter: NameOrId.optional(),
     description: z.string().optional(),
     name: Name.optional(),
-  })
-)
+  }),
+);
 
 /**
  * Updateable properties of a `Vpc`
@@ -3616,72 +3814,89 @@ export const VpcUpdate = z.preprocess(
     description: z.string().optional(),
     dnsName: Name.optional(),
     name: Name.optional(),
-  })
-)
+  }),
+);
 
 /**
  * Supported set of sort modes for scanning by name or id
  */
 export const NameOrIdSortMode = z.preprocess(
   processResponseBody,
-  z.enum(['name_ascending', 'name_descending', 'id_ascending'])
-)
+  z.enum(["name_ascending", "name_descending", "id_ascending"]),
+);
 
+export const DiskMetricNameEnumArray = [
+  "activated",
+  "flush",
+  "read",
+  "read_bytes",
+  "write",
+  "write_bytes",
+] as const;
 export const DiskMetricName = z.preprocess(
   processResponseBody,
-  z.enum(['activated', 'flush', 'read', 'read_bytes', 'write', 'write_bytes'])
-)
-
+  z.enum(DiskMetricNameEnumArray),
+);
 /**
  * The order in which the client wants to page through the requested collection
  */
+export const PaginationOrderEnumArray = ["ascending", "descending"] as const;
 export const PaginationOrder = z.preprocess(
   processResponseBody,
-  z.enum(['ascending', 'descending'])
-)
-
+  z.enum(PaginationOrderEnumArray),
+);
 /**
  * Supported set of sort modes for scanning by id only.
  *
  * Currently, we only support scanning in ascending order.
  */
-export const IdSortMode = z.preprocess(processResponseBody, z.enum(['id_ascending']))
+export const IdSortMode = z.preprocess(
+  processResponseBody,
+  z.enum(["id_ascending"]),
+);
 
+export const SystemMetricNameEnumArray = [
+  "virtual_disk_space_provisioned",
+  "cpus_provisioned",
+  "ram_provisioned",
+] as const;
 export const SystemMetricName = z.preprocess(
   processResponseBody,
-  z.enum(['virtual_disk_space_provisioned', 'cpus_provisioned', 'ram_provisioned'])
-)
-
+  z.enum(SystemMetricNameEnumArray),
+);
 /**
  * Supported set of sort modes for scanning by name only
  *
  * Currently, we only support scanning in ascending order.
  */
-export const NameSortMode = z.preprocess(processResponseBody, z.enum(['name_ascending']))
+export const NameSortMode = z.preprocess(
+  processResponseBody,
+  z.enum(["name_ascending"]),
+);
 
 export const DeviceAuthRequestParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({}),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const DeviceAuthConfirmParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({}),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const DeviceAccessTokenParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({}),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const ProbeListParams = z.preprocess(
   processResponseBody,
@@ -3693,8 +3908,8 @@ export const ProbeListParams = z.preprocess(
       project: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const ProbeCreateParams = z.preprocess(
   processResponseBody,
@@ -3703,8 +3918,8 @@ export const ProbeCreateParams = z.preprocess(
     query: z.object({
       project: NameOrId,
     }),
-  })
-)
+  }),
+);
 
 export const ProbeViewParams = z.preprocess(
   processResponseBody,
@@ -3715,8 +3930,8 @@ export const ProbeViewParams = z.preprocess(
     query: z.object({
       project: NameOrId,
     }),
-  })
-)
+  }),
+);
 
 export const ProbeDeleteParams = z.preprocess(
   processResponseBody,
@@ -3727,8 +3942,8 @@ export const ProbeDeleteParams = z.preprocess(
     query: z.object({
       project: NameOrId,
     }),
-  })
-)
+  }),
+);
 
 export const LoginSamlParams = z.preprocess(
   processResponseBody,
@@ -3738,8 +3953,8 @@ export const LoginSamlParams = z.preprocess(
       siloName: Name,
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const CertificateListParams = z.preprocess(
   processResponseBody,
@@ -3750,16 +3965,16 @@ export const CertificateListParams = z.preprocess(
       pageToken: z.string().optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const CertificateCreateParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({}),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const CertificateViewParams = z.preprocess(
   processResponseBody,
@@ -3768,8 +3983,8 @@ export const CertificateViewParams = z.preprocess(
       certificate: NameOrId,
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const CertificateDeleteParams = z.preprocess(
   processResponseBody,
@@ -3778,8 +3993,8 @@ export const CertificateDeleteParams = z.preprocess(
       certificate: NameOrId,
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const DiskListParams = z.preprocess(
   processResponseBody,
@@ -3791,8 +4006,8 @@ export const DiskListParams = z.preprocess(
       project: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const DiskCreateParams = z.preprocess(
   processResponseBody,
@@ -3801,8 +4016,8 @@ export const DiskCreateParams = z.preprocess(
     query: z.object({
       project: NameOrId,
     }),
-  })
-)
+  }),
+);
 
 export const DiskViewParams = z.preprocess(
   processResponseBody,
@@ -3813,8 +4028,8 @@ export const DiskViewParams = z.preprocess(
     query: z.object({
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const DiskDeleteParams = z.preprocess(
   processResponseBody,
@@ -3825,8 +4040,8 @@ export const DiskDeleteParams = z.preprocess(
     query: z.object({
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const DiskBulkWriteImportParams = z.preprocess(
   processResponseBody,
@@ -3837,8 +4052,8 @@ export const DiskBulkWriteImportParams = z.preprocess(
     query: z.object({
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const DiskBulkWriteImportStartParams = z.preprocess(
   processResponseBody,
@@ -3849,8 +4064,8 @@ export const DiskBulkWriteImportStartParams = z.preprocess(
     query: z.object({
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const DiskBulkWriteImportStopParams = z.preprocess(
   processResponseBody,
@@ -3861,8 +4076,8 @@ export const DiskBulkWriteImportStopParams = z.preprocess(
     query: z.object({
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const DiskFinalizeImportParams = z.preprocess(
   processResponseBody,
@@ -3873,8 +4088,8 @@ export const DiskFinalizeImportParams = z.preprocess(
     query: z.object({
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const DiskMetricsListParams = z.preprocess(
   processResponseBody,
@@ -3891,8 +4106,8 @@ export const DiskMetricsListParams = z.preprocess(
       startTime: z.coerce.date().optional(),
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const FloatingIpListParams = z.preprocess(
   processResponseBody,
@@ -3904,8 +4119,8 @@ export const FloatingIpListParams = z.preprocess(
       project: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const FloatingIpCreateParams = z.preprocess(
   processResponseBody,
@@ -3914,8 +4129,8 @@ export const FloatingIpCreateParams = z.preprocess(
     query: z.object({
       project: NameOrId,
     }),
-  })
-)
+  }),
+);
 
 export const FloatingIpViewParams = z.preprocess(
   processResponseBody,
@@ -3926,8 +4141,8 @@ export const FloatingIpViewParams = z.preprocess(
     query: z.object({
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const FloatingIpUpdateParams = z.preprocess(
   processResponseBody,
@@ -3938,8 +4153,8 @@ export const FloatingIpUpdateParams = z.preprocess(
     query: z.object({
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const FloatingIpDeleteParams = z.preprocess(
   processResponseBody,
@@ -3950,8 +4165,8 @@ export const FloatingIpDeleteParams = z.preprocess(
     query: z.object({
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const FloatingIpAttachParams = z.preprocess(
   processResponseBody,
@@ -3962,8 +4177,8 @@ export const FloatingIpAttachParams = z.preprocess(
     query: z.object({
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const FloatingIpDetachParams = z.preprocess(
   processResponseBody,
@@ -3974,8 +4189,8 @@ export const FloatingIpDetachParams = z.preprocess(
     query: z.object({
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const GroupListParams = z.preprocess(
   processResponseBody,
@@ -3986,8 +4201,8 @@ export const GroupListParams = z.preprocess(
       pageToken: z.string().optional(),
       sortBy: IdSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const GroupViewParams = z.preprocess(
   processResponseBody,
@@ -3996,8 +4211,8 @@ export const GroupViewParams = z.preprocess(
       groupId: z.string().uuid(),
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const ImageListParams = z.preprocess(
   processResponseBody,
@@ -4009,8 +4224,8 @@ export const ImageListParams = z.preprocess(
       project: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const ImageCreateParams = z.preprocess(
   processResponseBody,
@@ -4019,8 +4234,8 @@ export const ImageCreateParams = z.preprocess(
     query: z.object({
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const ImageViewParams = z.preprocess(
   processResponseBody,
@@ -4031,8 +4246,8 @@ export const ImageViewParams = z.preprocess(
     query: z.object({
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const ImageDeleteParams = z.preprocess(
   processResponseBody,
@@ -4043,8 +4258,8 @@ export const ImageDeleteParams = z.preprocess(
     query: z.object({
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const ImageDemoteParams = z.preprocess(
   processResponseBody,
@@ -4055,8 +4270,8 @@ export const ImageDemoteParams = z.preprocess(
     query: z.object({
       project: NameOrId,
     }),
-  })
-)
+  }),
+);
 
 export const ImagePromoteParams = z.preprocess(
   processResponseBody,
@@ -4067,8 +4282,8 @@ export const ImagePromoteParams = z.preprocess(
     query: z.object({
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const InstanceListParams = z.preprocess(
   processResponseBody,
@@ -4080,8 +4295,8 @@ export const InstanceListParams = z.preprocess(
       project: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const InstanceCreateParams = z.preprocess(
   processResponseBody,
@@ -4090,8 +4305,8 @@ export const InstanceCreateParams = z.preprocess(
     query: z.object({
       project: NameOrId,
     }),
-  })
-)
+  }),
+);
 
 export const InstanceViewParams = z.preprocess(
   processResponseBody,
@@ -4102,8 +4317,8 @@ export const InstanceViewParams = z.preprocess(
     query: z.object({
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const InstanceDeleteParams = z.preprocess(
   processResponseBody,
@@ -4114,8 +4329,8 @@ export const InstanceDeleteParams = z.preprocess(
     query: z.object({
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const InstanceDiskListParams = z.preprocess(
   processResponseBody,
@@ -4129,8 +4344,8 @@ export const InstanceDiskListParams = z.preprocess(
       project: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const InstanceDiskAttachParams = z.preprocess(
   processResponseBody,
@@ -4141,8 +4356,8 @@ export const InstanceDiskAttachParams = z.preprocess(
     query: z.object({
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const InstanceDiskDetachParams = z.preprocess(
   processResponseBody,
@@ -4153,8 +4368,8 @@ export const InstanceDiskDetachParams = z.preprocess(
     query: z.object({
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const InstanceExternalIpListParams = z.preprocess(
   processResponseBody,
@@ -4165,8 +4380,8 @@ export const InstanceExternalIpListParams = z.preprocess(
     query: z.object({
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const InstanceEphemeralIpAttachParams = z.preprocess(
   processResponseBody,
@@ -4177,8 +4392,8 @@ export const InstanceEphemeralIpAttachParams = z.preprocess(
     query: z.object({
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const InstanceEphemeralIpDetachParams = z.preprocess(
   processResponseBody,
@@ -4189,8 +4404,8 @@ export const InstanceEphemeralIpDetachParams = z.preprocess(
     query: z.object({
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const InstanceMigrateParams = z.preprocess(
   processResponseBody,
@@ -4201,8 +4416,8 @@ export const InstanceMigrateParams = z.preprocess(
     query: z.object({
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const InstanceRebootParams = z.preprocess(
   processResponseBody,
@@ -4213,8 +4428,8 @@ export const InstanceRebootParams = z.preprocess(
     query: z.object({
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const InstanceSerialConsoleParams = z.preprocess(
   processResponseBody,
@@ -4228,8 +4443,8 @@ export const InstanceSerialConsoleParams = z.preprocess(
       mostRecent: z.number().min(0).optional(),
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const InstanceSerialConsoleStreamParams = z.preprocess(
   processResponseBody,
@@ -4241,8 +4456,8 @@ export const InstanceSerialConsoleStreamParams = z.preprocess(
       mostRecent: z.number().min(0).optional(),
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const InstanceSshPublicKeyListParams = z.preprocess(
   processResponseBody,
@@ -4256,8 +4471,8 @@ export const InstanceSshPublicKeyListParams = z.preprocess(
       project: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const InstanceStartParams = z.preprocess(
   processResponseBody,
@@ -4268,8 +4483,8 @@ export const InstanceStartParams = z.preprocess(
     query: z.object({
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const InstanceStopParams = z.preprocess(
   processResponseBody,
@@ -4280,8 +4495,8 @@ export const InstanceStopParams = z.preprocess(
     query: z.object({
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const ProjectIpPoolListParams = z.preprocess(
   processResponseBody,
@@ -4292,8 +4507,8 @@ export const ProjectIpPoolListParams = z.preprocess(
       pageToken: z.string().optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const ProjectIpPoolViewParams = z.preprocess(
   processResponseBody,
@@ -4302,8 +4517,8 @@ export const ProjectIpPoolViewParams = z.preprocess(
       pool: NameOrId,
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const LoginLocalParams = z.preprocess(
   processResponseBody,
@@ -4312,24 +4527,24 @@ export const LoginLocalParams = z.preprocess(
       siloName: Name,
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const LogoutParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({}),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const CurrentUserViewParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({}),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const CurrentUserGroupsParams = z.preprocess(
   processResponseBody,
@@ -4340,8 +4555,8 @@ export const CurrentUserGroupsParams = z.preprocess(
       pageToken: z.string().optional(),
       sortBy: IdSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const CurrentUserSshKeyListParams = z.preprocess(
   processResponseBody,
@@ -4352,16 +4567,16 @@ export const CurrentUserSshKeyListParams = z.preprocess(
       pageToken: z.string().optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const CurrentUserSshKeyCreateParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({}),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const CurrentUserSshKeyViewParams = z.preprocess(
   processResponseBody,
@@ -4370,8 +4585,8 @@ export const CurrentUserSshKeyViewParams = z.preprocess(
       sshKey: NameOrId,
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const CurrentUserSshKeyDeleteParams = z.preprocess(
   processResponseBody,
@@ -4380,8 +4595,8 @@ export const CurrentUserSshKeyDeleteParams = z.preprocess(
       sshKey: NameOrId,
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const SiloMetricParams = z.preprocess(
   processResponseBody,
@@ -4397,8 +4612,8 @@ export const SiloMetricParams = z.preprocess(
       startTime: z.coerce.date().optional(),
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const InstanceNetworkInterfaceListParams = z.preprocess(
   processResponseBody,
@@ -4411,8 +4626,8 @@ export const InstanceNetworkInterfaceListParams = z.preprocess(
       project: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const InstanceNetworkInterfaceCreateParams = z.preprocess(
   processResponseBody,
@@ -4422,8 +4637,8 @@ export const InstanceNetworkInterfaceCreateParams = z.preprocess(
       instance: NameOrId,
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const InstanceNetworkInterfaceViewParams = z.preprocess(
   processResponseBody,
@@ -4435,8 +4650,8 @@ export const InstanceNetworkInterfaceViewParams = z.preprocess(
       instance: NameOrId.optional(),
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const InstanceNetworkInterfaceUpdateParams = z.preprocess(
   processResponseBody,
@@ -4448,8 +4663,8 @@ export const InstanceNetworkInterfaceUpdateParams = z.preprocess(
       instance: NameOrId.optional(),
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const InstanceNetworkInterfaceDeleteParams = z.preprocess(
   processResponseBody,
@@ -4461,32 +4676,32 @@ export const InstanceNetworkInterfaceDeleteParams = z.preprocess(
       instance: NameOrId.optional(),
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const PingParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({}),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const PolicyViewParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({}),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const PolicyUpdateParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({}),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const ProjectListParams = z.preprocess(
   processResponseBody,
@@ -4497,16 +4712,16 @@ export const ProjectListParams = z.preprocess(
       pageToken: z.string().optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const ProjectCreateParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({}),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const ProjectViewParams = z.preprocess(
   processResponseBody,
@@ -4515,8 +4730,8 @@ export const ProjectViewParams = z.preprocess(
       project: NameOrId,
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const ProjectUpdateParams = z.preprocess(
   processResponseBody,
@@ -4525,8 +4740,8 @@ export const ProjectUpdateParams = z.preprocess(
       project: NameOrId,
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const ProjectDeleteParams = z.preprocess(
   processResponseBody,
@@ -4535,8 +4750,8 @@ export const ProjectDeleteParams = z.preprocess(
       project: NameOrId,
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const ProjectPolicyViewParams = z.preprocess(
   processResponseBody,
@@ -4545,8 +4760,8 @@ export const ProjectPolicyViewParams = z.preprocess(
       project: NameOrId,
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const ProjectPolicyUpdateParams = z.preprocess(
   processResponseBody,
@@ -4555,8 +4770,8 @@ export const ProjectPolicyUpdateParams = z.preprocess(
       project: NameOrId,
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const SnapshotListParams = z.preprocess(
   processResponseBody,
@@ -4568,8 +4783,8 @@ export const SnapshotListParams = z.preprocess(
       project: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const SnapshotCreateParams = z.preprocess(
   processResponseBody,
@@ -4578,8 +4793,8 @@ export const SnapshotCreateParams = z.preprocess(
     query: z.object({
       project: NameOrId,
     }),
-  })
-)
+  }),
+);
 
 export const SnapshotViewParams = z.preprocess(
   processResponseBody,
@@ -4590,8 +4805,8 @@ export const SnapshotViewParams = z.preprocess(
     query: z.object({
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const SnapshotDeleteParams = z.preprocess(
   processResponseBody,
@@ -4602,8 +4817,8 @@ export const SnapshotDeleteParams = z.preprocess(
     query: z.object({
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const PhysicalDiskListParams = z.preprocess(
   processResponseBody,
@@ -4614,8 +4829,8 @@ export const PhysicalDiskListParams = z.preprocess(
       pageToken: z.string().optional(),
       sortBy: IdSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const PhysicalDiskViewParams = z.preprocess(
   processResponseBody,
@@ -4624,8 +4839,8 @@ export const PhysicalDiskViewParams = z.preprocess(
       diskId: z.string().uuid(),
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const RackListParams = z.preprocess(
   processResponseBody,
@@ -4636,8 +4851,8 @@ export const RackListParams = z.preprocess(
       pageToken: z.string().optional(),
       sortBy: IdSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const RackViewParams = z.preprocess(
   processResponseBody,
@@ -4646,8 +4861,8 @@ export const RackViewParams = z.preprocess(
       rackId: z.string().uuid(),
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const SledListParams = z.preprocess(
   processResponseBody,
@@ -4658,16 +4873,16 @@ export const SledListParams = z.preprocess(
       pageToken: z.string().optional(),
       sortBy: IdSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const SledAddParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({}),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const SledViewParams = z.preprocess(
   processResponseBody,
@@ -4676,8 +4891,8 @@ export const SledViewParams = z.preprocess(
       sledId: z.string().uuid(),
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const SledPhysicalDiskListParams = z.preprocess(
   processResponseBody,
@@ -4690,8 +4905,8 @@ export const SledPhysicalDiskListParams = z.preprocess(
       pageToken: z.string().optional(),
       sortBy: IdSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const SledInstanceListParams = z.preprocess(
   processResponseBody,
@@ -4704,8 +4919,8 @@ export const SledInstanceListParams = z.preprocess(
       pageToken: z.string().optional(),
       sortBy: IdSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const SledSetProvisionPolicyParams = z.preprocess(
   processResponseBody,
@@ -4714,8 +4929,8 @@ export const SledSetProvisionPolicyParams = z.preprocess(
       sledId: z.string().uuid(),
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const SledListUninitializedParams = z.preprocess(
   processResponseBody,
@@ -4725,8 +4940,8 @@ export const SledListUninitializedParams = z.preprocess(
       limit: z.number().min(1).max(4294967295).optional(),
       pageToken: z.string().optional(),
     }),
-  })
-)
+  }),
+);
 
 export const NetworkingSwitchPortListParams = z.preprocess(
   processResponseBody,
@@ -4738,8 +4953,8 @@ export const NetworkingSwitchPortListParams = z.preprocess(
       sortBy: IdSortMode.optional(),
       switchPortId: z.string().uuid().optional(),
     }),
-  })
-)
+  }),
+);
 
 export const NetworkingSwitchPortApplySettingsParams = z.preprocess(
   processResponseBody,
@@ -4751,8 +4966,8 @@ export const NetworkingSwitchPortApplySettingsParams = z.preprocess(
       rackId: z.string().uuid(),
       switchLocation: Name,
     }),
-  })
-)
+  }),
+);
 
 export const NetworkingSwitchPortClearSettingsParams = z.preprocess(
   processResponseBody,
@@ -4764,8 +4979,8 @@ export const NetworkingSwitchPortClearSettingsParams = z.preprocess(
       rackId: z.string().uuid(),
       switchLocation: Name,
     }),
-  })
-)
+  }),
+);
 
 export const NetworkingSwitchPortStatusParams = z.preprocess(
   processResponseBody,
@@ -4777,8 +4992,8 @@ export const NetworkingSwitchPortStatusParams = z.preprocess(
       rackId: z.string().uuid(),
       switchLocation: Name,
     }),
-  })
-)
+  }),
+);
 
 export const SwitchListParams = z.preprocess(
   processResponseBody,
@@ -4789,8 +5004,8 @@ export const SwitchListParams = z.preprocess(
       pageToken: z.string().optional(),
       sortBy: IdSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const SwitchViewParams = z.preprocess(
   processResponseBody,
@@ -4799,8 +5014,8 @@ export const SwitchViewParams = z.preprocess(
       switchId: z.string().uuid(),
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const SiloIdentityProviderListParams = z.preprocess(
   processResponseBody,
@@ -4812,8 +5027,8 @@ export const SiloIdentityProviderListParams = z.preprocess(
       silo: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const LocalIdpUserCreateParams = z.preprocess(
   processResponseBody,
@@ -4822,8 +5037,8 @@ export const LocalIdpUserCreateParams = z.preprocess(
     query: z.object({
       silo: NameOrId,
     }),
-  })
-)
+  }),
+);
 
 export const LocalIdpUserDeleteParams = z.preprocess(
   processResponseBody,
@@ -4834,8 +5049,8 @@ export const LocalIdpUserDeleteParams = z.preprocess(
     query: z.object({
       silo: NameOrId,
     }),
-  })
-)
+  }),
+);
 
 export const LocalIdpUserSetPasswordParams = z.preprocess(
   processResponseBody,
@@ -4846,8 +5061,8 @@ export const LocalIdpUserSetPasswordParams = z.preprocess(
     query: z.object({
       silo: NameOrId,
     }),
-  })
-)
+  }),
+);
 
 export const SamlIdentityProviderCreateParams = z.preprocess(
   processResponseBody,
@@ -4856,8 +5071,8 @@ export const SamlIdentityProviderCreateParams = z.preprocess(
     query: z.object({
       silo: NameOrId,
     }),
-  })
-)
+  }),
+);
 
 export const SamlIdentityProviderViewParams = z.preprocess(
   processResponseBody,
@@ -4868,8 +5083,8 @@ export const SamlIdentityProviderViewParams = z.preprocess(
     query: z.object({
       silo: NameOrId,
     }),
-  })
-)
+  }),
+);
 
 export const IpPoolListParams = z.preprocess(
   processResponseBody,
@@ -4880,16 +5095,16 @@ export const IpPoolListParams = z.preprocess(
       pageToken: z.string().optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const IpPoolCreateParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({}),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const IpPoolViewParams = z.preprocess(
   processResponseBody,
@@ -4898,8 +5113,8 @@ export const IpPoolViewParams = z.preprocess(
       pool: NameOrId,
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const IpPoolUpdateParams = z.preprocess(
   processResponseBody,
@@ -4908,8 +5123,8 @@ export const IpPoolUpdateParams = z.preprocess(
       pool: NameOrId,
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const IpPoolDeleteParams = z.preprocess(
   processResponseBody,
@@ -4918,8 +5133,8 @@ export const IpPoolDeleteParams = z.preprocess(
       pool: NameOrId,
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const IpPoolRangeListParams = z.preprocess(
   processResponseBody,
@@ -4931,8 +5146,8 @@ export const IpPoolRangeListParams = z.preprocess(
       limit: z.number().min(1).max(4294967295).optional(),
       pageToken: z.string().optional(),
     }),
-  })
-)
+  }),
+);
 
 export const IpPoolRangeAddParams = z.preprocess(
   processResponseBody,
@@ -4941,8 +5156,8 @@ export const IpPoolRangeAddParams = z.preprocess(
       pool: NameOrId,
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const IpPoolRangeRemoveParams = z.preprocess(
   processResponseBody,
@@ -4951,8 +5166,8 @@ export const IpPoolRangeRemoveParams = z.preprocess(
       pool: NameOrId,
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const IpPoolSiloListParams = z.preprocess(
   processResponseBody,
@@ -4965,8 +5180,8 @@ export const IpPoolSiloListParams = z.preprocess(
       pageToken: z.string().optional(),
       sortBy: IdSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const IpPoolSiloLinkParams = z.preprocess(
   processResponseBody,
@@ -4975,8 +5190,8 @@ export const IpPoolSiloLinkParams = z.preprocess(
       pool: NameOrId,
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const IpPoolSiloUpdateParams = z.preprocess(
   processResponseBody,
@@ -4986,8 +5201,8 @@ export const IpPoolSiloUpdateParams = z.preprocess(
       silo: NameOrId,
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const IpPoolSiloUnlinkParams = z.preprocess(
   processResponseBody,
@@ -4997,8 +5212,8 @@ export const IpPoolSiloUnlinkParams = z.preprocess(
       silo: NameOrId,
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const IpPoolUtilizationViewParams = z.preprocess(
   processResponseBody,
@@ -5007,16 +5222,16 @@ export const IpPoolUtilizationViewParams = z.preprocess(
       pool: NameOrId,
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const IpPoolServiceViewParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({}),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const IpPoolServiceRangeListParams = z.preprocess(
   processResponseBody,
@@ -5026,24 +5241,24 @@ export const IpPoolServiceRangeListParams = z.preprocess(
       limit: z.number().min(1).max(4294967295).optional(),
       pageToken: z.string().optional(),
     }),
-  })
-)
+  }),
+);
 
 export const IpPoolServiceRangeAddParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({}),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const IpPoolServiceRangeRemoveParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({}),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const SystemMetricParams = z.preprocess(
   processResponseBody,
@@ -5059,8 +5274,8 @@ export const SystemMetricParams = z.preprocess(
       startTime: z.coerce.date().optional(),
       silo: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const NetworkingAddressLotListParams = z.preprocess(
   processResponseBody,
@@ -5071,16 +5286,16 @@ export const NetworkingAddressLotListParams = z.preprocess(
       pageToken: z.string().optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const NetworkingAddressLotCreateParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({}),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const NetworkingAddressLotDeleteParams = z.preprocess(
   processResponseBody,
@@ -5089,8 +5304,8 @@ export const NetworkingAddressLotDeleteParams = z.preprocess(
       addressLot: NameOrId,
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const NetworkingAddressLotBlockListParams = z.preprocess(
   processResponseBody,
@@ -5103,48 +5318,48 @@ export const NetworkingAddressLotBlockListParams = z.preprocess(
       pageToken: z.string().optional(),
       sortBy: IdSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const NetworkingAllowListViewParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({}),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const NetworkingAllowListUpdateParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({}),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const NetworkingBfdDisableParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({}),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const NetworkingBfdEnableParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({}),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const NetworkingBfdStatusParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({}),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const NetworkingBgpConfigListParams = z.preprocess(
   processResponseBody,
@@ -5156,16 +5371,16 @@ export const NetworkingBgpConfigListParams = z.preprocess(
       pageToken: z.string().optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const NetworkingBgpConfigCreateParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({}),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const NetworkingBgpConfigDeleteParams = z.preprocess(
   processResponseBody,
@@ -5174,8 +5389,8 @@ export const NetworkingBgpConfigDeleteParams = z.preprocess(
     query: z.object({
       nameOrId: NameOrId,
     }),
-  })
-)
+  }),
+);
 
 export const NetworkingBgpAnnounceSetListParams = z.preprocess(
   processResponseBody,
@@ -5184,16 +5399,16 @@ export const NetworkingBgpAnnounceSetListParams = z.preprocess(
     query: z.object({
       nameOrId: NameOrId,
     }),
-  })
-)
+  }),
+);
 
-export const NetworkingBgpAnnounceSetCreateParams = z.preprocess(
+export const NetworkingBgpAnnounceSetUpdateParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({}),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const NetworkingBgpAnnounceSetDeleteParams = z.preprocess(
   processResponseBody,
@@ -5202,8 +5417,8 @@ export const NetworkingBgpAnnounceSetDeleteParams = z.preprocess(
     query: z.object({
       nameOrId: NameOrId,
     }),
-  })
-)
+  }),
+);
 
 export const NetworkingBgpMessageHistoryParams = z.preprocess(
   processResponseBody,
@@ -5212,8 +5427,8 @@ export const NetworkingBgpMessageHistoryParams = z.preprocess(
     query: z.object({
       asn: z.number().min(0).max(4294967295),
     }),
-  })
-)
+  }),
+);
 
 export const NetworkingBgpImportedRoutesIpv4Params = z.preprocess(
   processResponseBody,
@@ -5222,16 +5437,16 @@ export const NetworkingBgpImportedRoutesIpv4Params = z.preprocess(
     query: z.object({
       asn: z.number().min(0).max(4294967295),
     }),
-  })
-)
+  }),
+);
 
 export const NetworkingBgpStatusParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({}),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const NetworkingLoopbackAddressListParams = z.preprocess(
   processResponseBody,
@@ -5242,16 +5457,16 @@ export const NetworkingLoopbackAddressListParams = z.preprocess(
       pageToken: z.string().optional(),
       sortBy: IdSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const NetworkingLoopbackAddressCreateParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({}),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const NetworkingLoopbackAddressDeleteParams = z.preprocess(
   processResponseBody,
@@ -5263,8 +5478,8 @@ export const NetworkingLoopbackAddressDeleteParams = z.preprocess(
       switchLocation: Name,
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const NetworkingSwitchPortSettingsListParams = z.preprocess(
   processResponseBody,
@@ -5276,16 +5491,16 @@ export const NetworkingSwitchPortSettingsListParams = z.preprocess(
       portSettings: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const NetworkingSwitchPortSettingsCreateParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({}),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const NetworkingSwitchPortSettingsDeleteParams = z.preprocess(
   processResponseBody,
@@ -5294,8 +5509,8 @@ export const NetworkingSwitchPortSettingsDeleteParams = z.preprocess(
     query: z.object({
       portSettings: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const NetworkingSwitchPortSettingsViewParams = z.preprocess(
   processResponseBody,
@@ -5304,24 +5519,24 @@ export const NetworkingSwitchPortSettingsViewParams = z.preprocess(
       port: NameOrId,
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const SystemPolicyViewParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({}),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const SystemPolicyUpdateParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({}),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const RoleListParams = z.preprocess(
   processResponseBody,
@@ -5331,8 +5546,8 @@ export const RoleListParams = z.preprocess(
       limit: z.number().min(1).max(4294967295).optional(),
       pageToken: z.string().optional(),
     }),
-  })
-)
+  }),
+);
 
 export const RoleViewParams = z.preprocess(
   processResponseBody,
@@ -5341,8 +5556,8 @@ export const RoleViewParams = z.preprocess(
       roleName: z.string(),
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const SystemQuotasListParams = z.preprocess(
   processResponseBody,
@@ -5353,8 +5568,8 @@ export const SystemQuotasListParams = z.preprocess(
       pageToken: z.string().optional(),
       sortBy: IdSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const SiloListParams = z.preprocess(
   processResponseBody,
@@ -5365,16 +5580,16 @@ export const SiloListParams = z.preprocess(
       pageToken: z.string().optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const SiloCreateParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({}),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const SiloViewParams = z.preprocess(
   processResponseBody,
@@ -5383,8 +5598,8 @@ export const SiloViewParams = z.preprocess(
       silo: NameOrId,
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const SiloDeleteParams = z.preprocess(
   processResponseBody,
@@ -5393,8 +5608,8 @@ export const SiloDeleteParams = z.preprocess(
       silo: NameOrId,
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const SiloIpPoolListParams = z.preprocess(
   processResponseBody,
@@ -5407,8 +5622,8 @@ export const SiloIpPoolListParams = z.preprocess(
       pageToken: z.string().optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const SiloPolicyViewParams = z.preprocess(
   processResponseBody,
@@ -5417,8 +5632,8 @@ export const SiloPolicyViewParams = z.preprocess(
       silo: NameOrId,
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const SiloPolicyUpdateParams = z.preprocess(
   processResponseBody,
@@ -5427,8 +5642,8 @@ export const SiloPolicyUpdateParams = z.preprocess(
       silo: NameOrId,
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const SiloQuotasViewParams = z.preprocess(
   processResponseBody,
@@ -5437,8 +5652,8 @@ export const SiloQuotasViewParams = z.preprocess(
       silo: NameOrId,
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const SiloQuotasUpdateParams = z.preprocess(
   processResponseBody,
@@ -5447,8 +5662,8 @@ export const SiloQuotasUpdateParams = z.preprocess(
       silo: NameOrId,
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const SiloUserListParams = z.preprocess(
   processResponseBody,
@@ -5460,8 +5675,8 @@ export const SiloUserListParams = z.preprocess(
       silo: NameOrId.optional(),
       sortBy: IdSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const SiloUserViewParams = z.preprocess(
   processResponseBody,
@@ -5472,8 +5687,8 @@ export const SiloUserViewParams = z.preprocess(
     query: z.object({
       silo: NameOrId,
     }),
-  })
-)
+  }),
+);
 
 export const UserBuiltinListParams = z.preprocess(
   processResponseBody,
@@ -5484,8 +5699,8 @@ export const UserBuiltinListParams = z.preprocess(
       pageToken: z.string().optional(),
       sortBy: NameSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const UserBuiltinViewParams = z.preprocess(
   processResponseBody,
@@ -5494,8 +5709,8 @@ export const UserBuiltinViewParams = z.preprocess(
       user: NameOrId,
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const SiloUtilizationListParams = z.preprocess(
   processResponseBody,
@@ -5506,8 +5721,8 @@ export const SiloUtilizationListParams = z.preprocess(
       pageToken: z.string().optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const SiloUtilizationViewParams = z.preprocess(
   processResponseBody,
@@ -5516,16 +5731,16 @@ export const SiloUtilizationViewParams = z.preprocess(
       silo: NameOrId,
     }),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const TimeseriesQueryParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({}),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const TimeseriesSchemaListParams = z.preprocess(
   processResponseBody,
@@ -5535,8 +5750,8 @@ export const TimeseriesSchemaListParams = z.preprocess(
       limit: z.number().min(1).max(4294967295).optional(),
       pageToken: z.string().optional(),
     }),
-  })
-)
+  }),
+);
 
 export const UserListParams = z.preprocess(
   processResponseBody,
@@ -5548,16 +5763,16 @@ export const UserListParams = z.preprocess(
       pageToken: z.string().optional(),
       sortBy: IdSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const UtilizationViewParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({}),
     query: z.object({}),
-  })
-)
+  }),
+);
 
 export const VpcFirewallRulesViewParams = z.preprocess(
   processResponseBody,
@@ -5567,8 +5782,8 @@ export const VpcFirewallRulesViewParams = z.preprocess(
       project: NameOrId.optional(),
       vpc: NameOrId,
     }),
-  })
-)
+  }),
+);
 
 export const VpcFirewallRulesUpdateParams = z.preprocess(
   processResponseBody,
@@ -5578,8 +5793,8 @@ export const VpcFirewallRulesUpdateParams = z.preprocess(
       project: NameOrId.optional(),
       vpc: NameOrId,
     }),
-  })
-)
+  }),
+);
 
 export const VpcRouterRouteListParams = z.preprocess(
   processResponseBody,
@@ -5593,8 +5808,8 @@ export const VpcRouterRouteListParams = z.preprocess(
       sortBy: NameOrIdSortMode.optional(),
       vpc: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const VpcRouterRouteCreateParams = z.preprocess(
   processResponseBody,
@@ -5605,8 +5820,8 @@ export const VpcRouterRouteCreateParams = z.preprocess(
       router: NameOrId,
       vpc: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const VpcRouterRouteViewParams = z.preprocess(
   processResponseBody,
@@ -5619,8 +5834,8 @@ export const VpcRouterRouteViewParams = z.preprocess(
       router: NameOrId,
       vpc: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const VpcRouterRouteUpdateParams = z.preprocess(
   processResponseBody,
@@ -5633,8 +5848,8 @@ export const VpcRouterRouteUpdateParams = z.preprocess(
       router: NameOrId.optional(),
       vpc: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const VpcRouterRouteDeleteParams = z.preprocess(
   processResponseBody,
@@ -5647,8 +5862,8 @@ export const VpcRouterRouteDeleteParams = z.preprocess(
       router: NameOrId.optional(),
       vpc: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const VpcRouterListParams = z.preprocess(
   processResponseBody,
@@ -5661,8 +5876,8 @@ export const VpcRouterListParams = z.preprocess(
       sortBy: NameOrIdSortMode.optional(),
       vpc: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const VpcRouterCreateParams = z.preprocess(
   processResponseBody,
@@ -5672,8 +5887,8 @@ export const VpcRouterCreateParams = z.preprocess(
       project: NameOrId.optional(),
       vpc: NameOrId,
     }),
-  })
-)
+  }),
+);
 
 export const VpcRouterViewParams = z.preprocess(
   processResponseBody,
@@ -5685,8 +5900,8 @@ export const VpcRouterViewParams = z.preprocess(
       project: NameOrId.optional(),
       vpc: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const VpcRouterUpdateParams = z.preprocess(
   processResponseBody,
@@ -5698,8 +5913,8 @@ export const VpcRouterUpdateParams = z.preprocess(
       project: NameOrId.optional(),
       vpc: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const VpcRouterDeleteParams = z.preprocess(
   processResponseBody,
@@ -5711,8 +5926,8 @@ export const VpcRouterDeleteParams = z.preprocess(
       project: NameOrId.optional(),
       vpc: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const VpcSubnetListParams = z.preprocess(
   processResponseBody,
@@ -5725,8 +5940,8 @@ export const VpcSubnetListParams = z.preprocess(
       sortBy: NameOrIdSortMode.optional(),
       vpc: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const VpcSubnetCreateParams = z.preprocess(
   processResponseBody,
@@ -5736,8 +5951,8 @@ export const VpcSubnetCreateParams = z.preprocess(
       project: NameOrId.optional(),
       vpc: NameOrId,
     }),
-  })
-)
+  }),
+);
 
 export const VpcSubnetViewParams = z.preprocess(
   processResponseBody,
@@ -5749,8 +5964,8 @@ export const VpcSubnetViewParams = z.preprocess(
       project: NameOrId.optional(),
       vpc: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const VpcSubnetUpdateParams = z.preprocess(
   processResponseBody,
@@ -5762,8 +5977,8 @@ export const VpcSubnetUpdateParams = z.preprocess(
       project: NameOrId.optional(),
       vpc: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const VpcSubnetDeleteParams = z.preprocess(
   processResponseBody,
@@ -5775,8 +5990,8 @@ export const VpcSubnetDeleteParams = z.preprocess(
       project: NameOrId.optional(),
       vpc: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const VpcSubnetListNetworkInterfacesParams = z.preprocess(
   processResponseBody,
@@ -5791,8 +6006,8 @@ export const VpcSubnetListNetworkInterfacesParams = z.preprocess(
       sortBy: NameOrIdSortMode.optional(),
       vpc: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const VpcListParams = z.preprocess(
   processResponseBody,
@@ -5804,8 +6019,8 @@ export const VpcListParams = z.preprocess(
       project: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const VpcCreateParams = z.preprocess(
   processResponseBody,
@@ -5814,8 +6029,8 @@ export const VpcCreateParams = z.preprocess(
     query: z.object({
       project: NameOrId,
     }),
-  })
-)
+  }),
+);
 
 export const VpcViewParams = z.preprocess(
   processResponseBody,
@@ -5826,8 +6041,8 @@ export const VpcViewParams = z.preprocess(
     query: z.object({
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const VpcUpdateParams = z.preprocess(
   processResponseBody,
@@ -5838,8 +6053,8 @@ export const VpcUpdateParams = z.preprocess(
     query: z.object({
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);
 
 export const VpcDeleteParams = z.preprocess(
   processResponseBody,
@@ -5850,5 +6065,5 @@ export const VpcDeleteParams = z.preprocess(
     query: z.object({
       project: NameOrId.optional(),
     }),
-  })
-)
+  }),
+);

--- a/app/components/DocsPopover.tsx
+++ b/app/components/DocsPopover.tsx
@@ -50,7 +50,7 @@ export const DocsPopover = ({ heading, icon, summary, links }: DocsPopoverProps)
       <PopoverPanel
         // DocsPopoverPanel needed for enter animation
         className="DocsPopoverPanel z-10 w-96 rounded-lg border bg-raise border-secondary elevation-1"
-        anchor={{ to: 'bottom end', gap: 12 }}
+        anchor={{ to: 'bottom end', gap: 8 }}
       >
         <div className="px-4">
           <h2 className="mt-4 flex items-center gap-1 text-sans-md">

--- a/app/components/RefetchIntervalPicker.tsx
+++ b/app/components/RefetchIntervalPicker.tsx
@@ -8,7 +8,7 @@
 import cn from 'classnames'
 import { useEffect, useState } from 'react'
 
-import { Refresh16Icon, Time16Icon } from '@oxide/design-system/icons/react'
+import { Refresh16Icon } from '@oxide/design-system/icons/react'
 
 import { Listbox, type ListboxItem } from '~/ui/lib/Listbox'
 import { SpinnerLoader } from '~/ui/lib/Spinner'
@@ -37,9 +37,17 @@ type Props = {
   enabled: boolean
   isLoading: boolean
   fn: () => void
+  className?: string
+  variant?: 'table' | 'metrics'
 }
 
-export function useIntervalPicker({ enabled, isLoading, fn }: Props) {
+export function useIntervalPicker({
+  enabled,
+  isLoading,
+  fn,
+  className,
+  variant = 'metrics',
+}: Props) {
   const [intervalPreset, setIntervalPreset] = useState<IntervalPreset>('10s')
 
   const [lastFetched, setLastFetched] = useState(new Date())
@@ -53,18 +61,15 @@ export function useIntervalPicker({ enabled, isLoading, fn }: Props) {
   return {
     intervalMs: (enabled && intervalPresets[intervalPreset]) || undefined,
     intervalPicker: (
-      <div className="mb-12 flex items-center justify-between">
-        <div className="hidden items-center gap-2 text-right text-mono-sm text-quaternary lg+:flex">
-          <Time16Icon className="text-quinary" /> Refreshed{' '}
-          {toLocaleTimeString(lastFetched)}
-        </div>
+      <div className={cn('flex items-center justify-between', className)}>
         <div className="flex">
           <button
             type="button"
             className={cn(
-              'flex w-10 items-center justify-center rounded-l border-b border-l border-t border-default disabled:cursor-default',
+              'flex w-9 items-center justify-center rounded-l border-b border-l border-t border-default disabled:cursor-default',
               isLoading && 'hover:bg-hover',
-              !enabled && 'cursor-not-allowed bg-disabled'
+              !enabled && 'cursor-not-allowed bg-disabled',
+              variant === 'table' && 'h-8'
             )}
             onClick={fn}
             disabled={isLoading || !enabled}
@@ -75,11 +80,14 @@ export function useIntervalPicker({ enabled, isLoading, fn }: Props) {
           </button>
           <Listbox
             selected={enabled ? intervalPreset : 'Off'}
-            className="w-24 [&>button]:!rounded-l-none"
             items={intervalItems}
             onChange={setIntervalPreset}
             disabled={!enabled}
+            variant="inline"
           />
+        </div>
+        <div className="ml-2 hidden items-center text-right text-sans-sm text-tertiary lg+:flex">
+          Updated {toLocaleTimeString(lastFetched)}
         </div>
       </div>
     ),

--- a/app/components/TableFilter.tsx
+++ b/app/components/TableFilter.tsx
@@ -1,0 +1,324 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
+ */
+import { CloseButton, Popover, PopoverButton, PopoverPanel } from '@headlessui/react'
+import type { Column, ColumnFiltersState } from '@tanstack/react-table'
+import cn from 'classnames'
+import { isEqual } from 'lodash'
+import { useEffect, useState, type Dispatch, type SetStateAction } from 'react'
+
+import {
+  AddRoundel12Icon,
+  Close12Icon,
+  Filter12Icon,
+} from '@oxide/design-system/icons/react'
+
+import { defaultColumnFilters } from '~/table/QueryTable'
+import { Button, buttonStyle } from '~/ui/lib/Button'
+import { DateRangePicker } from '~/ui/lib/DateRangePicker'
+import { Listbox } from '~/ui/lib/Listbox'
+import { NumberInput } from '~/ui/lib/NumberInput'
+import { TextInput } from '~/ui/lib/TextInput'
+import { titleCase } from '~/util/str'
+import { GiB, KiB, MiB, TiB } from '~/util/units'
+
+export function TableFilter({
+  disabled,
+  columnFilters,
+  setColumnFilters,
+  localFilters,
+  setLocalFilters,
+  columnOptions,
+}: {
+  disabled: boolean
+  localFilters: ColumnFiltersState
+  setLocalFilters: Dispatch<SetStateAction<ColumnFiltersState>>
+  columnFilters: ColumnFiltersState
+  setColumnFilters: Dispatch<SetStateAction<ColumnFiltersState>>
+  columnOptions: Column<any, unknown>[]
+}) {
+  const [popoverElement, setPopoverElement] = useState<HTMLDivElement | null>()
+  const setPopoverRef = (element: HTMLDivElement | null) => {
+    setPopoverElement(element)
+  }
+
+  const addFilter = () => {
+    setLocalFilters([
+      ...localFilters,
+      { id: columnOptions[0].columnDef.id || '', value: '' },
+    ])
+  }
+
+  const updateFilter = (index: number, key: 'id' | 'value', value: string) => {
+    const newFilters = [...localFilters]
+    newFilters[index] = { ...newFilters[index], [key]: value }
+    if (key === 'id') {
+      newFilters[index].value = '' // We want to reset the value when the filter column changes
+    }
+    setLocalFilters(newFilters)
+  }
+
+  const deleteFilter = (index: number) => {
+    const newFilters = localFilters.filter((_, i) => i !== index)
+    if (newFilters.length > 0) {
+      setLocalFilters(newFilters)
+    } else {
+      setLocalFilters([...defaultColumnFilters])
+    }
+  }
+
+  const applyFilters = () => {
+    // we don't want to include the empty filter awaiting input
+    // in the actual columnFilter used against the table
+    const trimmedLocalFilters = localFilters.filter((filter) => filter.id !== '')
+    setColumnFilters(trimmedLocalFilters)
+  }
+
+  useEffect(() => {
+    if (!popoverElement) {
+      if (columnFilters.length > 0) {
+        setLocalFilters(columnFilters)
+      } else {
+        setLocalFilters([...defaultColumnFilters])
+      }
+    }
+  }, [columnFilters, popoverElement, setLocalFilters])
+
+  const clearFilters = () => {
+    setLocalFilters([...defaultColumnFilters])
+    setColumnFilters([])
+  }
+
+  const isFiltering = columnFilters.length > 0
+  const isDefault =
+    isEqual(localFilters, defaultColumnFilters) && columnFilters.length === 0
+
+  const hasChanges = !isEqual(localFilters, columnFilters) && !isDefault
+
+  return (
+    <Popover>
+      <PopoverButton
+        className={cn(
+          buttonStyle({ size: 'sm', variant: 'ghost' }),
+          'h-8 space-x-1',
+          isFiltering ? '!px-2' : 'w-8',
+          disabled && '!border-secondary [&>svg]:text-disabled'
+        )}
+        disabled={disabled}
+      >
+        <Filter12Icon
+          aria-label="Links to docs"
+          className={cn('shrink-0', isFiltering && 'text-accent')}
+        />
+        {isFiltering && (
+          <div className="text-sans-sm text-tertiary">{columnFilters.length}</div>
+        )}
+      </PopoverButton>
+      <PopoverPanel
+        ref={setPopoverRef}
+        modal
+        // FiltersPopoverPanel needed for enter animation
+        className="FiltersPopoverPanel z-10 w-[32rem] rounded-lg border bg-raise border-secondary elevation-1"
+        anchor={{ to: 'bottom end', gap: 8 }}
+      >
+        <div className="flex justify-between border-b p-4 text-sans-md text-secondary bg-secondary border-secondary">
+          Filter Snapshots
+          <CloseButton
+            onClick={clearFilters}
+            className={cn(
+              '-m-2 rounded p-2 transition-opacity text-sans-sm text-quaternary hover:bg-hover',
+              !hasChanges ? 'pointer-events-none opacity-50' : ''
+            )}
+          >
+            Clear
+          </CloseButton>
+        </div>
+        <div>
+          <div className="flex flex-col gap-2 px-4 py-3">
+            {localFilters.map((filter, index) => {
+              const columnOption = columnOptions.find((option) => option.id === filter.id)
+              const availableOptions = columnOptions.filter(
+                (col) => !localFilters.some((f) => f.id === col.id) || col.id === filter.id
+              )
+              const isRange = !!(
+                columnOption && columnOption.columnDef.meta?.filterVariant === 'range'
+              )
+              return (
+                <div key={index} className="flex items-center space-x-2">
+                  <div className="flex w-full items-center space-x-2">
+                    <Listbox
+                      selected={filter.id}
+                      items={
+                        availableOptions.map((col) => ({
+                          value: col.id,
+                          label: titleCase(
+                            typeof col.columnDef.header === 'string'
+                              ? col.columnDef.header
+                              : col.id
+                          ),
+                        })) || []
+                      }
+                      onChange={(value) => updateFilter(index, 'id', value)}
+                      className={cn(isRange ? 'w-1/3' : 'w-1/2', 'flex-shrink-0')}
+                    />
+                    <DynamicFilterInput
+                      column={columnOption}
+                      filterValue={filter.value}
+                      onFilterChange={(value) => updateFilter(index, 'value', value)}
+                    />
+                  </div>
+                  <button
+                    className="-m-2 flex-shrink-0 rounded p-2 hover:bg-hover"
+                    type="button"
+                    onClick={() => deleteFilter(index)}
+                  >
+                    <Close12Icon className="flex-shrink-0" />
+                  </button>
+                </div>
+              )
+            })}
+          </div>
+          <div className="flex justify-between border-t p-3 border-secondary">
+            <Button variant="secondary" className="space-x-2" size="sm" onClick={addFilter}>
+              <AddRoundel12Icon className="mr-2 text-quinary" />
+              Add Filter
+            </Button>
+
+            <CloseButton
+              as={Button}
+              size="sm"
+              onClick={applyFilters}
+              disabled={!hasChanges}
+              className={cn({ 'visually-disabled': !hasChanges })}
+            >
+              Apply
+            </CloseButton>
+          </div>
+        </div>
+      </PopoverPanel>
+    </Popover>
+  )
+}
+
+const DynamicFilterInput = ({
+  column,
+  filterValue,
+  onFilterChange,
+}: {
+  column: Column<any, unknown> | undefined
+  filterValue: string | number[]
+  onFilterChange: (value: string | number[]) => void
+}) => {
+  if (!column) {
+    return (
+      <TextInput
+        value={''}
+        className="w-1/2 rounded border shadow"
+        disabled
+        placeholder="Filter value"
+      />
+    )
+  }
+
+  const { filterVariant, options } = column.columnDef.meta ?? {}
+
+  if (filterVariant === 'range') {
+    return <FilterNumberRange filterValue={filterValue} onChange={onFilterChange} />
+  } else if (filterVariant === 'select' && options) {
+    return (
+      <Listbox
+        selected={filterValue?.toString()}
+        items={options.map((val) => ({ value: val, label: titleCase(val) }))}
+        onChange={(val) => onFilterChange(val)}
+        className="w-1/2"
+      />
+    )
+  } else if (filterVariant === 'datetime') {
+    return (
+      <DateRangePicker // close on select
+        value={filterValue}
+        onChange={(range) => {
+          onFilterChange(range)
+        }}
+        label="Label"
+        hideTimeZone
+        hourCycle={24}
+        disableTime
+        className="w-1/2 bg-default"
+      />
+    )
+  } else {
+    return (
+      <TextInput
+        value={filterValue.toString() ?? ''}
+        onChange={(e) => onFilterChange(e.target.value)}
+        className="w-1/2 rounded border shadow"
+        placeholder="Filter value"
+      />
+    )
+  }
+}
+
+const units = [
+  { label: 'KiB', value: KiB },
+  { label: 'MiB', value: MiB },
+  { label: 'TiB', value: TiB },
+  { label: 'GiB', value: GiB },
+]
+
+const FilterNumberRange = ({
+  filterValue,
+  onChange,
+}: {
+  filterValue: string | number[]
+  onChange: (value: string | number[]) => void
+}) => {
+  const [unit, setUnit] = useState(MiB.toString())
+  const numberUnit = parseInt(unit)
+
+  let min = undefined
+  let max = undefined
+  if (Array.isArray(filterValue) && filterValue.length === 2) {
+    min = typeof filterValue[0] === 'number' ? filterValue[0] / numberUnit : undefined
+    max = typeof filterValue[1] === 'number' ? filterValue[1] / numberUnit : undefined
+  }
+
+  console.log(filterValue)
+
+  return (
+    <div className="flex w-2/3 space-x-2">
+      <Listbox
+        selected={unit}
+        items={units.map((unit) => ({ label: unit.label, value: unit.value.toString() }))}
+        onChange={(val) => {
+          setUnit(val)
+        }}
+        className="w-1/3"
+      />
+      <NumberInput
+        value={min}
+        onChange={(value) => onChange([value * numberUnit, max ?? NaN])}
+        className="w-1/3"
+        placeholder="Min"
+        formatOptions={{
+          minimumFractionDigits: 0,
+          maximumFractionDigits: 2,
+        }}
+      />
+      <NumberInput
+        value={max}
+        onChange={(value) => onChange([min ?? NaN, value * numberUnit])}
+        className="w-1/3"
+        placeholder="Max"
+        formatOptions={{
+          minimumFractionDigits: 0,
+          maximumFractionDigits: 2,
+        }}
+      />
+    </div>
+  )
+}

--- a/app/components/form/fields/DateTimeRangePicker.tsx
+++ b/app/components/form/fields/DateTimeRangePicker.tsx
@@ -79,7 +79,7 @@ export function useDateTimeRangePicker({
   }
 }
 
-type DateTimeRange = { start: DateValue; end: DateValue }
+export type DateTimeRange = { start: DateValue; end: DateValue }
 
 type DateTimeRangePickerProps = {
   range: DateTimeRange
@@ -89,6 +89,7 @@ type DateTimeRangePickerProps = {
   onRangeChange?: (preset: RangeKeyAll) => void
   minValue?: DateValue | undefined
   maxValue?: DateValue | undefined
+  disableTime?: boolean
 }
 
 export function DateTimeRangePicker({
@@ -99,6 +100,7 @@ export function DateTimeRangePicker({
   minValue,
   maxValue,
   onRangeChange,
+  disableTime = false,
 }: DateTimeRangePickerProps) {
   return (
     <form className="flex">
@@ -126,6 +128,7 @@ export function DateTimeRangePicker({
           maxValue={maxValue}
           hideTimeZone
           className="[&_.rounded-l]:!rounded-l-none [&_button]:!border-l-0"
+          disableTime={disableTime}
         />
       </div>
     </form>

--- a/app/pages/project/instances/instance/tabs/NetworkingTab.tsx
+++ b/app/pages/project/instances/instance/tabs/NetworkingTab.tsx
@@ -33,7 +33,7 @@ import { addToast } from '~/stores/toast'
 import { EmptyCell, SkeletonCell } from '~/table/cells/EmptyCell'
 import { LinkCell } from '~/table/cells/LinkCell'
 import { useColsWithActions, type MenuAction } from '~/table/columns/action-col'
-import { Columns, DescriptionCell } from '~/table/columns/common'
+import { Columns, TruncateCell } from '~/table/columns/common'
 import { Table } from '~/table/Table'
 import { Badge } from '~/ui/lib/Badge'
 import { CopyableIp } from '~/ui/lib/CopyableIp'
@@ -263,7 +263,7 @@ export function NetworkingTab() {
     }),
     ipColHelper.accessor((row) => ('description' in row ? row.description : undefined), {
       header: 'description',
-      cell: (info) => <DescriptionCell text={info.getValue()} />,
+      cell: (info) => <TruncateCell text={info.getValue()} />,
     }),
   ]
 

--- a/app/pages/project/snapshots/SnapshotsPage.tsx
+++ b/app/pages/project/snapshots/SnapshotsPage.tsx
@@ -18,6 +18,7 @@ import {
 } from '@oxide/api'
 import { Snapshots16Icon, Snapshots24Icon } from '@oxide/design-system/icons/react'
 
+import { SnapshotStateEnumArray } from '~/api/__generated__/validate'
 import { DocsPopover } from '~/components/DocsPopover'
 import { SnapshotStatusBadge } from '~/components/StatusBadge'
 import { getProjectSelector, useProjectSelector } from '~/hooks'
@@ -30,7 +31,6 @@ import { Badge } from '~/ui/lib/Badge'
 import { CreateLink } from '~/ui/lib/CreateButton'
 import { EmptyMessage } from '~/ui/lib/EmptyMessage'
 import { PageHeader, PageTitle } from '~/ui/lib/PageHeader'
-import { TableActions } from '~/ui/lib/Table'
 import { docLinks } from '~/util/links'
 import { pb } from '~/util/path-builder'
 
@@ -84,17 +84,20 @@ SnapshotsPage.loader = async ({ params }: LoaderFunctionArgs) => {
 
 const colHelper = createColumnHelper<Snapshot>()
 const staticCols = [
-  colHelper.accessor('name', {}),
-  colHelper.accessor('description', Columns.description),
+  colHelper.accessor('name', Columns.name),
   colHelper.accessor('diskId', {
     header: 'disk',
     cell: (info) => <DiskNameFromId value={info.getValue()} />,
+    size: 125,
   }),
   colHelper.accessor('state', {
     cell: (info) => <SnapshotStatusBadge status={info.getValue()} />,
+    size: 125,
+    meta: { filterVariant: 'select', options: [...SnapshotStateEnumArray] },
   }),
   colHelper.accessor('size', Columns.size),
   colHelper.accessor('timeCreated', Columns.timeCreated),
+  colHelper.accessor('description', Columns.description),
 ]
 
 export function SnapshotsPage() {
@@ -143,10 +146,11 @@ export function SnapshotsPage() {
           links={[docLinks.snapshots]}
         />
       </PageHeader>
-      <TableActions>
-        <CreateLink to={pb.snapshotsNew({ project })}>New snapshot</CreateLink>
-      </TableActions>
-      <Table columns={columns} emptyState={<EmptyState />} />
+      <Table
+        columns={columns}
+        emptyState={<EmptyState />}
+        actions={<CreateLink to={pb.snapshotsNew({ project })}>New snapshot</CreateLink>}
+      />
       <Outlet />
     </>
   )

--- a/app/table/QueryTable.tsx
+++ b/app/table/QueryTable.tsx
@@ -7,16 +7,23 @@
  */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { hashKey, type UseQueryOptions } from '@tanstack/react-query'
+import { hashKey, useIsFetching, type UseQueryOptions } from '@tanstack/react-query'
 import {
   getCoreRowModel,
+  getFilteredRowModel,
   getPaginationRowModel,
+  getSortedRowModel,
   useReactTable,
   type ColumnDef,
+  type ColumnFiltersState,
+  type RowData,
 } from '@tanstack/react-table'
-import React, { useCallback, useMemo, useState, type ComponentType } from 'react'
+import cn from 'classnames'
+import React, { useCallback, useMemo, useRef, useState, type ComponentType } from 'react'
+import { useSearchParams } from 'react-router-dom'
 
 import {
+  apiQueryClient,
   useApiQuery,
   type ApiError,
   type ApiListMethods,
@@ -24,10 +31,13 @@ import {
   type Result,
   type ResultItem,
 } from '@oxide/api'
+import { Close12Icon, Search16Icon } from '@oxide/design-system/icons/react'
 
 import { Pagination } from '~/components/Pagination'
+import { useIntervalPicker } from '~/components/RefetchIntervalPicker'
+import { TableFilter } from '~/components/TableFilter'
 import { EmptyMessage } from '~/ui/lib/EmptyMessage'
-import { TableEmptyBox } from '~/ui/lib/Table'
+import { TableActions, TableEmptyBox } from '~/ui/lib/Table'
 
 import { Table } from './Table'
 
@@ -62,10 +72,26 @@ type QueryTableProps<Item> = {
   pageSize?: number
   rowHeight?: 'small' | 'large'
   emptyState: React.ReactElement
+  actions?: React.ReactElement
   columns: ColumnDef<Item, any>[]
 }
 
+declare module '@tanstack/react-table' {
+  // allows us to define custom properties for our columns
+  interface ColumnMeta<TData extends RowData, TValue> {
+    filterVariant?: 'text' | 'range' | 'select' | 'datetime'
+    options?: string[]
+  }
+}
+
 export const PAGE_SIZE = 25
+
+export const defaultColumnFilters = [
+  {
+    id: '',
+    value: '',
+  },
+]
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const makeQueryTable = <Item extends Record<string, unknown>>(
@@ -80,66 +106,238 @@ const makeQueryTable = <Item extends Record<string, unknown>>(
     rowHeight = 'small',
     emptyState,
     columns,
+    actions,
   }: QueryTableProps<Item>) {
-    const [currentPage, setCurrentPage] = useState(0)
+    const [globalFilter, setGlobalFilter] = useState('')
+    const [searching, setSearching] = useState(false)
+    const searchInputRef = useRef<HTMLInputElement>(null)
+
+    // localFilters are the state used for the filter popover
+    // columnFilters are the applied state used to do the actual filtering
+    const [localFilters, setLocalFilters] = useState(defaultColumnFilters)
+    const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
 
     const { data, isLoading } = useApiQuery(
       query,
       {
         path: params.path,
-        query: { ...params.query, limit: 10000 },
+        query: { ...params.query, limit: 500000 },
       },
       options
     )
 
+    const { intervalPicker } = useIntervalPicker({
+      enabled: true,
+      isLoading: useIsFetching({ queryKey: [query] }) > 0,
+      fn: () => apiQueryClient.invalidateQueries(query),
+      variant: 'table',
+    })
+
     const tableData: any[] = useMemo(() => (data as any)?.items || [], [data])
 
     const getRowId = useCallback((row: any) => row.name, [])
+
+    const [searchParams, setSearchParams] = useSearchParams()
+    const page = searchParams.get('page')
+    const currentPage = page ? Number(page) : 0
+
+    const nextPage = () => {
+      const maxPage = table.getPageCount() - 1
+      if (currentPage < maxPage) {
+        updatePage(currentPage + 1)
+      }
+    }
+
+    const prevPage = () => {
+      if (currentPage > 0) {
+        updatePage(currentPage - 1)
+      }
+    }
+
+    const updatePage = (p: number) => {
+      if (p === 0) {
+        // first page does not need to be in the URL
+        searchParams.delete('page')
+      } else {
+        searchParams.set('page', p.toString())
+      }
+      setSearchParams(searchParams, { replace: true })
+    }
 
     const table = useReactTable({
       columns,
       data: tableData,
       getRowId,
       getCoreRowModel: getCoreRowModel(),
+      getFilteredRowModel: getFilteredRowModel(),
+      getSortedRowModel: getSortedRowModel(),
+      enableSortingRemoval: false,
       getPaginationRowModel: getPaginationRowModel(),
+      onGlobalFilterChange: setGlobalFilter,
+      globalFilterFn: 'includesString',
+      initialState: {
+        sorting: [
+          {
+            id: 'timeCreated',
+            desc: true,
+          },
+        ],
+      },
       state: {
         pagination: {
           pageIndex: currentPage,
           pageSize,
         },
+        globalFilter,
+        columnFilters,
       },
       onPaginationChange: (updater) => {
         if (typeof updater === 'function') {
           const newState = updater({ pageIndex: currentPage, pageSize })
-          setCurrentPage(newState.pageIndex)
+          updatePage(newState.pageIndex)
         }
       },
       manualPagination: false,
-      pageCount: Math.ceil(tableData.length / pageSize),
     })
 
     if (debug) console.table((data as { items?: any[] })?.items || data)
-
     if (isLoading) return null
 
-    const isEmpty = tableData.length === 0
-    if (isEmpty) {
-      return (
-        <TableEmptyBox>{emptyState || <EmptyMessage title="No results" />}</TableEmptyBox>
-      )
+    const filteredLength = table.getPrePaginationRowModel().rows.length
+    const noResults = tableData.length === 0
+    const isEmpty = noResults || filteredLength === 0
+
+    const resetSearch = () => {
+      setGlobalFilter('')
+      setSearching(false)
     }
+
+    const clearAllFilters = () => {
+      setGlobalFilter('')
+      setSearching(false)
+      setLocalFilters([...defaultColumnFilters])
+      setColumnFilters([])
+    }
+
+    const isFilteringColumn = columnFilters.length > 0
 
     return (
       <>
-        <Table table={table} rowHeight={rowHeight} />
+        <TableActions className="justify-between">
+          <div>{intervalPicker}</div>
+          <div className="flex space-x-2">
+            <div className="flex items-center space-x-3">
+              {(globalFilter || isFilteringColumn) && (
+                <div className="text-sans-sm text-tertiary">
+                  {filteredLength.toLocaleString()} matches
+                </div>
+              )}
+              <div
+                className={cn(
+                  'relative flex h-8 items-center justify-center rounded border border-default',
+                  searching
+                    ? 'w-52 !justify-start !px-3 focus-within:ring-2 focus-within:ring-accent-secondary'
+                    : 'w-8 hover:bg-hover',
+                  noResults ? 'text-disabled !border-secondary' : ''
+                )}
+              >
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (!searching) {
+                      setSearching(true)
+                      searchInputRef.current?.focus()
+                    }
+                  }}
+                  className={searching ? 'pointer-events-none' : 'absolute inset-0'}
+                >
+                  <SearchIcon12 className="text-tertiary" />
+                </button>
+
+                <input
+                  ref={searchInputRef}
+                  value={globalFilter}
+                  className={cn(
+                    'absolute inset-0 z-10 ml-8 mr-8 border-none bg-transparent text-sans-md text-secondary border-secondary focus:outline-none',
+                    !searching && 'pointer-events-none opacity-0'
+                  )}
+                  onChange={(el) => setGlobalFilter(el.target.value)}
+                  onBlur={() => {
+                    if (globalFilter === '') {
+                      setSearching(false)
+                    }
+                  }}
+                />
+                <button
+                  type="button"
+                  className={cn(
+                    'absolute right-1 flex items-center justify-center rounded p-1 hover:bg-hover',
+                    !searching && 'hidden'
+                  )}
+                  onClick={resetSearch}
+                >
+                  <Close12Icon />
+                </button>
+              </div>
+            </div>
+            <TableFilter
+              disabled={noResults}
+              columnFilters={columnFilters}
+              setColumnFilters={setColumnFilters}
+              localFilters={localFilters}
+              setLocalFilters={setLocalFilters}
+              columnOptions={table.getAllColumns().filter((item) => !!item.accessorFn)} // If it doesnt have an accessorFn it probably isn't filterable
+            />
+            {actions}
+          </div>
+        </TableActions>
+        {isEmpty ? (
+          <TableEmptyBox>
+            {noResults ? (
+              emptyState || <EmptyMessage title="No results" />
+            ) : (
+              <EmptyMessage
+                icon={<Search16Icon />}
+                title="No matches"
+                body={
+                  isFilteringColumn
+                    ? 'Could not find items that match filters'
+                    : `Could not find item "${globalFilter}"`
+                }
+                buttonText={isFilteringColumn ? 'Clear filters' : 'Clear search'}
+                onClick={clearAllFilters}
+              />
+            )}
+          </TableEmptyBox>
+        ) : (
+          <Table table={table} rowHeight={rowHeight} />
+        )}
         <Pagination
           inline={pagination === 'inline'}
           pageSize={pageSize}
           currentPage={currentPage}
           pageCount={table.getPageCount()}
-          onNext={() => table.nextPage()}
-          onPrev={() => table.previousPage()}
+          onNext={nextPage}
+          onPrev={prevPage}
         />
       </>
     )
   }
+
+const SearchIcon12 = ({ className }: { className?: string }) => (
+  <svg
+    width="12"
+    height="12"
+    viewBox="0 0 12 12"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+  >
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M9 5.5C9 7.433 7.433 9 5.5 9C3.567 9 2 7.433 2 5.5C2 3.567 3.567 2 5.5 2C7.433 2 9 3.567 9 5.5ZM8.61752 10.0317C7.73148 10.6424 6.6575 11 5.5 11C2.46243 11 0 8.53757 0 5.5C0 2.46243 2.46243 0 5.5 0C8.53757 0 11 2.46243 11 5.5C11 6.6575 10.6424 7.73148 10.0317 8.61753L11.7333 10.3191C11.995 10.5808 11.995 11.005 11.7333 11.2666L11.2667 11.7333C11.005 11.995 10.5808 11.995 10.3191 11.7333L8.61752 10.0317Z"
+      fill="currentColor"
+    />
+  </svg>
+)

--- a/app/table/Table.tsx
+++ b/app/table/Table.tsx
@@ -31,14 +31,45 @@ export const Table = <TData,>({
     <UITable.Header>
       {table.getHeaderGroups().map((headerGroup) => (
         <UITable.HeaderRow key={headerGroup.id}>
-          {headerGroup.headers.map((header) => (
-            <UITable.HeadCell
-              key={header.id}
-              className={header.column.columnDef.meta?.thClassName}
-            >
-              {flexRender(header.column.columnDef.header, header.getContext())}
-            </UITable.HeadCell>
-          ))}
+          {headerGroup.headers.map((header) => {
+            const sortDir = header.column.getIsSorted()
+
+            return (
+              <UITable.HeadCell
+                key={header.id}
+                className={cn(
+                  header.column.columnDef.meta?.thClassName,
+                  header.column.getCanSort() ? 'cursor-pointer select-none' : '',
+                  'group'
+                )}
+                onClick={header.column.getToggleSortingHandler()}
+                style={{
+                  minWidth: `${header.getSize()}px`,
+                  maxWidth: `${header.getSize()}px`,
+                }}
+              >
+                <div className="-m-1 flex rounded p-1 group-hover:bg-[var(--base-neutral-300)]">
+                  {flexRender(header.column.columnDef.header, header.getContext())}
+                  <div
+                    className={cn(
+                      'invisible ml-2 flex flex-col group-hover:visible',
+                      sortDir && '!visible'
+                    )}
+                  >
+                    <SortArrow
+                      className={cn(
+                        sortDir === 'desc' && 'opacity-20',
+                        'rotate-180 text-tertiary'
+                      )}
+                    />
+                    <SortArrow
+                      className={cn(sortDir === 'asc' && 'opacity-20', 'text-tertiary')}
+                    />
+                  </div>
+                </div>
+              </UITable.HeadCell>
+            )
+          })}
         </UITable.HeaderRow>
       ))}
     </UITable.Header>
@@ -73,6 +104,10 @@ export const Table = <TData,>({
                 {...(i === 0 ? firstCellProps : {})}
                 className={cell.column.columnDef.meta?.tdClassName}
                 height={rowHeight}
+                style={{
+                  minWidth: `${cell.column.getSize()}px`,
+                  maxWidth: `${cell.column.getSize()}px`,
+                }}
               >
                 {flexRender(cell.column.columnDef.cell, cell.getContext())}
               </UITable.Cell>
@@ -82,4 +117,20 @@ export const Table = <TData,>({
       })}
     </UITable.Body>
   </UITable>
+)
+
+const SortArrow = ({ className }: { className?: string }) => (
+  <svg
+    width="6"
+    height="7"
+    viewBox="0 0 6 7"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+  >
+    <path
+      d="M3.32156 6.46407C3.17591 6.70682 2.82409 6.70682 2.67844 6.46407L0.340763 2.56794C0.190794 2.31799 0.370837 2 0.662322 2L5.33768 2C5.62916 2 5.80921 2.31799 5.65924 2.56794L3.32156 6.46407Z"
+      fill="currentColor"
+    />
+  </svg>
 )

--- a/app/table/columns/common.tsx
+++ b/app/table/columns/common.tsx
@@ -6,8 +6,11 @@
  * Copyright Oxide Computer Company
  */
 
+import { parseAbsolute } from '@internationalized/date'
+import { type Row } from '@tanstack/react-table'
 import { filesize } from 'filesize'
 
+import type { DateTimeRange } from '~/components/form/fields/DateTimeRangePicker'
 import { DateTime } from '~/ui/lib/DateTime'
 import { Truncate } from '~/ui/lib/Truncate'
 
@@ -30,16 +33,62 @@ function sizeCell(info: Info<number>) {
   )
 }
 
-export const DescriptionCell = ({ text }: { text?: string }) =>
-  text ? <Truncate text={text} maxLength={48} /> : <EmptyCell />
+export const TruncateCell = ({ text, length = 48 }: { text?: string; length?: number }) =>
+  text ? <Truncate text={text} maxLength={length} /> : <EmptyCell />
 
 /** Columns used in a bunch of tables */
 export const Columns = {
   /** Truncates text if too long, full text in tooltip */
-  description: {
-    cell: (info: Info<string | undefined>) => <DescriptionCell text={info.getValue()} />,
+  name: {
+    cell: (info: Info<string | undefined>) => <TruncateCell text={info.getValue()} />,
+    size: 200,
   },
-  size: { cell: sizeCell },
-  timeCreated: { header: 'created', cell: dateCell },
-  timeModified: { header: 'modified', cell: dateCell },
+  description: {
+    cell: (info: Info<string | undefined>) => (
+      <TruncateCell text={info.getValue()} length={26} />
+    ),
+    size: 225,
+  },
+  size: {
+    cell: sizeCell,
+    disableGlobalFilter: true,
+    size: 125,
+    meta: { filterVariant: 'range' as const },
+  },
+  timeCreated: {
+    header: 'created',
+    cell: dateCell,
+    disableGlobalFilter: true,
+    meta: { filterVariant: 'datetime' as const },
+    filterFn: dateTimeFilter,
+  },
+  timeModified: {
+    header: 'modified',
+    cell: dateCell,
+    disableGlobalFilter: true,
+    meta: { filterVariant: 'datetime' as const },
+    filterFn: dateTimeFilter,
+  },
+}
+
+function dateTimeFilter<TData>(
+  row: Row<TData>,
+  columnId: string,
+  filterValue: DateTimeRange
+): boolean {
+  const rowDate: Date = row.getValue(columnId)
+  const isoString = rowDate.toISOString()
+
+  const rowValue = parseAbsolute(isoString, 'UTC')
+  const { start, end } = filterValue
+
+  // we filter the dateTime by day ignorning the hours
+  // and minutes to avoid requiring that within the UI
+  // may revise if we think the user requires that granularity
+  const startOfDay = start.set({ hour: 0, minute: 0, second: 0, millisecond: 0 })
+  const endOfDay = end.set({ hour: 23, minute: 59, second: 59, millisecond: 999 })
+
+  const rowValueDate = rowValue.set({ hour: 0, minute: 0, second: 0, millisecond: 0 })
+
+  return rowValueDate.compare(startOfDay) >= 0 && rowValueDate.compare(endOfDay) <= 0
 }

--- a/app/ui/lib/DateTime.tsx
+++ b/app/ui/lib/DateTime.tsx
@@ -9,7 +9,7 @@
 import { toLocaleDateString, toLocaleTimeString } from '~/util/date'
 
 export const DateTime = ({ date, locale }: { date: Date; locale?: string }) => (
-  <time dateTime={date.toISOString()} className="flex flex-wrap gap-x-2">
+  <time dateTime={date.toISOString()} className="!flex flex-wrap gap-x-2">
     <span>{toLocaleDateString(date, locale)}</span>
     <span className="text-quaternary">{toLocaleTimeString(date, locale)}</span>
   </time>

--- a/app/ui/lib/Listbox.tsx
+++ b/app/ui/lib/Listbox.tsx
@@ -42,6 +42,7 @@ export interface ListboxProps<Value extends string = string> {
   description?: React.ReactNode
   required?: boolean
   isLoading?: boolean
+  variant?: 'default' | 'inline'
 }
 
 export const Listbox = <Value extends string = string>({
@@ -59,6 +60,7 @@ export const Listbox = <Value extends string = string>({
   required,
   disabled,
   isLoading = false,
+  variant = 'default',
   ...props
 }: ListboxProps<Value>) => {
   const selectedItem = selected && items.find((i) => i.value === selected)
@@ -89,7 +91,7 @@ export const Listbox = <Value extends string = string>({
             <ListboxButton
               name={name}
               className={cn(
-                `flex h-10 w-full items-center justify-between rounded border text-sans-md`,
+                `flex items-center justify-between rounded border text-sans-md`,
                 hasError
                   ? 'focus-error border-error-secondary hover:border-error'
                   : 'border-default hover:border-hover',
@@ -98,31 +100,40 @@ export const Listbox = <Value extends string = string>({
                 isDisabled
                   ? 'cursor-not-allowed text-disabled bg-disabled !border-default'
                   : 'bg-default',
-                isDisabled && hasError && '!border-error-secondary'
+                isDisabled && hasError && '!border-error-secondary',
+                variant === 'inline' ? 'h-8 w-8 !rounded-l-none' : 'h-10 w-full'
               )}
               {...props}
             >
-              <div className="w-full overflow-hidden overflow-ellipsis whitespace-pre px-3 text-left">
-                {selectedItem ? (
-                  // selectedLabel is one line, which is what we need when label is a ReactNode
-                  selectedItem.selectedLabel || selectedItem.label
-                ) : (
-                  <span className="text-quaternary">
-                    {noItems ? noItemsPlaceholder : placeholder}
-                  </span>
-                )}
-              </div>
+              {variant === 'default' && (
+                <div className="w-full overflow-hidden overflow-ellipsis whitespace-pre px-3 text-left">
+                  {selectedItem ? (
+                    // selectedLabel is one line, which is what we need when label is a ReactNode
+                    selectedItem.selectedLabel || selectedItem.label
+                  ) : (
+                    <span className="text-quaternary">
+                      {noItems ? noItemsPlaceholder : placeholder}
+                    </span>
+                  )}
+                </div>
+              )}
               {!isDisabled && <SpinnerLoader isLoading={isLoading} />}
               <div
-                className="flex h-[calc(100%-12px)] items-center border-l px-3 border-secondary"
+                className={cn(
+                  'flex h-[calc(100%-12px)] items-center px-3',
+                  variant === 'default' && 'border-l px-3 border-default'
+                )}
                 aria-hidden
               >
                 <SelectArrows6Icon title="Select" className="w-2 text-tertiary" />
               </div>
             </ListboxButton>
             <ListboxOptions
-              anchor={{ gap: 12 }}
-              className={`ox-menu pointer-events-auto ${zIndex} w-[var(--button-width)] overflow-y-auto !outline-none`}
+              anchor={{ gap: 12, to: 'bottom start' }}
+              className={cn(
+                `ox-menu pointer-events-auto ${zIndex} overflow-y-auto !outline-none`,
+                variant === 'default' ? 'w-[var(--button-width)]' : 'w-24'
+              )}
               // This is to prevent the `useOthersInert` call in ListboxOptions.
               // Without this, when the listbox options box scrolls under the
               // top bar (for example) you can click through the top bar to the

--- a/app/ui/lib/Pagination.tsx
+++ b/app/ui/lib/Pagination.tsx
@@ -17,7 +17,7 @@ const PageInput = ({ number, className }: PageInputProps) => {
   return (
     <span
       className={cn(
-        'h-4 whitespace-nowrap rounded px-[3px] pb-[3px] pt-[1px] ring-1 ring-inset text-mono-sm text-secondary bg-tertiary ring-secondary',
+        'h-4 whitespace-nowrap rounded px-[3px] pb-[3px] pt-[1px] ring-1 ring-inset text-mono-sm text-secondary ring-secondary',
         className
       )}
     >
@@ -29,23 +29,24 @@ const PageInput = ({ number, className }: PageInputProps) => {
 export interface PaginationProps {
   type?: 'inline' | 'page'
   pageSize: number
-  hasNext: boolean
-  hasPrev: boolean
-  nextPage: string | undefined
-  onNext: (nextPage: string) => void
+  currentPage: number
+  pageCount: number
+  onNext: () => void
   onPrev: () => void
   className?: string
 }
 export const Pagination = ({
   type = 'inline',
   pageSize,
-  hasNext,
-  hasPrev,
-  nextPage,
+  currentPage,
+  pageCount,
   onNext,
   onPrev,
   className,
 }: PaginationProps) => {
+  const hasNext = currentPage < pageCount - 1
+  const hasPrev = currentPage > 0
+
   return (
     <>
       <div
@@ -58,12 +59,12 @@ export const Pagination = ({
         <span className="flex-inline grow text-tertiary">
           rows per page <PageInput number={pageSize} />
         </span>
-        <span className="flex space-x-3">
+        <span className="flex">
           <button
             type="button"
             className={cn(
               hasPrev ? 'text-secondary hover:text-default' : 'text-disabled',
-              'flex items-center text-mono-sm'
+              '-m-2 flex items-center p-2 text-mono-sm'
             )}
             disabled={!hasPrev}
             onClick={onPrev}
@@ -71,19 +72,20 @@ export const Pagination = ({
             <DirectionLeftIcon
               className={cn('mr-1', hasPrev ? 'text-secondary' : 'text-disabled')}
             />
-            prev
+            {currentPage + 1}
           </button>
+          <span className="mx-2 text-quaternary">of</span>
           <button
             type="button"
             className={cn(
               hasNext ? 'text-secondary hover:text-default' : 'text-disabled',
-              'flex items-center text-mono-sm'
+              '-m-2 flex items-center p-2 text-mono-sm'
             )}
             disabled={!hasNext}
             // nextPage will be defined if hasNext is true
-            onClick={onNext.bind(null, nextPage!)}
+            onClick={onNext}
           >
-            next
+            {pageCount}
             <DirectionRightIcon
               className={cn('ml-1', hasNext ? 'text-secondary' : 'text-disabled')}
             />

--- a/app/ui/lib/Table.tsx
+++ b/app/ui/lib/Table.tsx
@@ -115,7 +115,7 @@ Table.Cell = ({ height = 'small', className, children, ...props }: TableCellProp
  * Used _outside_ of the `Table`, this element wraps buttons that sit on top
  * of the table.
  */
-export const TableActions = classed.div`-mt-11 mb-3 flex justify-end space-x-2`
+export const TableActions = classed.div`mb-3 flex justify-end space-x-2`
 
 export const TableEmptyBox = classed.div`flex h-full max-h-[480px] items-center justify-center rounded-lg border border-secondary p-4`
 

--- a/app/ui/styles/components/menu-button.css
+++ b/app/ui/styles/components/menu-button.css
@@ -44,13 +44,15 @@
 }
 
 .DropdownMenuContent,
-.DocsPopoverPanel {
+.DocsPopoverPanel,
+.FiltersPopoverPanel {
   animation: slide-down 0.2s ease;
 }
 
 @media (prefers-reduced-motion) {
   .DropdownMenuContent,
-  .DocsPopoverPanel {
+  .DocsPopoverPanel,
+  .FiltersPopoverPanel {
     animation-name: none;
   }
 }

--- a/app/ui/styles/components/menu-list.css
+++ b/app/ui/styles/components/menu-list.css
@@ -11,7 +11,7 @@
 }
 
 .ox-menu-item {
-  @apply relative cursor-pointer px-3 py-2 text-sans-md text-default;
+  @apply relative cursor-pointer px-3 py-2 text-sans-md text-secondary;
 }
 
 .ox-menu-item.is-highlighted {

--- a/app/ui/styles/components/table.css
+++ b/app/ui/styles/components/table.css
@@ -30,7 +30,7 @@ table.ox-table {
 
   & th,
   & td {
-    min-width: fit-content;
+    /* min-width: fit-content; */
     white-space: nowrap;
     @apply text-secondary;
   }
@@ -55,7 +55,7 @@ table.ox-table {
   */
   & th:last-of-type.action-col,
   & td:last-of-type.action-col {
-    @apply sticky right-0 bg-default;
+    @apply sticky right-0 !min-w-0 bg-default;
   }
   & th:last-of-type.action-col {
     @apply bg-secondary;

--- a/mock-api/snapshot.ts
+++ b/mock-api/snapshot.ts
@@ -14,7 +14,7 @@ import { disks } from './disk'
 import type { Json } from './json-type'
 import { project } from './project'
 
-const generatedSnapshots: Json<Snapshot>[] = Array.from({ length: 25 }, (_, i) =>
+const generatedSnapshots: Json<Snapshot>[] = Array.from({ length: 521 }, (_, i) =>
   generateSnapshot(i)
 )
 
@@ -89,13 +89,21 @@ export const snapshots: Json<Snapshot>[] = [
 ]
 
 function generateSnapshot(index: number): Json<Snapshot> {
+  const now = new Date()
+  const timeCreated = new Date(
+    now.setMonth(now.getMonth() - Math.abs(Math.random() * 24))
+  ).toISOString()
+  const timeModified = new Date(
+    now.setMonth(now.getMonth() - Math.abs(Math.random() * 24))
+  ).toISOString()
+
   return {
     id: uuid(),
     name: `disk-1-snapshot-${index + 6}`,
     description: '',
     project_id: project.id,
-    time_created: new Date().toISOString(),
-    time_modified: new Date().toISOString(),
+    time_created: timeCreated,
+    time_modified: timeModified,
     size: 1024 * (index + 1),
     disk_id: disks[0].id,
     state: 'ready',


### PR DESCRIPTION
This is not a production PR, but a sandbox to test out client-side pagination and filtering.

My recommendation would be that we work towards this incrementally. We can start with the client-side query, pagination and sorting – and follow up with the searching and filtering.

To address with client-side pagination initially:

1. Optimising response time querying all the resources upfront 
a. Perhaps preloading the first page and getting the rest async
b. Gzip on the dropshot response body (https://github.com/oxidecomputer/dropshot/issues/221)
2. Handling situations where there's a number of resources greater than the query page size
3. Does this work effectively when polling (e.g. when an instance is in a transitional state)

Example:
![output](https://github.com/user-attachments/assets/7daa229f-92d1-485c-a50b-d80a2873d0cd)
