### PR TITLE
Add picker to Sled page topbar

### DIFF
--- a/app/components/TopBarPicker.tsx
+++ b/app/components/TopBarPicker.tsx
@@ -19,6 +19,7 @@ import {
   useInstanceSelector,
   useIpPoolSelector,
   useSiloSelector,
+  useSledParams,
   useVpcRouterSelector,
   useVpcSelector,
 } from '~/hooks/use-params'
@@ -340,6 +341,28 @@ export function InstancePicker() {
       to={pb.instance({ project, instance })}
       items={items}
       noItemsText="No instances found"
+    />
+  )
+}
+
+export function SledPicker() {
+  // picker only shows up when a sled is in scope
+  const { sledId } = useSledParams()
+  const { data: sleds } = useApiQuery('sledList', {
+    query: { limit: PAGE_SIZE },
+  })
+  const items = (sleds?.items || []).map(({ id }) => ({
+    label: id,
+    to: pb.sled({ sledId: id }),
+  }))
+  return (
+    <TopBarPicker
+      aria-label="Switch sled"
+      category="Sled"
+      current={sledId}
+      to={pb.sled({ sledId })}
+      items={items}
+      noItemsText="No sleds found"
     />
   )
 }

--- a/app/layouts/SystemLayout.tsx
+++ b/app/layouts/SystemLayout.tsx
@@ -19,7 +19,12 @@ import {
 import { trigger404 } from '~/components/ErrorBoundary'
 import { DocsLinkItem, NavLinkItem, Sidebar } from '~/components/Sidebar'
 import { TopBar } from '~/components/TopBar'
-import { IpPoolPicker, SiloPicker, SiloSystemPicker } from '~/components/TopBarPicker'
+import {
+  IpPoolPicker,
+  SiloPicker,
+  SiloSystemPicker,
+  SledPicker,
+} from '~/components/TopBarPicker'
 import { useQuickActions } from '~/hooks/use-quick-actions'
 import { Divider } from '~/ui/lib/Divider'
 import { pb } from '~/util/path-builder'
@@ -55,7 +60,7 @@ export function SystemLayout() {
   // robust way of doing this would be to make a separate layout for the
   // silo-specific routes in the route config, but it's overkill considering
   // this is a one-liner. Switch to that approach at the first sign of trouble.
-  const { silo, pool } = useParams()
+  const { silo, pool, sledId } = useParams()
   const navigate = useNavigate()
   const { pathname } = useLocation()
 
@@ -92,6 +97,7 @@ export function SystemLayout() {
         <SiloSystemPicker value="system" />
         {silo && <SiloPicker />}
         {pool && <IpPoolPicker />}
+        {sledId && <SledPicker />}
       </TopBar>
       <Sidebar>
         <Sidebar.Nav>


### PR DESCRIPTION
Closes #1527 

This adds a sled picker to the topbar on the Sled view page

<img width="1512" alt="Screenshot 2024-10-08 at 10 00 08 PM" src="https://github.com/user-attachments/assets/4f2c26b7-8917-4b75-8e7b-9f139eaec631">
