### PR TITLE
Dynamic units

### DIFF
--- a/app/components/CapacityBars.tsx
+++ b/app/components/CapacityBars.tsx
@@ -9,7 +9,7 @@
 import type { VirtualResourceCounts } from '@oxide/api'
 import { Cpu16Icon, Ram16Icon, Ssd16Icon } from '@oxide/design-system/icons/react'
 
-import { bytesToSpecificUnit, getUnits } from '~/util/units'
+import { bytesToSpecificUnit, getUnit } from '~/util/units'
 
 import { CapacityBar } from './CapacityBar'
 
@@ -23,14 +23,14 @@ export const CapacityBars = ({
   allocatedLabel: string
 }) => {
   // These will most likely be GiB, but calculating dynamically to handle larger configurations in the future
-  const memoryUnits = getUnits(Math.max(provisioned.memory, allocated.memory))
-  const provisionedMemory = bytesToSpecificUnit(provisioned.memory, memoryUnits)
-  const allocatedMemory = bytesToSpecificUnit(allocated.memory, memoryUnits)
+  const memoryUnit = getUnit(Math.max(provisioned.memory, allocated.memory))
+  const provisionedMemory = bytesToSpecificUnit(provisioned.memory, memoryUnit)
+  const allocatedMemory = bytesToSpecificUnit(allocated.memory, memoryUnit)
 
   // These will most likely be TiB, but calculating dynamically for the same reason as above
-  const storageUnits = getUnits(Math.max(provisioned.storage, allocated.storage))
-  const provisionedStorage = bytesToSpecificUnit(provisioned.storage, storageUnits)
-  const allocatedStorage = bytesToSpecificUnit(allocated.storage, storageUnits)
+  const storageUnit = getUnit(Math.max(provisioned.storage, allocated.storage))
+  const provisionedStorage = bytesToSpecificUnit(provisioned.storage, storageUnit)
+  const allocatedStorage = bytesToSpecificUnit(allocated.storage, storageUnit)
 
   return (
     <div className="mb-12 flex min-w-min flex-col gap-3 lg+:flex-row">
@@ -46,7 +46,7 @@ export const CapacityBars = ({
       <CapacityBar
         icon={<Ram16Icon />}
         title="MEMORY"
-        unit={memoryUnits}
+        unit={memoryUnit}
         provisioned={provisionedMemory}
         capacity={allocatedMemory}
         capacityLabel={allocatedLabel}
@@ -54,7 +54,7 @@ export const CapacityBars = ({
       <CapacityBar
         icon={<Ssd16Icon />}
         title="STORAGE"
-        unit={storageUnits}
+        unit={storageUnit}
         provisioned={provisionedStorage}
         capacity={allocatedStorage}
         capacityLabel={allocatedLabel}

--- a/app/components/CapacityBars.tsx
+++ b/app/components/CapacityBars.tsx
@@ -9,7 +9,7 @@
 import type { VirtualResourceCounts } from '@oxide/api'
 import { Cpu16Icon, Ram16Icon, Ssd16Icon } from '@oxide/design-system/icons/react'
 
-import { bytesToSpecificUnit, getUnit } from '~/util/units'
+import { useConvertBytesToSpecificUnit, useGetUnit } from '~/util/units'
 
 import { CapacityBar } from './CapacityBar'
 
@@ -23,14 +23,14 @@ export const CapacityBars = ({
   allocatedLabel: string
 }) => {
   // These will most likely be GiB, but calculating dynamically to handle larger configurations in the future
-  const memoryUnit = getUnit(Math.max(provisioned.memory, allocated.memory))
-  const provisionedMemory = bytesToSpecificUnit(provisioned.memory, memoryUnit)
-  const allocatedMemory = bytesToSpecificUnit(allocated.memory, memoryUnit)
+  const memoryUnit = useGetUnit(provisioned.memory, allocated.memory)
+  const provisionedMemory = useConvertBytesToSpecificUnit(provisioned.memory, memoryUnit)
+  const allocatedMemory = useConvertBytesToSpecificUnit(allocated.memory, memoryUnit)
 
   // These will most likely be TiB, but calculating dynamically for the same reason as above
-  const storageUnit = getUnit(Math.max(provisioned.storage, allocated.storage))
-  const provisionedStorage = bytesToSpecificUnit(provisioned.storage, storageUnit)
-  const allocatedStorage = bytesToSpecificUnit(allocated.storage, storageUnit)
+  const storageUnit = useGetUnit(provisioned.storage, allocated.storage)
+  const provisionedStorage = useConvertBytesToSpecificUnit(provisioned.storage, storageUnit)
+  const allocatedStorage = useConvertBytesToSpecificUnit(allocated.storage, storageUnit)
 
   return (
     <div className="mb-12 flex min-w-min flex-col gap-3 lg+:flex-row">

--- a/app/components/CapacityBars.tsx
+++ b/app/components/CapacityBars.tsx
@@ -9,7 +9,7 @@
 import type { VirtualResourceCounts } from '@oxide/api'
 import { Cpu16Icon, Ram16Icon, Ssd16Icon } from '@oxide/design-system/icons/react'
 
-import { bytesToGiB, bytesToTiB } from '~/util/units'
+import { bytesToSpecificUnit, getUnits } from '~/util/units'
 
 import { CapacityBar } from './CapacityBar'
 
@@ -22,6 +22,16 @@ export const CapacityBars = ({
   provisioned: VirtualResourceCounts
   allocatedLabel: string
 }) => {
+  // These will most likely be GiB, but calculating dynamically to handle larger configurations in the future
+  const memoryUnits = getUnits(Math.max(provisioned.memory, allocated.memory))
+  const provisionedMemory = bytesToSpecificUnit(provisioned.memory, memoryUnits)
+  const allocatedMemory = bytesToSpecificUnit(allocated.memory, memoryUnits)
+
+  // These will most likely be TiB, but calculating dynamically for the same reason as above
+  const storageUnits = getUnits(Math.max(provisioned.storage, allocated.storage))
+  const provisionedStorage = bytesToSpecificUnit(provisioned.storage, storageUnits)
+  const allocatedStorage = bytesToSpecificUnit(allocated.storage, storageUnits)
+
   return (
     <div className="mb-12 flex min-w-min flex-col gap-3 lg+:flex-row">
       <CapacityBar
@@ -36,17 +46,17 @@ export const CapacityBars = ({
       <CapacityBar
         icon={<Ram16Icon />}
         title="MEMORY"
-        unit="GiB"
-        provisioned={bytesToGiB(provisioned.memory)}
-        capacity={bytesToGiB(allocated.memory)}
+        unit={memoryUnits}
+        provisioned={provisionedMemory}
+        capacity={allocatedMemory}
         capacityLabel={allocatedLabel}
       />
       <CapacityBar
         icon={<Ssd16Icon />}
         title="STORAGE"
-        unit="TiB"
-        provisioned={bytesToTiB(provisioned.storage)}
-        capacity={bytesToTiB(allocated.storage)}
+        unit={storageUnits}
+        provisioned={provisionedStorage}
+        capacity={allocatedStorage}
         capacityLabel={allocatedLabel}
       />
     </div>

--- a/app/pages/system/silos/SiloQuotasTab.tsx
+++ b/app/pages/system/silos/SiloQuotasTab.tsx
@@ -23,7 +23,7 @@ import { Message } from '~/ui/lib/Message'
 import { Table } from '~/ui/lib/Table'
 import { classed } from '~/util/classed'
 import { links } from '~/util/links'
-import { bytesToGiB, GiB } from '~/util/units'
+import { bytesToGiB, GiB, useConvertBytesToSpecificUnit, useGetUnit } from '~/util/units'
 
 const Unit = classed.span`ml-1 text-tertiary`
 
@@ -34,6 +34,16 @@ export function SiloQuotasTab() {
   })
 
   const { allocated: quotas, provisioned } = utilization
+  const memoryUnits = useGetUnit(provisioned.memory, quotas.memory)
+  const provisionedMemory = useConvertBytesToSpecificUnit(provisioned.memory, memoryUnits)
+  const quotasMemory = useConvertBytesToSpecificUnit(quotas.memory, memoryUnits)
+
+  const storageUnits = useGetUnit(provisioned.storage, quotas.storage)
+  const provisionedStorage = useConvertBytesToSpecificUnit(
+    provisioned.storage,
+    storageUnits
+  )
+  const quotasStorage = useConvertBytesToSpecificUnit(quotas.storage, storageUnits)
 
   const [editing, setEditing] = useState(false)
 
@@ -60,19 +70,19 @@ export function SiloQuotasTab() {
           <Table.Row>
             <Table.Cell>Memory</Table.Cell>
             <Table.Cell>
-              {bytesToGiB(provisioned.memory)} <Unit>GiB</Unit>
+              {provisionedMemory} <Unit>{memoryUnits}</Unit>
             </Table.Cell>
             <Table.Cell>
-              {bytesToGiB(quotas.memory)} <Unit>GiB</Unit>
+              {quotasMemory} <Unit>{memoryUnits}</Unit>
             </Table.Cell>
           </Table.Row>
           <Table.Row>
             <Table.Cell>Storage</Table.Cell>
             <Table.Cell>
-              {bytesToGiB(provisioned.storage)} <Unit>GiB</Unit>
+              {provisionedStorage} <Unit>{storageUnits}</Unit>
             </Table.Cell>
             <Table.Cell>
-              {bytesToGiB(quotas.storage)} <Unit>GiB</Unit>
+              {quotasStorage} <Unit>{storageUnits}</Unit>
             </Table.Cell>
           </Table.Row>
         </Table.Body>

--- a/app/util/units.spec.ts
+++ b/app/util/units.spec.ts
@@ -7,51 +7,51 @@
  */
 import { expect, it } from 'vitest'
 
-import { bytesToRationalNumber } from './units'
+import { bytesToReadableNumber } from './units'
 
-function bytesToRationalNumberTest() {
+function bytesToReadableNumberTest() {
   // the basics
-  expect(bytesToRationalNumber(1024)).toEqual({ number: 1, unit: 'KiB' })
-  expect(bytesToRationalNumber(1048576)).toEqual({ number: 1, unit: 'MiB' })
-  expect(bytesToRationalNumber(1073741824)).toEqual({ number: 1, unit: 'GiB' })
-  expect(bytesToRationalNumber(1099511627776)).toEqual({ number: 1, unit: 'TiB' })
+  expect(bytesToReadableNumber(1024)).toEqual({ number: 1, unit: 'KiB' })
+  expect(bytesToReadableNumber(1048576)).toEqual({ number: 1, unit: 'MiB' })
+  expect(bytesToReadableNumber(1073741824)).toEqual({ number: 1, unit: 'GiB' })
+  expect(bytesToReadableNumber(1099511627776)).toEqual({ number: 1, unit: 'TiB' })
 
   // double those
-  expect(bytesToRationalNumber(2048)).toEqual({ number: 2, unit: 'KiB' })
-  expect(bytesToRationalNumber(2097152)).toEqual({ number: 2, unit: 'MiB' })
-  expect(bytesToRationalNumber(2147483648)).toEqual({ number: 2, unit: 'GiB' })
-  expect(bytesToRationalNumber(2199023255552)).toEqual({ number: 2, unit: 'TiB' })
+  expect(bytesToReadableNumber(2048)).toEqual({ number: 2, unit: 'KiB' })
+  expect(bytesToReadableNumber(2097152)).toEqual({ number: 2, unit: 'MiB' })
+  expect(bytesToReadableNumber(2147483648)).toEqual({ number: 2, unit: 'GiB' })
+  expect(bytesToReadableNumber(2199023255552)).toEqual({ number: 2, unit: 'TiB' })
 
   // just 1.5 now
-  expect(bytesToRationalNumber(1536)).toEqual({ number: 1.5, unit: 'KiB' })
-  expect(bytesToRationalNumber(1572864)).toEqual({ number: 1.5, unit: 'MiB' })
-  expect(bytesToRationalNumber(1610612736)).toEqual({ number: 1.5, unit: 'GiB' })
-  expect(bytesToRationalNumber(1649267441664)).toEqual({ number: 1.5, unit: 'TiB' })
+  expect(bytesToReadableNumber(1536)).toEqual({ number: 1.5, unit: 'KiB' })
+  expect(bytesToReadableNumber(1572864)).toEqual({ number: 1.5, unit: 'MiB' })
+  expect(bytesToReadableNumber(1610612736)).toEqual({ number: 1.5, unit: 'GiB' })
+  expect(bytesToReadableNumber(1649267441664)).toEqual({ number: 1.5, unit: 'TiB' })
 
   // let's do two decimal places (1.75)
-  expect(bytesToRationalNumber(1792)).toEqual({ number: 1.75, unit: 'KiB' })
-  expect(bytesToRationalNumber(1835008)).toEqual({ number: 1.75, unit: 'MiB' })
-  expect(bytesToRationalNumber(1879048192)).toEqual({ number: 1.75, unit: 'GiB' })
-  expect(bytesToRationalNumber(1924145348608)).toEqual({ number: 1.75, unit: 'TiB' })
+  expect(bytesToReadableNumber(1792)).toEqual({ number: 1.75, unit: 'KiB' })
+  expect(bytesToReadableNumber(1835008)).toEqual({ number: 1.75, unit: 'MiB' })
+  expect(bytesToReadableNumber(1879048192)).toEqual({ number: 1.75, unit: 'GiB' })
+  expect(bytesToReadableNumber(1924145348608)).toEqual({ number: 1.75, unit: 'TiB' })
 
   // and three decimal places (1.755)
-  expect(bytesToRationalNumber(1797.12, 3)).toEqual({ number: 1.755, unit: 'KiB' })
-  expect(bytesToRationalNumber(1840250.88, 3)).toEqual({ number: 1.755, unit: 'MiB' })
-  expect(bytesToRationalNumber(1884416901.12, 3)).toEqual({ number: 1.755, unit: 'GiB' })
-  expect(bytesToRationalNumber(1929642906746.88, 3)).toEqual({
+  expect(bytesToReadableNumber(1797.12, 3)).toEqual({ number: 1.755, unit: 'KiB' })
+  expect(bytesToReadableNumber(1840250.88, 3)).toEqual({ number: 1.755, unit: 'MiB' })
+  expect(bytesToReadableNumber(1884416901.12, 3)).toEqual({ number: 1.755, unit: 'GiB' })
+  expect(bytesToReadableNumber(1929642906746.88, 3)).toEqual({
     number: 1.755,
     unit: 'TiB',
   })
 
   // but if we only want two decimal places, it should round appropriately
   // note the missing second argument, so we'll used the default decimal value, 2
-  expect(bytesToRationalNumber(1797.12)).toEqual({ number: 1.76, unit: 'KiB' })
-  expect(bytesToRationalNumber(1840250.88)).toEqual({ number: 1.76, unit: 'MiB' })
-  expect(bytesToRationalNumber(1884416901.12)).toEqual({ number: 1.76, unit: 'GiB' })
-  expect(bytesToRationalNumber(1929642906746.88)).toEqual({
+  expect(bytesToReadableNumber(1797.12)).toEqual({ number: 1.76, unit: 'KiB' })
+  expect(bytesToReadableNumber(1840250.88)).toEqual({ number: 1.76, unit: 'MiB' })
+  expect(bytesToReadableNumber(1884416901.12)).toEqual({ number: 1.76, unit: 'GiB' })
+  expect(bytesToReadableNumber(1929642906746.88)).toEqual({
     number: 1.76,
     unit: 'TiB',
   })
 }
 
-it('rounds to a rational number', bytesToRationalNumberTest)
+it('rounds to a rational number', bytesToReadableNumberTest)

--- a/app/util/units.spec.ts
+++ b/app/util/units.spec.ts
@@ -1,0 +1,57 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
+ */
+import { expect, it } from 'vitest'
+
+import { bytesToRationalNumber } from './units'
+
+function bytesToRationalNumberTest() {
+  // the basics
+  expect(bytesToRationalNumber(1024)).toEqual({ number: 1, unit: 'KiB' })
+  expect(bytesToRationalNumber(1048576)).toEqual({ number: 1, unit: 'MiB' })
+  expect(bytesToRationalNumber(1073741824)).toEqual({ number: 1, unit: 'GiB' })
+  expect(bytesToRationalNumber(1099511627776)).toEqual({ number: 1, unit: 'TiB' })
+
+  // double those
+  expect(bytesToRationalNumber(2048)).toEqual({ number: 2, unit: 'KiB' })
+  expect(bytesToRationalNumber(2097152)).toEqual({ number: 2, unit: 'MiB' })
+  expect(bytesToRationalNumber(2147483648)).toEqual({ number: 2, unit: 'GiB' })
+  expect(bytesToRationalNumber(2199023255552)).toEqual({ number: 2, unit: 'TiB' })
+
+  // just 1.5 now
+  expect(bytesToRationalNumber(1536)).toEqual({ number: 1.5, unit: 'KiB' })
+  expect(bytesToRationalNumber(1572864)).toEqual({ number: 1.5, unit: 'MiB' })
+  expect(bytesToRationalNumber(1610612736)).toEqual({ number: 1.5, unit: 'GiB' })
+  expect(bytesToRationalNumber(1649267441664)).toEqual({ number: 1.5, unit: 'TiB' })
+
+  // let's do two decimal places (1.75)
+  expect(bytesToRationalNumber(1792)).toEqual({ number: 1.75, unit: 'KiB' })
+  expect(bytesToRationalNumber(1835008)).toEqual({ number: 1.75, unit: 'MiB' })
+  expect(bytesToRationalNumber(1879048192)).toEqual({ number: 1.75, unit: 'GiB' })
+  expect(bytesToRationalNumber(1924145348608)).toEqual({ number: 1.75, unit: 'TiB' })
+
+  // and three decimal places (1.755)
+  expect(bytesToRationalNumber(1797.12, 3)).toEqual({ number: 1.755, unit: 'KiB' })
+  expect(bytesToRationalNumber(1840250.88, 3)).toEqual({ number: 1.755, unit: 'MiB' })
+  expect(bytesToRationalNumber(1884416901.12, 3)).toEqual({ number: 1.755, unit: 'GiB' })
+  expect(bytesToRationalNumber(1929642906746.88, 3)).toEqual({
+    number: 1.755,
+    unit: 'TiB',
+  })
+
+  // but if we only want two decimal places, it should round appropriately
+  // note the missing second argument, so we'll used the default decimal value, 2
+  expect(bytesToRationalNumber(1797.12)).toEqual({ number: 1.76, unit: 'KiB' })
+  expect(bytesToRationalNumber(1840250.88)).toEqual({ number: 1.76, unit: 'MiB' })
+  expect(bytesToRationalNumber(1884416901.12)).toEqual({ number: 1.76, unit: 'GiB' })
+  expect(bytesToRationalNumber(1929642906746.88)).toEqual({
+    number: 1.76,
+    unit: 'TiB',
+  })
+}
+
+it('rounds to a rational number', bytesToRationalNumberTest)

--- a/app/util/units.ts
+++ b/app/util/units.ts
@@ -5,10 +5,12 @@
  *
  * Copyright Oxide Computer Company
  */
+import { useMemo } from 'react'
+
 import { round } from './math'
 
 // We only need to support up to TiB for now, but we can add more if needed
-type BinaryUnit = 'B' | 'KiB' | 'MiB' | 'GiB' | 'TiB' // | 'PiB' | 'EiB' | 'ZiB' | 'YiB'
+export type BinaryUnit = 'B' | 'KiB' | 'MiB' | 'GiB' | 'TiB' // | 'PiB' | 'EiB' | 'ZiB' | 'YiB'
 
 export const KiB = 1024
 export const MiB = 1024 * KiB
@@ -43,13 +45,22 @@ export const bytesToReadableNumber = (b: number, digits = 2): BytesToReadableNum
 
 // Used when we have multiple related numbers that might normally round to different units.
 // Once the proper "unified" unit base is established, all numbers can be converted to a specific unit.
-export const bytesToSpecificUnit = (b: number, unit: BinaryUnit, digits = 2): number =>
-  ({
-    B: round(b, digits),
-    KiB: bytesToKiB(b, digits),
-    MiB: bytesToMiB(b, digits),
-    GiB: bytesToGiB(b, digits),
-    TiB: bytesToTiB(b, digits),
-  })[unit]
+export const useConvertBytesToSpecificUnit = (
+  bytes: number,
+  unit: BinaryUnit,
+  digits = 2
+): number =>
+  useMemo(
+    () =>
+      ({
+        B: round(bytes, digits),
+        KiB: bytesToKiB(bytes, digits),
+        MiB: bytesToMiB(bytes, digits),
+        GiB: bytesToGiB(bytes, digits),
+        TiB: bytesToTiB(bytes, digits),
+      })[unit],
+    [bytes, digits, unit]
+  )
 
-export const getUnit = (bytes: number): BinaryUnit => bytesToReadableNumber(bytes).unit
+export const useGetUnit = (n1: number, n2: number): BinaryUnit =>
+  useMemo(() => bytesToReadableNumber(Math.max(n1, n2)).unit, [n1, n2])

--- a/app/util/units.ts
+++ b/app/util/units.ts
@@ -12,5 +12,52 @@ export const MiB = 1024 * KiB
 export const GiB = 1024 * MiB
 export const TiB = 1024 * GiB
 
+export const bytesToKiB = (b: number, digits = 2) => round(b / KiB, digits)
+export const bytesToMiB = (b: number, digits = 2) => round(b / MiB, digits)
 export const bytesToGiB = (b: number, digits = 2) => round(b / GiB, digits)
 export const bytesToTiB = (b: number, digits = 2) => round(b / TiB, digits)
+
+type Unit = 'B' | 'KiB' | 'MiB' | 'GiB' | 'TiB'
+
+export type BytesToRationalNumber = {
+  number: number
+  unit: Unit
+}
+
+export const bytesToRationalNumber = (b: number, digits = 2) => {
+  if (b < 1024) {
+    return { number: round(b, digits), unit: 'B' }
+  }
+  // 1024^2 = 1,048,576
+  if (b < 1048576) {
+    return { number: bytesToKiB(b, digits), unit: 'KiB' }
+  }
+  // 1024^3 = 1,073,741,824
+  if (b < 1073741824) {
+    return { number: bytesToMiB(b, digits), unit: 'MiB' }
+  }
+  // 1024^4 = 1,099,511,627,776
+  if (b < 1099511627776) {
+    return { number: bytesToGiB(b, digits), unit: 'GiB' }
+  }
+  return { number: bytesToTiB(b, digits), unit: 'TiB' }
+}
+
+// Used when we have multiple related numbers that might normally round to different units.
+// Once the proper "unified" unit base is established, all numbers can be converted to a specific unit.
+export const bytesToSpecificUnit = (b: number, unit: Unit, digits = 2) => {
+  if (unit === 'KiB') {
+    return bytesToKiB(b, digits)
+  }
+  if (unit === 'MiB') {
+    return bytesToMiB(b, digits)
+  }
+  if (unit === 'GiB') {
+    return bytesToGiB(b, digits)
+  }
+  if (unit === 'TiB') {
+    return bytesToTiB(b, digits)
+  }
+}
+
+export const getUnits = (number: number) => bytesToRationalNumber(number).unit

--- a/app/util/units.ts
+++ b/app/util/units.ts
@@ -7,6 +7,9 @@
  */
 import { round } from './math'
 
+// We only need to support up to TiB for now, but we can add more if needed
+type BinaryUnit = 'B' | 'KiB' | 'MiB' | 'GiB' | 'TiB' // | 'PiB' | 'EiB' | 'ZiB' | 'YiB'
+
 export const KiB = 1024
 export const MiB = 1024 * KiB
 export const GiB = 1024 * MiB
@@ -17,14 +20,9 @@ export const bytesToMiB = (b: number, digits = 2) => round(b / MiB, digits)
 export const bytesToGiB = (b: number, digits = 2) => round(b / GiB, digits)
 export const bytesToTiB = (b: number, digits = 2) => round(b / TiB, digits)
 
-type Unit = 'B' | 'KiB' | 'MiB' | 'GiB' | 'TiB'
-
-export type BytesToRationalNumber = {
-  number: number
-  unit: Unit
-}
-
-export const bytesToRationalNumber = (b: number, digits = 2) => {
+type BytesToReadableNumber = { number: number; unit: BinaryUnit }
+/** Takes a raw byte count and determines the appropriate unit to use in formatting it */
+export const bytesToReadableNumber = (b: number, digits = 2): BytesToReadableNumber => {
   if (b < 1024) {
     return { number: round(b, digits), unit: 'B' }
   }
@@ -45,19 +43,13 @@ export const bytesToRationalNumber = (b: number, digits = 2) => {
 
 // Used when we have multiple related numbers that might normally round to different units.
 // Once the proper "unified" unit base is established, all numbers can be converted to a specific unit.
-export const bytesToSpecificUnit = (b: number, unit: Unit, digits = 2) => {
-  if (unit === 'KiB') {
-    return bytesToKiB(b, digits)
-  }
-  if (unit === 'MiB') {
-    return bytesToMiB(b, digits)
-  }
-  if (unit === 'GiB') {
-    return bytesToGiB(b, digits)
-  }
-  if (unit === 'TiB') {
-    return bytesToTiB(b, digits)
-  }
-}
+export const bytesToSpecificUnit = (b: number, unit: BinaryUnit, digits = 2): number =>
+  ({
+    B: round(b, digits),
+    KiB: bytesToKiB(b, digits),
+    MiB: bytesToMiB(b, digits),
+    GiB: bytesToGiB(b, digits),
+    TiB: bytesToTiB(b, digits),
+  })[unit]
 
-export const getUnits = (number: number) => bytesToRationalNumber(number).unit
+export const getUnit = (bytes: number): BinaryUnit => bytesToReadableNumber(bytes).unit

--- a/test/e2e/utilization.e2e.ts
+++ b/test/e2e/utilization.e2e.ts
@@ -116,6 +116,37 @@ test.describe('Silo utilization', () => {
   })
 })
 
+test('Utilization shows correct units for CPU, memory, and storage', async ({ page }) => {
+  await page.goto('/system/utilization')
+
+  // Verify the original values for the Memory tile
+  await expect(page.getByText('Memory(GIB)')).toBeVisible()
+  await expect(page.getByText('Provisioned384 GiB')).toBeVisible()
+  await expect(page.getByText('Quota (Total)800 GiB')).toBeVisible()
+
+  // Navigate to the quotas tab
+  await page.goto('system/silos/maze-war?tab=quotas')
+
+  // Verify that there's a row for memory with the correct units
+  await expect(page.getByText('Memory234 GiB300 GiB')).toBeVisible()
+
+  // Edit the quota and verify the new value
+  await page.getByRole('button', { name: 'Edit quotas' }).click()
+  await page.getByRole('textbox', { name: 'Memory (GiB)' }).fill('3000')
+  await page.getByRole('button', { name: 'Update quotas' }).click()
+  // The table has been updated
+  await expect(page.getByText('Memory0.23 TiB2.93 TiB')).toBeVisible()
+
+  // Navigate back to the utilization page without refreshing
+  await page.getByRole('link', { name: 'Utilization' }).click()
+  await expect(page.getByRole('heading', { name: 'Utilization' })).toBeVisible()
+
+  // Verify the updated values for the Memory tile
+  await expect(page.getByText('Memory(TiB)')).toBeVisible()
+  await expect(page.getByText('Provisioned0.38 TiB')).toBeVisible()
+  await expect(page.getByText('Quota (Total)3.42 TiB')).toBeVisible()
+})
+
 // TODO: it would be nice to test that actual data shows up in the graphs and
 // the date range picker works as expected, but it's hard to do asserts about
 // the graphs because they're big SVGs, the data coming from MSW is randomized,


### PR DESCRIPTION
Open to general conversation on this.

Currently, we have a few set units that we apply to our Memory (GiB) and Storage (TiB) utilization representations. The important thing is that they should be the same unit on each tile:
<img width="812" alt="Screenshot 2024-10-07 at 5 08 49 PM" src="https://github.com/user-attachments/assets/b2657f2e-704b-43e4-8fa4-4cb143ee0252">

As we move to having larger drives in the future, we probably won't be able to assume that GiB and TiB will be reliable values for the Memory and Storage tiles (and other representations). This PR introduces a dynamic way to determine the appropriate unit and to convert the numbers.

I am open to any thoughts on this. For example, is the core assumption here off? Is it more straightforward to a user to say `3000 GiB` rather than recasting it as `TiB`?

There are a few places where we'd need to revisit our existing "toGiB"-style conversions, but I think this is a good proof of concept so we can talk through it.

Here's one spot, for example, where we're always running a "to GiB" conversion (note the bottom row), but where a dynamic converter might make more sense …
<img width="544" alt="Screenshot 2024-10-09 at 1 17 46 AM" src="https://github.com/user-attachments/assets/f538d6ae-f403-4a51-87ed-944657ed21ad">
… I was focused on embiggening the middle row, but then noticed that since I added the dynamic conversion, both rows now show the proper (TiB) value. (Note: TiB for the bottom row was because it was already large enough for that, not based off of the middle row's new TiB scale.)
<img width="534" alt="Screenshot 2024-10-09 at 1 17 28 AM" src="https://github.com/user-attachments/assets/c4c913d1-db44-4c55-bac0-0d06520acab2">

