### PR TITLE
Trim descriptions

### DIFF
--- a/app/components/form/fields/DescriptionField.tsx
+++ b/app/components/form/fields/DescriptionField.tsx
@@ -16,7 +16,18 @@ export function DescriptionField<
   TFieldValues extends FieldValues,
   TName extends FieldPath<TFieldValues>,
 >(props: Omit<TextFieldProps<TFieldValues, TName>, 'validate'>) {
-  return <TextField as="textarea" validate={validateDescription} {...props} />
+  return (
+    <TextField
+      as="textarea"
+      validate={validateDescription}
+      onBlur={(event) => {
+        const trimmedDescription = event.target.value.trim()
+        event.target.value = trimmedDescription
+        props.control._formValues.description = trimmedDescription
+      }}
+      {...props}
+    />
+  )
 }
 
 // TODO Update JSON schema to match this, add fuzz testing between this and name pattern

--- a/test/e2e/floating-ip-create.e2e.ts
+++ b/test/e2e/floating-ip-create.e2e.ts
@@ -24,9 +24,8 @@ test('can create a floating IP', async ({ page }) => {
 
   const floatingIpName = 'my-floating-ip'
   await page.fill('input[name=name]', floatingIpName)
-  await page
-    .getByRole('textbox', { name: 'Description' })
-    .fill('A description for this Floating IP')
+  const description = page.getByRole('textbox', { name: 'Description' })
+  await description.fill('A description for this Floating IP')
 
   const poolListbox = page.getByRole('button', { name: 'IP pool' })
 
@@ -49,6 +48,20 @@ test('can create a floating IP', async ({ page }) => {
   await expectRowVisible(page.getByRole('table'), {
     name: floatingIpName,
     description: 'A description for this Floating IP',
+    'IP pool': 'ip-pool-1',
+  })
+
+  // Make sure that descriptions with only whitespace get trimmed
+  await page.locator('text="New Floating IP"').click()
+  await page.fill('input[name=name]', 'no-description')
+  await description.fill('    ')
+  await description.blur()
+  await expect(description).toContainText('')
+  await page.getByRole('button', { name: 'Create floating IP' }).click()
+
+  await expectRowVisible(page.getByRole('table'), {
+    name: 'no-description',
+    description: '—',
     'IP pool': 'ip-pool-1',
   })
 })


### PR DESCRIPTION
For discussion …

This PR fixes an edge case with DescriptionFields. Currently, they can be created with an empty space (or some other combination of whitespace) as the only text in the description. This PR updates the DescriptionField, so that when it is blurred, the value is trimmed.

I like this approach, as it keeps the change scoped to the DescriptionField component, whereas if we handled it at the form layer, we'd need to add a function in each place in the app where we use the DescriptionField. This way, it's handled within the one file. That being said, forcing an update to `props.control._formValues.description` feels off.

If we move forward with it …
Closes #2515 