### PR TITLE
Fix dropdown z index

### DIFF
--- a/app/components/TopBar.tsx
+++ b/app/components/TopBar.tsx
@@ -55,7 +55,7 @@ export function TopBar({ children }: { children: React.ReactNode }) {
                 </span>
                 <DirectionDownIcon className="!w-2.5" />
               </DropdownMenu.Trigger>
-              <DropdownMenu.Content gap={8} className="!z-topBarDropdown">
+              <DropdownMenu.Content gap={8}>
                 <DropdownMenu.LinkItem to={pb.profile()}>Settings</DropdownMenu.LinkItem>
                 <DropdownMenu.Item onSelect={() => logout.mutate({})}>
                   Sign out

--- a/app/components/TopBar.tsx
+++ b/app/components/TopBar.tsx
@@ -55,7 +55,7 @@ export function TopBar({ children }: { children: React.ReactNode }) {
                 </span>
                 <DirectionDownIcon className="!w-2.5" />
               </DropdownMenu.Trigger>
-              <DropdownMenu.Content gap={8} className="!z-topBarPopover">
+              <DropdownMenu.Content gap={8} className="!z-topBarDropdown">
                 <DropdownMenu.LinkItem to={pb.profile()}>Settings</DropdownMenu.LinkItem>
                 <DropdownMenu.Item onSelect={() => logout.mutate({})}>
                   Sign out

--- a/app/components/TopBarPicker.tsx
+++ b/app/components/TopBarPicker.tsx
@@ -112,7 +112,7 @@ const TopBarPicker = (props: TopBarPickerProps) => {
       {/* TODO: popover position should be further right */}
       {props.items && (
         <DropdownMenu.Content
-          className="!z-topBarPopover mt-2 max-h-80 min-w-[12.8125rem] overflow-y-auto"
+          className="!z-topBarDropdown mt-2 max-h-80 min-w-[12.8125rem] overflow-y-auto"
           anchor="bottom start"
         >
           {props.items.length > 0 ? (

--- a/app/components/TopBarPicker.tsx
+++ b/app/components/TopBarPicker.tsx
@@ -112,7 +112,7 @@ const TopBarPicker = (props: TopBarPickerProps) => {
       {/* TODO: popover position should be further right */}
       {props.items && (
         <DropdownMenu.Content
-          className="!z-topBarDropdown mt-2 max-h-80 min-w-[12.8125rem] overflow-y-auto"
+          className="mt-2 max-h-80 min-w-[12.8125rem] overflow-y-auto"
           anchor="bottom start"
         >
           {props.items.length > 0 ? (

--- a/app/ui/styles/components/menu-button.css
+++ b/app/ui/styles/components/menu-button.css
@@ -7,7 +7,7 @@
  */
 
 .DropdownMenuContent {
-  @apply z-popover min-w-36 rounded border p-0 bg-raise border-secondary;
+  @apply z-topBarDropdown min-w-36 rounded border p-0 bg-raise border-secondary;
 
   & .DropdownMenuItem {
     @apply block w-full cursor-pointer select-none border-b py-2 pl-3 pr-6 text-left text-sans-md text-secondary border-secondary last:border-b-0;

--- a/app/ui/styles/components/menu-button.css
+++ b/app/ui/styles/components/menu-button.css
@@ -7,6 +7,7 @@
  */
 
 .DropdownMenuContent {
+  /* we want menu popover to be on top of top bar and pagination bar too */
   @apply z-topBarDropdown min-w-36 rounded border p-0 bg-raise border-secondary;
 
   & .DropdownMenuItem {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -48,7 +48,7 @@ module.exports = {
         modal: '40',
         sideModalDropdown: '40',
         sideModal: '30',
-        topBarPopover: '25',
+        topBarDropdown: '25',
         topBar: '20',
         popover: '10',
         contentDropdown: '10',


### PR DESCRIPTION
Per #2521, action menu dropdowns were stacking behind the footer bar, which has a z-index of `20`. 
![image](https://github.com/user-attachments/assets/824bdebc-aac1-48c6-93dc-63dc1817c1a7)

This PR updates the imported classes for `.DropdownMenuContent` to use a z-index of `25`. We also had a few overrides of the default z-index in TopBar and TopBarPicker, but since those are now using the same z-index, we can remove the overrides.

<img width="220" alt="Screenshot 2024-10-28 at 2 35 21 PM" src="https://github.com/user-attachments/assets/ba71d34c-cfaa-4959-b2c9-185c4ce42dad">

I have clicked through as many scenarios as I can think of regarding popovers and modals, and all seem to be working as expected.

Closes #2521.