### PR TITLE
Disable spellcheck on inputs

### DIFF
--- a/app/ui/lib/TextInput.tsx
+++ b/app/ui/lib/TextInput.tsx
@@ -93,6 +93,7 @@ export const TextInput = React.forwardRef<
           )}
           aria-invalid={error}
           disabled={disabled}
+          spellCheck={false}
           {...fieldProps}
         />
         {copyable && (


### PR DESCRIPTION
In Safari, input fields currently suggest spellchecked variations of what you've entered:
<img width="460" alt="Screenshot 2024-11-13 at 12 01 55 PM" src="https://github.com/user-attachments/assets/f667bfad-f16e-4d21-b451-bd2e89d2a487">

This PR turns that off:
<img width="459" alt="Screenshot 2024-11-13 at 12 02 27 PM" src="https://github.com/user-attachments/assets/d87fe7a0-9567-4195-b300-9fbeb2b4f0e3">

Note, though, that there are some browser-level preferences that we do not have control over, like this one:
<img width="844" alt="Screenshot 2024-11-13 at 11 58 06 AM" src="https://github.com/user-attachments/assets/0008254e-93e4-4e32-a5a0-c6fee2c3b7b9">
which decides to suggest names from your contacts list to the "Name" field:
<img width="465" alt="Screenshot 2024-11-13 at 11 57 53 AM" src="https://github.com/user-attachments/assets/bec4d20e-8fae-412b-99af-a238192bd56a">

I looked into various ways of turning that off, but everything I found was hacky (like adding hidden pseudo form fields to the page to intercept autocompletes, [as described in this SO thread](https://stackoverflow.com/questions/22661977/disabling-safari-autofill-on-usernames-and-passwords)).

Nevertheless, field-level spellchecking prefs do seem to be respected by the browser, so we'll apply that here.

Closes #2532 