### PR TITLE
How about we don't hold the entire image in memory

### DIFF
--- a/app/forms/image-upload.tsx
+++ b/app/forms/image-upload.tsx
@@ -215,7 +215,13 @@ export function CreateImageSideModalForm() {
 
   const createDisk = useApiMutation('diskCreate')
   const startImport = useApiMutation('diskBulkWriteImportStart')
-  const uploadChunk = useApiMutation('diskBulkWriteImport')
+
+  // gcTime: 0 prevents the mutation cache from holding onto all the chunks for
+  // 5 minutes. It can be a ton of memory. To be honest, I don't even understand
+  // why the mutation cache exists. It's not like the query cache, which dedupes
+  // identical queries made around the same time.
+  // https://tanstack.com/query/v5/docs/reference/MutationCache
+  const uploadChunk = useApiMutation('diskBulkWriteImport', { gcTime: 0 })
 
   // synthetic state for upload step because it consists of multiple requests
   const [syntheticUploadState, setSyntheticUploadState] =


### PR DESCRIPTION
Closes #2270

Reduce `gcTime` on upload chunk React Query mutation from default of 5 minutes to zero.

As I say in the comment, I don't even understand why the mutation cache exists — it's not like we're reading from it. The query cache is a different story. So I don't see a downside to turning it off for this mutation. I have asked about in the Tanstack Discord and on Twitter, so I'll see if anything helpful comes out of that.

https://tanstack.com/query/v5/docs/reference/MutationCache
https://tanstack.com/query/v5/docs/framework/react/reference/useMutation
https://tkdodo.eu/blog/mastering-mutations-in-react-query

### Before

Taking some snapshots in FF throughout a big upload. Memory goes up and up.

![Screenshot 2024-10-15 at 3 58 10 PM](https://github.com/user-attachments/assets/19507270-c9ac-49fe-ab5d-c3a4871224fc)

### After

Memory fluctuates around a relatively small value, consistent with GC functioning as desired.

<img width="774" alt="image" src="https://github.com/user-attachments/assets/5e209497-70f3-4d77-8ac2-87d6e13f335d">

### With shorter but non-zero `gcTime`

As a test, I set `gcTime: 60000` (1 minute) and saw as expected that memory use still plateaus, but at a higher number because it holds onto everything it can process in one minute.

<img width="513" alt="image" src="https://github.com/user-attachments/assets/57a068bf-0a9a-4b0e-8341-4e1bd0a1ad64">
