### PR TITLE
Set up normalizeName string utility function

### DIFF
--- a/app/components/form/fields/NameField.tsx
+++ b/app/components/form/fields/NameField.tsx
@@ -7,7 +7,7 @@
  */
 import type { FieldPath, FieldValues } from 'react-hook-form'
 
-import { capitalize, nameSyntax } from '~/util/str'
+import { capitalize, normalizeName } from '~/util/str'
 
 import { TextField, type TextFieldProps } from './TextField'
 
@@ -30,7 +30,7 @@ export function NameField<
       required={required}
       label={label}
       name={name}
-      transform={(value) => nameSyntax(value)}
+      transform={(value) => normalizeName(value)}
       // https://www.stefanjudis.com/snippets/turn-off-password-managers/
       data-1p-ignore
       data-bwignore

--- a/app/components/form/fields/NameField.tsx
+++ b/app/components/form/fields/NameField.tsx
@@ -7,7 +7,7 @@
  */
 import type { FieldPath, FieldValues } from 'react-hook-form'
 
-import { capitalize } from '~/util/str'
+import { capitalize, nameSyntax } from '~/util/str'
 
 import { TextField, type TextFieldProps } from './TextField'
 
@@ -30,12 +30,7 @@ export function NameField<
       required={required}
       label={label}
       name={name}
-      transform={(value) =>
-        value
-          .toLowerCase()
-          .replace(/[\s_]+/g, '-')
-          .replace(/[^a-z0-9-]/g, '')
-      }
+      transform={(value) => nameSyntax(value)}
       // https://www.stefanjudis.com/snippets/turn-off-password-managers/
       data-1p-ignore
       data-bwignore

--- a/app/ui/lib/Combobox.tsx
+++ b/app/ui/lib/Combobox.tsx
@@ -19,6 +19,8 @@ import { useEffect, useId, useState, type ReactNode, type Ref } from 'react'
 
 import { SelectArrows6Icon } from '@oxide/design-system/icons/react'
 
+import { nameSyntax } from '~/util/str'
+
 import { FieldLabel } from './FieldLabel'
 import { usePopoverZIndex } from './SideModal'
 import { TextInputHint } from './TextInput'
@@ -119,6 +121,9 @@ export const Combobox = ({
     if (allowArbitraryValues && !selectedItemValue) {
       setQuery('')
     }
+    if (selectedItemValue) {
+      setQuery(selectedItemValue)
+    }
   }, [allowArbitraryValues, selectedItemValue])
 
   // If the user has typed in a value that isn't in the list,
@@ -193,13 +198,18 @@ export const Combobox = ({
               // selectedItemValue is displayed when the user can type in a new value.
               // Otherwise, use the provided selectedItemLabel
               displayValue={() =>
-                allowArbitraryValues ? selectedItemValue : selectedItemLabel
+                selectedItemValue
+                  ? allowArbitraryValues
+                    ? selectedItemValue
+                    : selectedItemLabel
+                  : query
               }
               onChange={(event) => {
+                const value = nameSyntax(event.target.value, false)
                 // updates the query state as the user types, in order to filter the list of items
-                setQuery(event.target.value)
+                setQuery(value)
                 // if the parent component wants to know about input changes, call the callback
-                onInputChange?.(event.target.value)
+                onInputChange?.(value)
               }}
               onKeyDown={(e) => {
                 // Prevent form submission when the user presses Enter inside a combobox.

--- a/app/ui/lib/Combobox.tsx
+++ b/app/ui/lib/Combobox.tsx
@@ -19,8 +19,6 @@ import { useEffect, useId, useState, type ReactNode, type Ref } from 'react'
 
 import { SelectArrows6Icon } from '@oxide/design-system/icons/react'
 
-import { nameSyntax } from '~/util/str'
-
 import { FieldLabel } from './FieldLabel'
 import { usePopoverZIndex } from './SideModal'
 import { TextInputHint } from './TextInput'
@@ -121,9 +119,6 @@ export const Combobox = ({
     if (allowArbitraryValues && !selectedItemValue) {
       setQuery('')
     }
-    if (selectedItemValue) {
-      setQuery(selectedItemValue)
-    }
   }, [allowArbitraryValues, selectedItemValue])
 
   // If the user has typed in a value that isn't in the list,
@@ -198,18 +193,13 @@ export const Combobox = ({
               // selectedItemValue is displayed when the user can type in a new value.
               // Otherwise, use the provided selectedItemLabel
               displayValue={() =>
-                selectedItemValue
-                  ? allowArbitraryValues
-                    ? selectedItemValue
-                    : selectedItemLabel
-                  : query
+                allowArbitraryValues ? selectedItemValue : selectedItemLabel
               }
               onChange={(event) => {
-                const value = nameSyntax(event.target.value, false)
                 // updates the query state as the user types, in order to filter the list of items
-                setQuery(value)
+                setQuery(event.target.value)
                 // if the parent component wants to know about input changes, call the callback
-                onInputChange?.(value)
+                onInputChange?.(event.target.value)
               }}
               onKeyDown={(e) => {
                 // Prevent form submission when the user presses Enter inside a combobox.

--- a/app/util/str.spec.tsx
+++ b/app/util/str.spec.tsx
@@ -13,7 +13,7 @@ import {
   commaSeries,
   extractText,
   kebabCase,
-  nameSyntax,
+  normalizeName,
   titleCase,
 } from './str'
 
@@ -112,39 +112,39 @@ describe('extractText', () => {
   })
 })
 
-describe('nameSyntax', () => {
+describe('normalizeName', () => {
   it('converts to lowercase', () => {
-    expect(nameSyntax('Hello')).toBe('hello')
+    expect(normalizeName('Hello')).toBe('hello')
   })
 
   it('replaces spaces with dashes', () => {
-    expect(nameSyntax('Hello World')).toBe('hello-world')
+    expect(normalizeName('Hello World')).toBe('hello-world')
   })
 
   it('removes non-alphanumeric characters', () => {
-    expect(nameSyntax('Hello, World!')).toBe('hello-world')
+    expect(normalizeName('Hello, World!')).toBe('hello-world')
   })
 
   it('caps at 63 characters', () => {
-    expect(nameSyntax('aaa')).toBe('aaa')
-    expect(nameSyntax('aaaaaaaaa')).toBe('aaaaaaaaa')
-    expect(nameSyntax('a'.repeat(63))).toBe('a'.repeat(63))
-    expect(nameSyntax('a'.repeat(64))).toBe('a'.repeat(63))
+    expect(normalizeName('aaa')).toBe('aaa')
+    expect(normalizeName('aaaaaaaaa')).toBe('aaaaaaaaa')
+    expect(normalizeName('a'.repeat(63))).toBe('a'.repeat(63))
+    expect(normalizeName('a'.repeat(64))).toBe('a'.repeat(63))
   })
 
   it('can optionally start with numbers', () => {
-    expect(nameSyntax('123abc')).toBe('abc')
-    expect(nameSyntax('123abc', false)).toBe('abc')
-    expect(nameSyntax('123abc', true)).toBe('123abc')
+    expect(normalizeName('123abc')).toBe('abc')
+    expect(normalizeName('123abc', false)).toBe('abc')
+    expect(normalizeName('123abc', true)).toBe('123abc')
   })
 
   it('can optionally start with a dash', () => {
-    expect(nameSyntax('-abc')).toBe('abc')
-    expect(nameSyntax('-abc', false)).toBe('abc')
-    expect(nameSyntax('-abc', true)).toBe('-abc')
+    expect(normalizeName('-abc')).toBe('abc')
+    expect(normalizeName('-abc', false)).toBe('abc')
+    expect(normalizeName('-abc', true)).toBe('-abc')
   })
 
   it('does not complain when multiple dashes are present', () => {
-    expect(nameSyntax('a--b')).toBe('a--b')
+    expect(normalizeName('a--b')).toBe('a--b')
   })
 })

--- a/app/util/str.spec.tsx
+++ b/app/util/str.spec.tsx
@@ -13,6 +13,7 @@ import {
   commaSeries,
   extractText,
   kebabCase,
+  nameSyntax,
   titleCase,
 } from './str'
 
@@ -108,5 +109,42 @@ describe('extractText', () => {
   })
   it('can handle regular strings', () => {
     expect(extractText('Some more text')).toBe('Some more text')
+  })
+})
+
+describe('nameSyntax', () => {
+  it('converts to lowercase', () => {
+    expect(nameSyntax('Hello')).toBe('hello')
+  })
+
+  it('replaces spaces with dashes', () => {
+    expect(nameSyntax('Hello World')).toBe('hello-world')
+  })
+
+  it('removes non-alphanumeric characters', () => {
+    expect(nameSyntax('Hello, World!')).toBe('hello-world')
+  })
+
+  it('caps at 63 characters', () => {
+    expect(nameSyntax('aaa')).toBe('aaa')
+    expect(nameSyntax('aaaaaaaaa')).toBe('aaaaaaaaa')
+    expect(nameSyntax('a'.repeat(63))).toBe('a'.repeat(63))
+    expect(nameSyntax('a'.repeat(64))).toBe('a'.repeat(63))
+  })
+
+  it('can optionally start with numbers', () => {
+    expect(nameSyntax('123abc')).toBe('abc')
+    expect(nameSyntax('123abc', false)).toBe('abc')
+    expect(nameSyntax('123abc', true)).toBe('123abc')
+  })
+
+  it('can optionally start with a dash', () => {
+    expect(nameSyntax('-abc')).toBe('abc')
+    expect(nameSyntax('-abc', false)).toBe('abc')
+    expect(nameSyntax('-abc', true)).toBe('-abc')
+  })
+
+  it('does not complain when multiple dashes are present', () => {
+    expect(nameSyntax('a--b')).toBe('a--b')
   })
 })

--- a/app/util/str.ts
+++ b/app/util/str.ts
@@ -58,6 +58,26 @@ export const titleCase = (text: string): string => {
  */
 export const isAllZeros = (base64Data: string) => /^A*=*$/.test(base64Data)
 
+/** Clean up text so that it conforms to Name field syntax rules:
+ *   - lowercase only
+ *   - no spaces
+ *   - only letters/numbers/dashes allowed
+ *   - capped at 63 characters
+ *  By default, it must start with a letter; this can be overriden with the second argument,
+ *  for contexts where we want to allow numbers at the start, like searching in comboboxes.
+ */
+export const nameSyntax = (text: string, allowNonLetterStart = false): string => {
+  const cleanedText = text
+    .toLowerCase()
+    .replace(/[\s_]+/g, '-') // Replace spaces and underscores with dashes
+    .replace(/[^a-z0-9-]/g, '') // Remove non-alphanumeric (or dash) characters
+    .slice(0, 63) // Limit string to 63 characters
+  if (allowNonLetterStart) {
+    return cleanedText
+  }
+  return cleanedText.replace(/^[^a-z]+/, '') // Remove any non-letter characters from the start
+}
+
 /**
  * Extract the string contents of a ReactNode, so <>This <HL>highlighted</HL> text</> becomes "This highlighted text"
  */

--- a/app/util/str.ts
+++ b/app/util/str.ts
@@ -66,7 +66,7 @@ export const isAllZeros = (base64Data: string) => /^A*=*$/.test(base64Data)
  *  By default, it must start with a letter; this can be overriden with the second argument,
  *  for contexts where we want to allow numbers at the start, like searching in comboboxes.
  */
-export const nameSyntax = (text: string, allowNonLetterStart = false): string => {
+export const normalizeName = (text: string, allowNonLetterStart = false): string => {
   const cleanedText = text
     .toLowerCase()
     .replace(/[\s_]+/g, '-') // Replace spaces and underscores with dashes

--- a/app/util/str.ts
+++ b/app/util/str.ts
@@ -67,15 +67,15 @@ export const isAllZeros = (base64Data: string) => /^A*=*$/.test(base64Data)
  *  for contexts where we want to allow numbers at the start, like searching in comboboxes.
  */
 export const normalizeName = (text: string, allowNonLetterStart = false): string => {
-  const cleanedText = text
+  const normalizedName = text
     .toLowerCase()
     .replace(/[\s_]+/g, '-') // Replace spaces and underscores with dashes
     .replace(/[^a-z0-9-]/g, '') // Remove non-alphanumeric (or dash) characters
     .slice(0, 63) // Limit string to 63 characters
   if (allowNonLetterStart) {
-    return cleanedText
+    return normalizedName
   }
-  return cleanedText.replace(/^[^a-z]+/, '') // Remove any non-letter characters from the start
+  return normalizedName.replace(/^[^a-z]+/, '') // Remove any non-letter characters from the start
 }
 
 /**


### PR DESCRIPTION
We are already restricting some of the characters that users can add to the Name field. While working on #2546 I figured that it might be helpful to have this string manipulation available in an external function, so we can restrict what's typed in to the Combobox field. Because we'll want to give users the option of typing a number in as the initial character ("I'm trying to filter for Images with `2024` in them"), the `nameSyntax` function has an optional second prop. Left off, the default action is to only permit a letter in the zeroth position. If `true` is passed in to `allowNonLetterStart`, the user can enter either a number or a dash. Non-allowed characters are dropped.