### PR TITLE
Route create: make gateway target value input free-form

### DIFF
--- a/app/forms/vpc-router-route-common.tsx
+++ b/app/forms/vpc-router-route-common.tsx
@@ -30,8 +30,6 @@ export type RouteFormValues = RouterRouteCreate | Required<RouterRouteUpdate>
 export const routeFormMessage = {
   vpcSubnetNotModifiable:
     'Routes of type VPC Subnet within the system router are not modifiable',
-  internetGatewayTargetValue:
-    'For ‘Internet gateway’ targets, the value must be ‘outbound’',
   // https://github.com/oxidecomputer/omicron/blob/914f5fd7d51f9b060dcc0382a30b607e25df49b2/nexus/src/app/vpc_router.rs#L201-L204
   noNewRoutesOnSystemRouter: 'User-provided routes cannot be added to a system router',
   // https://github.com/oxidecomputer/omicron/blob/914f5fd7d51f9b060dcc0382a30b607e25df49b2/nexus/src/app/vpc_router.rs#L300-L304
@@ -84,7 +82,7 @@ const targetValuePlaceholder: Record<RouteTarget['type'], string | undefined> = 
 const targetValueDescription: Record<RouteTarget['type'], string | undefined> = {
   ip: 'An IP address, like 10.0.1.5',
   instance: undefined,
-  internet_gateway: routeFormMessage.internetGatewayTargetValue,
+  internet_gateway: undefined,
   drop: undefined,
   subnet: undefined,
   vpc: undefined,
@@ -130,7 +128,7 @@ export const RouteFormFields = ({ form, disabled }: RouteFormFieldsProps) => {
     placeholder: targetValuePlaceholder[targetType],
     required: true,
     // 'internet_gateway' targetTypes can only have the value 'outbound', so we disable the field
-    disabled: disabled || targetType === 'internet_gateway',
+    disabled,
     description: targetValueDescription[targetType],
     // need a default to prevent the text field validation function from
     // sticking around when we switch to the combobox
@@ -176,8 +174,8 @@ export const RouteFormFields = ({ form, disabled }: RouteFormFieldsProps) => {
         items={toListboxItems(targetTypes)}
         placeholder="Select a target type"
         required
-        onChange={(value) => {
-          form.setValue('target.value', value === 'internet_gateway' ? 'outbound' : '')
+        onChange={() => {
+          form.setValue('target.value', '')
           form.clearErrors('target.value')
         }}
         disabled={disabled}


### PR DESCRIPTION
I learned from https://github.com/oxidecomputer/docs/pull/463#discussion_r1796647026 that 

* the restriction of gateway targets to `outbound` is no longer in place
* the default gateway is now named `default`
* most importantly, if people are using gateways, they are almost certainly creating other ones besides the default and they'll want their routes to point to those

So the simple thing here is to have it be a normal free-form text field like subnet. However, while making that change I realized that all the target types except IP should probably be arbitrary values comboboxes populated with the existing things of that kind (need to confirm arbitrary values are desirable, but that boolean prop is the easy part of the change anyway). So if we're pushing this into v12 I'd definitely like to do it that way.

<img width="988" alt="image" src="https://github.com/user-attachments/assets/09aafda5-7b80-4284-b85a-8d3c5043a09c">
