### PR TITLE
Set date pickers to match other input elements' heights

### DIFF
--- a/app/ui/lib/DatePicker.tsx
+++ b/app/ui/lib/DatePicker.tsx
@@ -62,7 +62,7 @@ export function DatePicker(props: DatePickerProps) {
           type="button"
           className={cn(
             state.isOpen && 'z-10 ring-2',
-            'relative flex h-10 items-center rounded-l rounded-r border text-sans-md border-default focus-within:ring-2 hover:border-raise focus:z-10',
+            'relative flex h-11 items-center rounded-l rounded-r border text-sans-md border-default focus-within:ring-2 hover:border-raise focus:z-10',
             state.isInvalid
               ? 'focus-error border-error ring-error-secondary'
               : 'border-default ring-accent-secondary'

--- a/app/ui/lib/DateRangePicker.tsx
+++ b/app/ui/lib/DateRangePicker.tsx
@@ -62,7 +62,7 @@ export function DateRangePicker(props: DateRangePickerProps) {
           type="button"
           className={cn(
             state.isOpen && 'z-10 ring-2',
-            'relative flex h-10 items-center rounded-l rounded-r border text-sans-md border-default focus-within:ring-2 hover:border-raise focus:z-10',
+            'relative flex h-11 items-center rounded-l rounded-r border text-sans-md border-default focus-within:ring-2 hover:border-raise focus:z-10',
             state.isInvalid
               ? 'focus-error border-error ring-error-secondary'
               : 'border-default ring-accent-secondary'


### PR DESCRIPTION
Woof. We recently made comboboxes / listboxes larger, to match the height of input fields. The DatePicker component had an independent height, though, and so it wasn't matching the height of the listbox on the Metrics page. This fixes that, so DatePickers now match the other input components' heights.

Broken:
<img width="499" alt="Screenshot 2024-11-18 at 4 48 40 PM" src="https://github.com/user-attachments/assets/b59f8206-1e87-4626-ba67-6e0b7015e340">

Fixed:
<img width="497" alt="Screenshot 2024-11-18 at 4 48 30 PM" src="https://github.com/user-attachments/assets/caff2c12-15ad-4739-882a-176b48b816e6">

