### PR TITLE
chore: update API for instance resize without adding instance resize UI

### DIFF
--- a/OMICRON_VERSION
+++ b/OMICRON_VERSION
@@ -1,1 +1,1 @@
-33bbad374205a8fcf3d23d8d4c218cfaf74b1e15
+9c8aa5372fede528bff8e69fd88cabda0e92fac4

--- a/app/api/__generated__/Api.ts
+++ b/app/api/__generated__/Api.ts
@@ -1992,6 +1992,10 @@ Currently, the global default auto-restart policy is "best-effort", so instances
 
 If not provided, unset the instance's boot disk. */
   bootDisk?: NameOrId
+  /** The amount of memory to assign to this instance. */
+  memory: ByteCount
+  /** The number of CPUs to assign to this instance. */
+  ncpus: InstanceCpuCount
 }
 
 /**
@@ -2319,7 +2323,7 @@ export type TxEqConfig = {
 export type LinkConfigCreate = {
   /** Whether or not to set autonegotiation */
   autoneg: boolean
-  /** The forward error correction mode of the link. */
+  /** The requested forward-error correction method.  If this is not specified, the standard FEC for the underlying media will be applied if it can be determined. */
   fec?: LinkFec
   /** The link-layer discovery protocol (LLDP) configuration for the link. */
   lldp: LldpLinkConfigCreate
@@ -3504,7 +3508,7 @@ export type SwitchPortConfigCreate = {
 export type SwitchPortLinkConfig = {
   /** Whether or not the link has autonegotiation enabled. */
   autoneg: boolean
-  /** The forward error correction mode of the link. */
+  /** The requested forward-error correction method.  If this is not specified, the standard FEC for the underlying media will be applied if it can be determined. */
   fec?: LinkFec
   /** The name of this link. */
   linkName: string

--- a/app/api/__generated__/OMICRON_VERSION
+++ b/app/api/__generated__/OMICRON_VERSION
@@ -1,2 +1,2 @@
 # generated file. do not update manually. see docs/update-pinned-api.md
-33bbad374205a8fcf3d23d8d4c218cfaf74b1e15
+9c8aa5372fede528bff8e69fd88cabda0e92fac4

--- a/app/api/__generated__/validate.ts
+++ b/app/api/__generated__/validate.ts
@@ -1856,6 +1856,8 @@ export const InstanceUpdate = z.preprocess(
   z.object({
     autoRestartPolicy: InstanceAutoRestartPolicy.optional(),
     bootDisk: NameOrId.optional(),
+    memory: ByteCount,
+    ncpus: InstanceCpuCount,
   })
 )
 

--- a/app/pages/project/instances/instance/tabs/StorageTab.tsx
+++ b/app/pages/project/instances/instance/tabs/StorageTab.tsx
@@ -146,6 +146,10 @@ export function Component() {
     [disks.items, instance.bootDiskId]
   )
 
+  // Needed to keep them the same while setting boot disk.
+  // Extracted to keep dep array appropriately zealous.
+  const { ncpus, memory } = instance
+
   const makeBootDiskActions = useCallback(
     (disk: InstanceDisk): MenuAction[] => [
       getSnapshotAction(disk),
@@ -164,6 +168,8 @@ export function Component() {
                 path: { instance: instance.id },
                 body: {
                   bootDisk: undefined,
+                  ncpus,
+                  memory,
                   // this would get unset if we left it out
                   autoRestartPolicy: instance.autoRestartPolicy,
                 },
@@ -194,7 +200,7 @@ export function Component() {
         onActivate() {}, // it's always disabled, so noop is ok
       },
     ],
-    [instanceUpdate, instance, getSnapshotAction]
+    [instanceUpdate, instance, getSnapshotAction, ncpus, memory]
   )
 
   const makeOtherDiskActions = useCallback(
@@ -217,6 +223,8 @@ export function Component() {
                 path: { instance: instance.id },
                 body: {
                   bootDisk: disk.id,
+                  ncpus,
+                  memory,
                   // this would get unset if we left it out
                   autoRestartPolicy: instance.autoRestartPolicy,
                 },
@@ -254,7 +262,7 @@ export function Component() {
         },
       },
     ],
-    [detachDisk, instanceUpdate, instance, getSnapshotAction, bootDisks]
+    [detachDisk, instanceUpdate, instance, getSnapshotAction, bootDisks, ncpus, memory]
   )
 
   const attachDisk = useApiMutation('instanceDiskAttach', {

--- a/mock-api/msw/handlers.ts
+++ b/mock-api/msw/handlers.ts
@@ -613,6 +613,10 @@ export const handlers = makeHandlers({
       instance.boot_disk_id = undefined
     }
 
+    // always present on the body, always set them
+    instance.ncpus = body.ncpus
+    instance.memory = body.memory
+
     return instance
   },
   instanceDelete({ path, query }) {


### PR DESCRIPTION
This does a bit of what's in #2487. I want to merge this so we can get it on dogfood asap because without this, changing the boot disk will 400 because the instance update body is missing `ncpus` and `memory`.