### PR TITLE
refactor: Use `queryOptions` API to clean up `useApiQuery` hook definitions

### DIFF
--- a/test/e2e/breadcrumbs.e2e.ts
+++ b/test/e2e/breadcrumbs.e2e.ts
@@ -41,10 +41,12 @@ test('breadcrumbs', async ({ page }) => {
   // the form route doesn't have its own crumb
   await page.getByRole('link', { name: 'New VPC' }).click()
   await expect(page).toHaveURL('/projects/mock-project/vpcs-new')
+  await expect(page.getByRole('dialog', { name: 'Create VPC' })).toBeVisible()
   await expectCrumbs(page, vpcsCrumbs)
 
   // try a nested one with a tab
   await page.goto('/projects/mock-project/instances/db1/networking')
+  await expect(page.getByRole('tab', { name: 'Networking' })).toBeVisible()
   await expectCrumbs(page, [
     ...projectCrumbs,
     ['Instances', '/projects/mock-project/instances'],
@@ -77,6 +79,8 @@ test('breadcrumbs', async ({ page }) => {
     ['ip-pool-1', '/system/networking/ip-pools/ip-pool-1'],
   ]
   await expectCrumbs(page, poolCrumbs)
-  await page.goto('/system/networking/ip-pools/ip-pool-1/ranges-add')
+  await page.getByRole('link', { name: 'Add range' }).click()
+  await expect(page).toHaveURL('/system/networking/ip-pools/ip-pool-1/ranges-add')
+  await expect(page.getByRole('dialog', { name: 'Add IP range' })).toBeVisible()
   await expectCrumbs(page, poolCrumbs)
 })


### PR DESCRIPTION
Was inspired. 

<img width="590" alt="image" src="https://github.com/user-attachments/assets/c71df377-f66e-4c3c-8d5c-2d93549c49cf">

https://x.com/TkDodo/status/1857764199813861829

The goal here is to keep this change very minimal and show that nothing changes in order to enable a more interesting followup change improving `QueryTable`. But it makes some other interesting things possible (which I don't do in this PR):

```ts
export const apiq = getApiQueryOptions(api.methods)
```

```diff
- apiQueryClient.prefetchQuery('projectList', { query: { limit: PAGE_SIZE } })
- useApiQuery('projectList', { query: { limit: PAGE_SIZE } })

+ const projectListOptions = apiq('projectList', { query: { limit: PAGE_SIZE } })
+ 
+ queryClient.prefetchQuery(projectListOptions)
+ useQuery(projectListOptions)
```

See also tRPC’s [RFC](https://github.com/trpc/trpc/discussions/6240) to do something very similar in their generated client.
