### PR TITLE
Fix rendering of empty IP pool description

### DIFF
--- a/app/components/form/fields/ip-pool-item.tsx
+++ b/app/components/form/fields/ip-pool-item.tsx
@@ -21,7 +21,7 @@ export function toIpPoolItem(p: SiloIpPool) {
           </Badge>
         )}
       </div>
-      {p.description.length && (
+      {!!p.description && (
         <div className="text-tertiary selected:text-accent-secondary">{p.description}</div>
       )}
     </div>


### PR DESCRIPTION
### Before

<img width="485" src="https://github.com/user-attachments/assets/bc722c93-380e-495b-b81c-108971d89086">

### After

<img width="491" src="https://github.com/user-attachments/assets/1911a986-751e-4526-8a55-64698a902a8e">

### What about the linter

I tried using https://typescript-eslint.io/rules/strict-boolean-expressions to catch this, but even with the following config I got 78 errors. It gets thrown off by types that are a union including `null` or `undefined` — doesn't seem to understand that they're nullable.

```js
'@typescript-eslint/strict-boolean-expressions': [
  'error',
  {
    allowNumber: false,
    allowNullableNumber: false,

    allowString: true,
    allowNullableObject: true,
    allowNullableEnum: true,
    allowNullableBoolean: true,
    allowNullableString: true,
    allowAny: true,
  },
],
```