### PR TITLE
Tell password managers to stop trying to fill `name` field

### DIFF
--- a/app/components/form/fields/NameField.tsx
+++ b/app/components/form/fields/NameField.tsx
@@ -36,6 +36,11 @@ export function NameField<
           .replace(/[\s_]+/g, '-')
           .replace(/[^a-z0-9-]/g, '')
       }
+      // https://www.stefanjudis.com/snippets/turn-off-password-managers/
+      data-1p-ignore
+      data-bwignore
+      data-lpignore="true"
+      data-form-type="other"
       {...textFieldProps}
     />
   )


### PR DESCRIPTION
This 1Password thing on `name` fields in our forms is so silly.

<img width="506" alt="image" src="https://github.com/user-attachments/assets/18ad981d-0924-4d75-988e-22992e4cc4fb">

I've noticed this forever but didn't realize how easy it would be to fix. 

https://www.stefanjudis.com/snippets/turn-off-password-managers/