### PR TITLE
Mock serial console with MSW

### DIFF
--- a/mock-api/msw/handlers.ts
+++ b/mock-api/msw/handlers.ts
@@ -5,7 +5,7 @@
  *
  * Copyright Oxide Computer Company
  */
-import { delay } from 'msw'
+import { delay, ws } from 'msw'
 import * as R from 'remeda'
 import { validate as isUuid, v4 as uuid } from 'uuid'
 
@@ -63,7 +63,7 @@ import {
 // client camel-cases the keys and parses date fields. Inside the mock API everything
 // is *JSON type.
 
-export const handlers = makeHandlers({
+const httpHandlers = makeHandlers({
   logout: () => 204,
   ping: () => ({ status: 'ok' }),
   deviceAuthRequest: () => 200,
@@ -1592,3 +1592,16 @@ export const handlers = makeHandlers({
   userBuiltinList: NotImplemented,
   userBuiltinView: NotImplemented,
 })
+
+const serialWs = ws.link(
+  `ws://${window.location.host}/v1/instances/:instance/serial-console/stream`
+)
+
+export const handlers = [
+  ...httpHandlers,
+  serialWs.addEventListener('connection', ({ client }) => {
+    client.addEventListener('message', (_event) => {
+      client.send('hello from server!')
+    })
+  }),
+]


### PR DESCRIPTION
Closes #2071
Closes #2072 

MSW finally added websockets mocking in [v2.6](https://github.com/mswjs/msw/releases/tag/v2.6.0). It's very easy to use in a basic way, but it will take a little more work to get it to act more like the real API does.

- [x] Basic connection works
- [ ] Only connect in instance states that would let you connect in the real API
- [ ] More realistic initial response and a little behavior on typing

This is not merely cosmetic! This will help enormously with serial console feature work like #1505 and #1489 because it means we can write Playwright tests that exercise those features.