### PR TITLE
Generate boot disk name from image name

### DIFF
--- a/test/e2e/instance-create.e2e.ts
+++ b/test/e2e/instance-create.e2e.ts
@@ -376,7 +376,7 @@ test('maintains selected values even when changing tabs', async ({ page }) => {
   await expectVisible(page, [`h1:has-text("${instanceName}")`, 'text=8 GiB'])
   // when a disk name isn’t assigned, the generated one uses the ID of the image,
   // so this checks to make sure that the arch-based image — with ID `bd6aa051…` — was used
-  await expectVisible(page, [`text=${instanceName}-bd6aa051`])
+  await expectVisible(page, [`text=${instanceName}-${arch}`])
 })
 
 test('does not attach an ephemeral IP when the checkbox is unchecked', async ({ page }) => {

--- a/test/e2e/instance-create.e2e.ts
+++ b/test/e2e/instance-create.e2e.ts
@@ -374,8 +374,8 @@ test('maintains selected values even when changing tabs', async ({ page }) => {
   await page.getByRole('button', { name: 'Create instance' }).click()
   await expect(page).toHaveURL(`/projects/mock-project/instances/${instanceName}/storage`)
   await expectVisible(page, [`h1:has-text("${instanceName}")`, 'text=8 GiB'])
-  // when a disk name isn’t assigned, the generated one uses the ID of the image,
-  // so this checks to make sure that the arch-based image — with ID `bd6aa051…` — was used
+  // when a disk name isn’t assigned, the generated one uses the name of the image,
+  // so this checks to make sure that the arch-based image — with name `arch-2022-06-01` — was used
   await expectVisible(page, [`text=${instanceName}-${arch}`])
 })
 


### PR DESCRIPTION
This update changes how the fallback boot disk name is generated. Currently, we use the ID of the image used as the boot disk, but we'd like to use the image's name instead. The user is still able to set a boot disk name, as normal.

We are also looking into a means of showing the image used as the boot disk so that info is available whether the user names their boot disk or not, but that's a separate issue from this one.

Closes #2476