### PR TITLE
Instance resize modal

### DIFF
--- a/app/forms/instance-resize.tsx
+++ b/app/forms/instance-resize.tsx
@@ -7,20 +7,24 @@
  */
 import { useForm } from 'react-hook-form'
 import { useNavigate, type LoaderFunctionArgs } from 'react-router-dom'
-import * as R from 'remeda'
 
 import {
   apiQueryClient,
+  INSTANCE_MAX_CPU,
+  INSTANCE_MAX_RAM_GiB,
+  instanceCan,
   useApiMutation,
   useApiQueryClient,
   usePrefetchedApiQuery,
 } from '@oxide/api'
 
 import { NumberField } from '~/components/form/fields/NumberField'
-import { SideModalForm } from '~/components/form/SideModalForm'
 import { getInstanceSelector, useInstanceSelector } from '~/hooks/use-params'
 import { addToast } from '~/stores/toast'
+import { Message } from '~/ui/lib/Message'
+import { Modal } from '~/ui/lib/Modal'
 import { pb } from '~/util/path-builder'
+import { GiB } from '~/util/units'
 
 InstanceResizeForm.loader = async ({ params }: LoaderFunctionArgs) => {
   const { project, instance } = getInstanceSelector(params)
@@ -41,35 +45,109 @@ export function InstanceResizeForm() {
     query: { project },
   })
 
+  const onDismiss = () => navigate(pb.instance({ project, instance: instanceName }))
+
   const instanceUpdate = useApiMutation('instanceUpdate', {
     onSuccess(_updatedInstance) {
       queryClient.invalidateQueries('instanceView')
       navigate(pb.instance({ project, instance: instanceName }))
-      addToast({ title: 'Instance updated' })
+      addToast({ title: 'Instance resized' })
     },
+    onError: (err) => {
+      addToast({ title: 'Error', content: err.message, variant: 'error' })
+    },
+    onSettled: onDismiss,
   })
 
-  const form = useForm({ defaultValues: R.pick(instance, ['ncpus', 'memory']) })
+  const form = useForm({
+    defaultValues: {
+      ncpus: instance.ncpus,
+      memory: instance.memory / GiB, // memory is stored as bytes
+    },
+    mode: 'onChange',
+  })
+
+  const canResize = instanceCan.update(instance)
+  const isDisabled = !form.formState.isValid || !canResize
+
+  const onAction = form.handleSubmit(({ ncpus, memory }) => {
+    instanceUpdate.mutate({
+      path: { instance: instanceName },
+      query: { project },
+      body: { ncpus, memory: memory * GiB, bootDisk: instance.bootDiskId },
+    })
+  })
 
   return (
-    <SideModalForm
-      form={form}
-      formType="edit"
-      resourceName="Instance"
+    <Modal
+      title="Resize instance"
+      isOpen
       onDismiss={() => navigate(pb.instance({ project, instance: instanceName }))}
-      onSubmit={({ ncpus, memory }) => {
-        instanceUpdate.mutate({
-          path: { instance: instanceName },
-          query: { project },
-          // very important to include the boot disk or it will be unset
-          body: { ncpus, memory, bootDisk: instance.bootDiskId },
-        })
-      }}
-      loading={instanceUpdate.isPending}
-      submitError={instanceUpdate.error}
     >
-      <NumberField name="ncpus" control={form.control} />
-      <NumberField name="memory" control={form.control} />
-    </SideModalForm>
+      <Modal.Body>
+        <Modal.Section>
+          {!canResize ? (
+            <Message variant="error" content="An instance must be stopped to be resized" />
+          ) : (
+            <Message
+              variant="info"
+              content={
+                <>
+                  <span>Currently using:</span> {instance.ncpus} vCPUs /{' '}
+                  {instance.memory / GiB} GiB
+                </>
+              }
+            />
+          )}
+          <form autoComplete="off" className="space-y-4">
+            <NumberField
+              required
+              label="CPUs"
+              name="ncpus"
+              min={1}
+              control={form.control}
+              validate={(cpus) => {
+                if (cpus < 1) {
+                  return `Must be at least 1 vCPU`
+                }
+                if (cpus > INSTANCE_MAX_CPU) {
+                  return `CPUs capped to ${INSTANCE_MAX_CPU}`
+                }
+                // We can show this error and therefore inform the user
+                // of the limit rather than preventing it completely
+              }}
+              disabled={!canResize}
+            />
+            <NumberField
+              units="GiB"
+              required
+              label="Memory"
+              name="memory"
+              min={1}
+              control={form.control}
+              validate={(memory) => {
+                if (memory < 1) {
+                  return `Must be at least 1 GiB`
+                }
+                if (memory > INSTANCE_MAX_RAM_GiB) {
+                  return `Can be at most ${INSTANCE_MAX_RAM_GiB} GiB`
+                }
+              }}
+              disabled={!canResize}
+            />
+          </form>
+          {instanceUpdate.error && (
+            <p className="mt-4 text-error">{instanceUpdate.error.message}</p>
+          )}
+        </Modal.Section>
+      </Modal.Body>
+      <Modal.Footer
+        onDismiss={onDismiss}
+        onAction={onAction}
+        actionText="Resize"
+        actionLoading={instanceUpdate.isPending}
+        disabled={isDisabled}
+      />
+    </Modal>
   )
 }

--- a/app/ui/lib/Modal.tsx
+++ b/app/ui/lib/Modal.tsx
@@ -75,7 +75,7 @@ export function Modal({ children, onDismiss, title, isOpen }: ModalProps) {
                   )}
                   {children}
                   <Dialog.Close
-                    className="absolute right-2 top-3 flex rounded p-2 hover:bg-hover"
+                    className="absolute right-2 top-4 flex items-center justify-center rounded p-2 hover:bg-hover"
                     aria-label="Close"
                   >
                     <Close12Icon className="text-secondary" />


### PR DESCRIPTION
Building on your PR @david-crespo 

<img width="750" alt="image" src="https://github.com/user-attachments/assets/f0398125-38c7-4e89-a4c0-369e0861cc8d">

As you said, modal seems to work much better here. Kept it as a route so we can link to it from the instances list page. One thing to keep in mind is because it's a link, you can get here even if the instance is not currently stopped – so we should highlight that, even if the API would prevent it.

<img width="478" alt="image" src="https://github.com/user-attachments/assets/08fb42ff-423b-4384-b1fe-638114c1a7f7">

We can reuse the number fields from the instance create form. On that, I think we should remove the number limit and instead let the form validation describe to the user why they cannot create an instance above the CPU and memory threshold rather than just preventing it.

<img width="441" alt="image" src="https://github.com/user-attachments/assets/857f35d6-4054-4a4f-859d-c6378154c070">

Unsure if this error handling is sufficient. Do we want to expand the modal to show errors like the side modal form, instead of the toast?