### PR TITLE
Add descriptions to IP Pool dropdowns

### DIFF
--- a/app/forms/floating-ip-create.tsx
+++ b/app/forms/floating-ip-create.tsx
@@ -19,8 +19,8 @@ import {
 } from '@oxide/api'
 
 import { AccordionItem } from '~/components/AccordionItem'
+import { ComboboxField } from '~/components/form/fields/ComboboxField'
 import { DescriptionField } from '~/components/form/fields/DescriptionField'
-import { ListboxField } from '~/components/form/fields/ListboxField'
 import { NameField } from '~/components/form/fields/NameField'
 import { SideModalForm } from '~/components/form/SideModalForm'
 import { useProjectSelector } from '~/hooks/use-params'
@@ -30,23 +30,28 @@ import { Message } from '~/ui/lib/Message'
 import { ALL_ISH } from '~/util/consts'
 import { pb } from '~/util/path-builder'
 
-const toListboxItem = (p: SiloIpPool) => {
-  if (!p.isDefault) {
-    return { value: p.name, label: p.name }
-  }
-  // For the default pool, add a label to the dropdown
-  return {
-    value: p.name,
-    selectedLabel: p.name,
-    label: (
-      <>
-        {p.name}{' '}
-        <Badge className="ml-1" color="neutral">
-          default
-        </Badge>
-      </>
-    ),
-  }
+const toComboboxItem = (p: SiloIpPool) => {
+  const value = p.name
+  const selectedLabel = p.name
+  const label = (
+    <div className="flex flex-col gap-1">
+      <div>
+        {p.name}
+        {p.isDefault && (
+          <>
+            {' '}
+            <Badge className="ml-1" color="neutral">
+              default
+            </Badge>
+          </>
+        )}
+      </div>
+      {p.description.length && (
+        <div className="text-tertiary selected:text-accent-secondary">{p.description}</div>
+      )}
+    </div>
+  )
+  return { value, selectedLabel, label }
 }
 
 const defaultValues: Omit<FloatingIpCreate, 'ip'> = {
@@ -106,9 +111,9 @@ export function CreateFloatingIpSideModalForm() {
             content="If you don’t specify a pool, the default will be used"
           />
 
-          <ListboxField
+          <ComboboxField
             name="pool"
-            items={(allPools?.items || []).map((p) => toListboxItem(p))}
+            items={(allPools?.items || []).map((p) => toComboboxItem(p))}
             label="IP pool"
             control={form.control}
             placeholder="Select a pool"

--- a/app/forms/floating-ip-create.tsx
+++ b/app/forms/floating-ip-create.tsx
@@ -26,11 +26,12 @@ import { SideModalForm } from '~/components/form/SideModalForm'
 import { useProjectSelector } from '~/hooks/use-params'
 import { addToast } from '~/stores/toast'
 import { Badge } from '~/ui/lib/Badge'
+import type { ComboboxItem } from '~/ui/lib/Combobox'
 import { Message } from '~/ui/lib/Message'
 import { ALL_ISH } from '~/util/consts'
 import { pb } from '~/util/path-builder'
 
-const toComboboxItem = (p: SiloIpPool) => {
+const toComboboxItem = (p: SiloIpPool): ComboboxItem => {
   const value = p.name
   const selectedLabel = p.name
   const label = (

--- a/app/forms/ip-pool-create.tsx
+++ b/app/forms/ip-pool-create.tsx
@@ -14,6 +14,7 @@ import { DescriptionField } from '~/components/form/fields/DescriptionField'
 import { NameField } from '~/components/form/fields/NameField'
 import { SideModalForm } from '~/components/form/SideModalForm'
 import { addToast } from '~/stores/toast'
+import { Message } from '~/ui/lib/Message'
 import { pb } from '~/util/path-builder'
 
 const defaultValues: IpPoolCreate = {
@@ -51,6 +52,10 @@ export function CreateIpPoolSideModalForm() {
     >
       <NameField name="name" control={form.control} />
       <DescriptionField name="description" control={form.control} />
+      <Message
+        variant="info"
+        content="IP pool names and descriptions are visible to end users in linked silos."
+      />
     </SideModalForm>
   )
 }

--- a/app/forms/ip-pool-edit.tsx
+++ b/app/forms/ip-pool-edit.tsx
@@ -20,6 +20,7 @@ import { NameField } from '~/components/form/fields/NameField'
 import { SideModalForm } from '~/components/form/SideModalForm'
 import { getIpPoolSelector, useIpPoolSelector } from '~/hooks/use-params'
 import { addToast } from '~/stores/toast'
+import { Message } from '~/ui/lib/Message'
 import { pb } from '~/util/path-builder'
 
 EditIpPoolSideModalForm.loader = async ({ params }: LoaderFunctionArgs) => {
@@ -68,6 +69,10 @@ export function EditIpPoolSideModalForm() {
     >
       <NameField name="name" control={form.control} />
       <DescriptionField name="description" control={form.control} />
+      <Message
+        variant="info"
+        content="IP pool names and descriptions are visible to end users in linked silos."
+      />
     </SideModalForm>
   )
 }


### PR DESCRIPTION
This adds the IP Pool description to the IP Pool dropdown visible to the end user on the silo …
<img width="463" alt="Screenshot 2024-10-22 at 3 51 33 PM" src="https://github.com/user-attachments/assets/49e82d1c-8679-447e-9915-607d5ba6ff00">
http://localhost:4000/projects/mock-project/floating-ips-new

And adds a note to the IP Pool form …
<img width="513" alt="Screenshot 2024-10-22 at 3 53 32 PM" src="https://github.com/user-attachments/assets/5bf9d581-4cfa-41a2-bbeb-e36f5a67d9e3">
http://localhost:4000/system/networking/ip-pools-new

Closes #2041 
Closes #2042 