### PR TITLE
Add console.error to the error boundary

### DIFF
--- a/app/components/ErrorBoundary.tsx
+++ b/app/components/ErrorBoundary.tsx
@@ -38,5 +38,6 @@ export const ErrorBoundary = (props: { children: React.ReactNode }) => (
 export function RouterDataErrorBoundary() {
   // TODO: validate this unknown at runtime _before_ passing to ErrorFallback
   const error = useRouteError() as Props['error']
+  console.error(error)
   return <ErrorFallback error={error} />
 }


### PR DESCRIPTION
This adds a bit of error logging to the browser dev tools.

This was in #2488, but isn't directly related to that work, and since that PR needs some more thinking / general work, I figured I'd pluck it out of that branch.