### PR TITLE
Make IP on Floating IPs page copyable

### DIFF
--- a/app/pages/project/floating-ips/FloatingIpsPage.tsx
+++ b/app/pages/project/floating-ips/FloatingIpsPage.tsx
@@ -32,6 +32,7 @@ import { IpPoolCell } from '~/table/cells/IpPoolCell'
 import { useColsWithActions, type MenuAction } from '~/table/columns/action-col'
 import { Columns } from '~/table/columns/common'
 import { PAGE_SIZE, useQueryTable } from '~/table/QueryTable'
+import { CopyableIp } from '~/ui/lib/CopyableIp'
 import { CreateLink } from '~/ui/lib/CreateButton'
 import { EmptyMessage } from '~/ui/lib/EmptyMessage'
 import { Message } from '~/ui/lib/Message'
@@ -85,6 +86,7 @@ const staticCols = [
   colHelper.accessor('description', Columns.description),
   colHelper.accessor('ip', {
     header: 'IP address',
+    cell: (info) => <CopyableIp ip={info.getValue()} isLinked={false} />,
   }),
   colHelper.accessor('ipPoolId', {
     header: 'IP pool',


### PR DESCRIPTION
Closes #2500

This makes the IP addresses on the Floating IPs list page copyable.
<img width="1248" alt="Screenshot 2024-10-11 at 12 03 23 AM" src="https://github.com/user-attachments/assets/965114e1-f6ca-45ed-9239-fd677d53ea89">
