### PR TITLE
Add truncation component to prevent table breakage

### DIFF
--- a/app/components/DocsPopover.tsx
+++ b/app/components/DocsPopover.tsx
@@ -44,7 +44,7 @@ type DocsPopoverProps = {
 export const DocsPopover = ({ heading, icon, summary, links }: DocsPopoverProps) => {
   return (
     <Popover>
-      <PopoverButton className={cn(buttonStyle({ size: 'sm', variant: 'ghost' }), 'w-9')}>
+      <PopoverButton className={cn(buttonStyle({ size: 'sm', variant: 'ghost' }), 'w-8')}>
         <Question12Icon aria-label="Links to docs" className="shrink-0" />
       </PopoverButton>
       <PopoverPanel

--- a/app/components/form/fields/DisksTableField.tsx
+++ b/app/components/form/fields/DisksTableField.tsx
@@ -16,6 +16,7 @@ import type { InstanceCreateInput } from '~/forms/instance-create'
 import { Badge } from '~/ui/lib/Badge'
 import { Button } from '~/ui/lib/Button'
 import * as MiniTable from '~/ui/lib/MiniTable'
+import { Truncate } from '~/ui/lib/Truncate'
 import { bytesToGiB } from '~/util/units'
 
 export type DiskTableItem =
@@ -60,7 +61,9 @@ export function DisksTableField({
                   aria-label={`Name: ${item.name}, Type: ${item.type}`}
                   key={item.name}
                 >
-                  <MiniTable.Cell>{item.name}</MiniTable.Cell>
+                  <MiniTable.Cell>
+                    <Truncate text={item.name} maxLength={35} />
+                  </MiniTable.Cell>
                   <MiniTable.Cell>
                     <Badge variant="solid">{item.type}</Badge>
                   </MiniTable.Cell>

--- a/app/ui/styles/components/mini-table.css
+++ b/app/ui/styles/components/mini-table.css
@@ -29,7 +29,7 @@
   }
 
   & td > div {
-    @apply flex h-11 items-center border-y py-3 pl-3 text-accent bg-accent-secondary border-accent-tertiary;
+    @apply flex h-11 items-center border-y py-3 pl-3 pr-6 text-accent bg-accent-secondary border-accent-tertiary;
   }
 
   & td:last-child > div {


### PR DESCRIPTION
Closes #2486 
Closes #2490 

This adds a truncation component to the name cell, to prevent it from breaking the layout when the disk has a long name.

**Broken:**
![image](https://github.com/user-attachments/assets/e2b07369-a659-41d0-861b-74724f936994)


**Fixed:**
<img width="537" alt="Screenshot 2024-10-11 at 4 57 49 PM" src="https://github.com/user-attachments/assets/b64a6b84-f2d6-4a49-81ae-e4ec2837423d">
<img width="665" alt="Screenshot 2024-10-11 at 4 57 56 PM" src="https://github.com/user-attachments/assets/c4b5824d-b1d1-496c-bc1d-98cbb98cf165">
