### PR TITLE
Add Group Attribute Name field to IdP view

### DIFF
--- a/app/forms/idp/create.tsx
+++ b/app/forms/idp/create.tsx
@@ -133,7 +133,7 @@ export function CreateIdpSideModalForm() {
       <TextField
         name="groupAttributeName"
         label="Group attribute name"
-        description="Name of SAML attribute where we can find a comma-separated list of names of groups the user belongs to"
+        description="Name of the SAML attribute in the IdP response listing the user’s groups"
         control={form.control}
       />
       {/* TODO: Email field, probably */}

--- a/app/forms/idp/edit.tsx
+++ b/app/forms/idp/edit.tsx
@@ -104,14 +104,13 @@ export function EditIdpSideModalForm() {
         control={form.control}
         disabled
       />
-      {/* TODO: add group attribute name when it is added to the API
-          <TextField
-            name="groupAttributeName"
-            label="Group attribute name"
-            description="Name of SAML attribute where we can find a comma-separated list of names of groups the user belongs to"
-            control={form.control}
-            disabled
-          /> */}
+      <TextField
+        name="groupAttributeName"
+        label="Group attribute name"
+        description="Name of the SAML attribute sent by the IdP containing a comma-separated list of groups for the authenticated user"
+        control={form.control}
+        disabled
+      />
       {/* TODO: Email field, probably */}
       <TextField
         name="technicalContactEmail"

--- a/app/forms/idp/edit.tsx
+++ b/app/forms/idp/edit.tsx
@@ -107,7 +107,7 @@ export function EditIdpSideModalForm() {
       <TextField
         name="groupAttributeName"
         label="Group attribute name"
-        description="Name of the SAML attribute sent by the IdP containing a comma-separated list of groups for the authenticated user"
+        description="Name of the SAML attribute in the IdP response listing the user’s groups"
         required
         control={form.control}
         disabled

--- a/app/forms/idp/edit.tsx
+++ b/app/forms/idp/edit.tsx
@@ -108,6 +108,7 @@ export function EditIdpSideModalForm() {
         name="groupAttributeName"
         label="Group attribute name"
         description="Name of the SAML attribute sent by the IdP containing a comma-separated list of groups for the authenticated user"
+        required
         control={form.control}
         disabled
       />

--- a/app/ui/lib/TextInput.tsx
+++ b/app/ui/lib/TextInput.tsx
@@ -101,7 +101,7 @@ export const TextInputHint = ({ id, children, className }: HintProps) => (
   <div
     id={id}
     className={cn(
-      'mt-1 text-balance text-sans-sm text-tertiary [&_>_a]:underline hover:[&_>_a]:text-default',
+      'mt-1 text-sans-sm text-tertiary [&_>_a]:underline hover:[&_>_a]:text-default',
       className
     )}
   >

--- a/app/ui/lib/TextInput.tsx
+++ b/app/ui/lib/TextInput.tsx
@@ -101,7 +101,7 @@ export const TextInputHint = ({ id, children, className }: HintProps) => (
   <div
     id={id}
     className={cn(
-      'mt-1 text-sans-sm text-tertiary [&_>_a]:underline hover:[&_>_a]:text-default',
+      'mt-1 text-balance text-sans-sm text-tertiary [&_>_a]:underline hover:[&_>_a]:text-default',
       className
     )}
   >

--- a/mock-api/silo.ts
+++ b/mock-api/silo.ts
@@ -85,6 +85,7 @@ export const samlIdp: Json<SamlIdentityProvider> = {
   slo_url: '',
   sp_client_id: '',
   technical_contact_email: '',
+  group_attribute_name: 'groups',
 }
 
 // This works differently from Nexus, but the result is the same. In Nexus,

--- a/test/e2e/silos.e2e.ts
+++ b/test/e2e/silos.e2e.ts
@@ -186,6 +186,10 @@ test('Identity providers', async ({ page }) => {
     'text="Single Logout (SLO) URL"',
   ])
 
+  await expect(page.getByRole('textbox', { name: 'Group attribute name' })).toHaveValue(
+    'groups'
+  )
+
   await page.getByRole('button', { name: 'Cancel' }).click()
   await expectNotVisible(page, ['role=dialog[name="Identity provider"]'])
 })


### PR DESCRIPTION
This field was already present, just hidden in the "edit" (though not really editable) view.

I also adjusted the help text's CSS to have `text-balance`, so we avoid having ragged descriptions.
<img width="459" alt="Screenshot 2024-10-28 at 11 59 26 AM" src="https://github.com/user-attachments/assets/23357b05-6c21-4ead-94f1-b35c3da75523">

Closes #2473