### PR TITLE
refactor: new `useQueryTable` with legit types, returns the query data

### DIFF
--- a/app/api/client.ts
+++ b/app/api/client.ts
@@ -9,6 +9,7 @@ import { QueryClient } from '@tanstack/react-query'
 
 import { Api } from './__generated__/Api'
 import {
+  getApiQueryOptions,
   getUseApiMutation,
   getUseApiQueries,
   getUseApiQuery,
@@ -17,6 +18,8 @@ import {
   wrapQueryClient,
 } from './hooks'
 
+export { ensure } from './hooks'
+
 export const api = new Api({
   // unit tests run in Node, whose fetch implementation requires a full URL
   host: process.env.NODE_ENV === 'test' ? 'http://testhost' : '',
@@ -24,6 +27,7 @@ export const api = new Api({
 
 export type ApiMethods = typeof api.methods
 
+export const apiq = getApiQueryOptions(api.methods)
 export const useApiQuery = getUseApiQuery(api.methods)
 export const useApiQueries = getUseApiQueries(api.methods)
 /**

--- a/app/api/client.ts
+++ b/app/api/client.ts
@@ -10,6 +10,7 @@ import { QueryClient } from '@tanstack/react-query'
 import { Api } from './__generated__/Api'
 import {
   getApiQueryOptions,
+  getListQueryOptionsFn,
   getUseApiMutation,
   getUseApiQueries,
   getUseApiQuery,
@@ -18,7 +19,7 @@ import {
   wrapQueryClient,
 } from './hooks'
 
-export { ensure } from './hooks'
+export { ensurePrefetched, PAGE_SIZE } from './hooks'
 
 export const api = new Api({
   // unit tests run in Node, whose fetch implementation requires a full URL
@@ -27,7 +28,14 @@ export const api = new Api({
 
 export type ApiMethods = typeof api.methods
 
+/** API-specific query options helper. */
 export const apiq = getApiQueryOptions(api.methods)
+/**
+ * Query options helper that only supports list endpoints. Returns
+ * a function `(limit, pageToken) => QueryOptions` for use with
+ * `useQueryTable`.
+ */
+export const getListQFn = getListQueryOptionsFn(api.methods)
 export const useApiQuery = getUseApiQuery(api.methods)
 export const useApiQueries = getUseApiQueries(api.methods)
 /**

--- a/app/api/client.ts
+++ b/app/api/client.ts
@@ -19,7 +19,7 @@ import {
   wrapQueryClient,
 } from './hooks'
 
-export { ensurePrefetched, PAGE_SIZE } from './hooks'
+export { ensurePrefetched, PAGE_SIZE, type PaginatedQuery } from './hooks'
 
 export const api = new Api({
   // unit tests run in Node, whose fetch implementation requires a full URL

--- a/app/api/hooks.ts
+++ b/app/api/hooks.ts
@@ -171,7 +171,11 @@ export const getListQueryOptionsFn =
     return {
       optionsFn: (pageToken?: string) => {
         const newParams = { ...params, query: { ...params.query, limit, pageToken } }
-        return getApiQueryOptions(api)(method, newParams, options)
+        return getApiQueryOptions(api)(method, newParams, {
+          ...options,
+          // identity function so current page sticks around while next loads
+          placeholderData: (x) => x,
+        })
       },
       pageSize: limit,
     }

--- a/app/api/hooks.ts
+++ b/app/api/hooks.ts
@@ -165,7 +165,11 @@ export const getListQueryOptionsFn =
     params: Params<A[M]>,
     options: UseQueryOtherOptions<Result<A[M]>, ApiError> = {}
   ): PaginatedQuery<Result<A[M]>> => {
-    // pathOr plays nice when the properties don't exist
+    // We pull limit out of the query params rather than passing it in some
+    // other way so that there is exactly one way of specifying it. If we had
+    // some other way of doing it, and then you also passed it in as a query
+    // param, it would be hard to guess which takes precedence. (pathOr plays
+    // nice when the properties don't exist.)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const limit = R.pathOr(params as any, ['query', 'limit'], PAGE_SIZE)
     return {

--- a/app/api/util.ts
+++ b/app/api/util.ts
@@ -23,6 +23,8 @@ import type {
   VpcFirewallRuleUpdate,
 } from './__generated__/Api'
 
+export type ResultsPage<TItem> = { items: TItem[]; nextPage?: string }
+
 // API limits encoded in https://github.com/oxidecomputer/omicron/blob/main/nexus/src/app/mod.rs
 
 export const MAX_NICS_PER_INSTANCE = 8

--- a/app/layouts/helpers.tsx
+++ b/app/layouts/helpers.tsx
@@ -20,7 +20,12 @@ export function ContentPane() {
   const ref = useRef<HTMLDivElement>(null)
   useScrollRestoration(ref)
   return (
-    <div ref={ref} className="flex flex-col overflow-auto" data-testid="scroll-container">
+    <div
+      ref={ref}
+      className="flex flex-col overflow-auto"
+      id="scroll-container"
+      data-testid="scroll-container"
+    >
       <div className="flex grow flex-col pb-8">
         <SkipLinkTarget />
         <main className="[&>*]:gutter">

--- a/app/pages/project/snapshots/SnapshotsPage.tsx
+++ b/app/pages/project/snapshots/SnapshotsPage.tsx
@@ -59,7 +59,7 @@ const snapshotList = (project: string) => getListQFn('snapshotList', { query: { 
 SnapshotsPage.loader = async ({ params }: LoaderFunctionArgs) => {
   const { project } = getProjectSelector(params)
   await Promise.all([
-    queryClient.prefetchQuery(snapshotList(project)()),
+    queryClient.prefetchQuery(snapshotList(project).optionsFn()),
 
     // Fetch disks and preload into RQ cache so fetches by ID in DiskNameFromId
     // can be mostly instant yet gracefully fall back to fetching individually
@@ -134,7 +134,7 @@ export function SnapshotsPage() {
   )
   const columns = useColsWithActions(staticCols, makeActions)
   const { table } = useQueryTable({
-    optionsFn: snapshotList(project),
+    query: snapshotList(project),
     columns,
     emptyState: <EmptyState />,
   })

--- a/app/pages/system/inventory/DisksTab.tsx
+++ b/app/pages/system/inventory/DisksTab.tsx
@@ -8,7 +8,7 @@
 import { createColumnHelper } from '@tanstack/react-table'
 
 import {
-  apiq,
+  getListQFn,
   queryClient,
   type PhysicalDisk,
   type PhysicalDiskPolicy,
@@ -16,7 +16,7 @@ import {
 } from '@oxide/api'
 import { Servers24Icon } from '@oxide/design-system/icons/react'
 
-import { PAGE_SIZE, useQueryTable } from '~/table/QueryTable2'
+import { useQueryTable } from '~/table/QueryTable2'
 import { Badge, type BadgeColor } from '~/ui/lib/Badge'
 import { EmptyMessage } from '~/ui/lib/EmptyMessage'
 
@@ -38,11 +38,10 @@ const EmptyState = () => (
   />
 )
 
-const diskList = (limit: number, pageToken?: string) =>
-  apiq('physicalDiskList', { query: { limit, pageToken } }, { placeholderData: (x) => x })
+const diskList = getListQFn('physicalDiskList', {}, { placeholderData: (x) => x })
 
 export async function loader() {
-  await queryClient.prefetchQuery(diskList(PAGE_SIZE))
+  await queryClient.prefetchQuery(diskList())
   return null
 }
 

--- a/app/pages/system/inventory/DisksTab.tsx
+++ b/app/pages/system/inventory/DisksTab.tsx
@@ -38,7 +38,7 @@ const EmptyState = () => (
   />
 )
 
-const diskList = getListQFn('physicalDiskList', {}, { placeholderData: (x) => x })
+const diskList = getListQFn('physicalDiskList', {})
 
 export async function loader() {
   await queryClient.prefetchQuery(diskList.optionsFn())

--- a/app/pages/system/inventory/DisksTab.tsx
+++ b/app/pages/system/inventory/DisksTab.tsx
@@ -8,14 +8,15 @@
 import { createColumnHelper } from '@tanstack/react-table'
 
 import {
-  apiQueryClient,
+  apiq,
+  queryClient,
   type PhysicalDisk,
   type PhysicalDiskPolicy,
   type PhysicalDiskState,
 } from '@oxide/api'
 import { Servers24Icon } from '@oxide/design-system/icons/react'
 
-import { PAGE_SIZE, useQueryTable } from '~/table/QueryTable'
+import { PAGE_SIZE, useQueryTable } from '~/table/QueryTable2'
 import { Badge, type BadgeColor } from '~/ui/lib/Badge'
 import { EmptyMessage } from '~/ui/lib/EmptyMessage'
 
@@ -37,8 +38,11 @@ const EmptyState = () => (
   />
 )
 
+const diskList = (limit: number, pageToken?: string) =>
+  apiq('physicalDiskList', { query: { limit, pageToken } }, { placeholderData: (x) => x })
+
 export async function loader() {
-  await apiQueryClient.prefetchQuery('physicalDiskList', { query: { limit: PAGE_SIZE } })
+  await queryClient.prefetchQuery(diskList(PAGE_SIZE))
   return null
 }
 
@@ -68,6 +72,10 @@ const staticCols = [
 
 Component.displayName = 'DisksTab'
 export function Component() {
-  const { Table } = useQueryTable('physicalDiskList', {})
-  return <Table emptyState={<EmptyState />} columns={staticCols} />
+  const { table } = useQueryTable({
+    optionsFn: diskList,
+    columns: staticCols,
+    emptyState: <EmptyState />,
+  })
+  return table
 }

--- a/app/pages/system/inventory/DisksTab.tsx
+++ b/app/pages/system/inventory/DisksTab.tsx
@@ -41,7 +41,7 @@ const EmptyState = () => (
 const diskList = getListQFn('physicalDiskList', {}, { placeholderData: (x) => x })
 
 export async function loader() {
-  await queryClient.prefetchQuery(diskList())
+  await queryClient.prefetchQuery(diskList.optionsFn())
   return null
 }
 
@@ -71,10 +71,7 @@ const staticCols = [
 
 Component.displayName = 'DisksTab'
 export function Component() {
-  const { table } = useQueryTable({
-    optionsFn: diskList,
-    columns: staticCols,
-    emptyState: <EmptyState />,
-  })
+  const emptyState = <EmptyState />
+  const { table } = useQueryTable({ query: diskList, columns: staticCols, emptyState })
   return table
 }

--- a/app/pages/system/inventory/SledsTab.tsx
+++ b/app/pages/system/inventory/SledsTab.tsx
@@ -45,7 +45,7 @@ const EmptyState = () => {
 const sledList = getListQFn('sledList', {}, { placeholderData: (x) => x })
 
 export async function loader() {
-  await queryClient.prefetchQuery(sledList())
+  await queryClient.prefetchQuery(sledList.optionsFn())
   return null
 }
 
@@ -75,10 +75,7 @@ const staticCols = [
 
 Component.displayName = 'SledsTab'
 export function Component() {
-  const { table } = useQueryTable({
-    optionsFn: sledList,
-    columns: staticCols,
-    emptyState: <EmptyState />,
-  })
+  const emptyState = <EmptyState />
+  const { table } = useQueryTable({ query: sledList, columns: staticCols, emptyState })
   return table
 }

--- a/app/pages/system/inventory/SledsTab.tsx
+++ b/app/pages/system/inventory/SledsTab.tsx
@@ -7,11 +7,11 @@
  */
 import { createColumnHelper } from '@tanstack/react-table'
 
-import { apiQueryClient, type Sled, type SledPolicy, type SledState } from '@oxide/api'
+import { apiq, queryClient, type Sled, type SledPolicy, type SledState } from '@oxide/api'
 import { Servers24Icon } from '@oxide/design-system/icons/react'
 
 import { makeLinkCell } from '~/table/cells/LinkCell'
-import { PAGE_SIZE, useQueryTable } from '~/table/QueryTable'
+import { PAGE_SIZE, useQueryTable } from '~/table/QueryTable2'
 import { Badge, type BadgeColor } from '~/ui/lib/Badge'
 import { EmptyMessage } from '~/ui/lib/EmptyMessage'
 import { pb } from '~/util/path-builder'
@@ -36,10 +36,11 @@ const EmptyState = () => {
   )
 }
 
+const sledList = (limit: number, pageToken?: string) =>
+  apiq('sledList', { query: { limit, pageToken } }, { placeholderData: (x) => x })
+
 export async function loader() {
-  await apiQueryClient.prefetchQuery('sledList', {
-    query: { limit: PAGE_SIZE },
-  })
+  await queryClient.prefetchQuery(sledList(PAGE_SIZE))
   return null
 }
 
@@ -69,6 +70,10 @@ const staticCols = [
 
 Component.displayName = 'SledsTab'
 export function Component() {
-  const { Table } = useQueryTable('sledList', {}, { placeholderData: (x) => x })
-  return <Table emptyState={<EmptyState />} columns={staticCols} />
+  const { table } = useQueryTable({
+    optionsFn: sledList,
+    columns: staticCols,
+    emptyState: <EmptyState />,
+  })
+  return table
 }

--- a/app/pages/system/inventory/SledsTab.tsx
+++ b/app/pages/system/inventory/SledsTab.tsx
@@ -42,7 +42,7 @@ const EmptyState = () => {
   )
 }
 
-const sledList = getListQFn('sledList', {}, { placeholderData: (x) => x })
+const sledList = getListQFn('sledList', {})
 
 export async function loader() {
   await queryClient.prefetchQuery(sledList.optionsFn())

--- a/app/pages/system/inventory/SledsTab.tsx
+++ b/app/pages/system/inventory/SledsTab.tsx
@@ -7,11 +7,17 @@
  */
 import { createColumnHelper } from '@tanstack/react-table'
 
-import { apiq, queryClient, type Sled, type SledPolicy, type SledState } from '@oxide/api'
+import {
+  getListQFn,
+  queryClient,
+  type Sled,
+  type SledPolicy,
+  type SledState,
+} from '@oxide/api'
 import { Servers24Icon } from '@oxide/design-system/icons/react'
 
 import { makeLinkCell } from '~/table/cells/LinkCell'
-import { PAGE_SIZE, useQueryTable } from '~/table/QueryTable2'
+import { useQueryTable } from '~/table/QueryTable2'
 import { Badge, type BadgeColor } from '~/ui/lib/Badge'
 import { EmptyMessage } from '~/ui/lib/EmptyMessage'
 import { pb } from '~/util/path-builder'
@@ -36,11 +42,10 @@ const EmptyState = () => {
   )
 }
 
-const sledList = (limit: number, pageToken?: string) =>
-  apiq('sledList', { query: { limit, pageToken } }, { placeholderData: (x) => x })
+const sledList = getListQFn('sledList', {}, { placeholderData: (x) => x })
 
 export async function loader() {
-  await queryClient.prefetchQuery(sledList(PAGE_SIZE))
+  await queryClient.prefetchQuery(sledList())
   return null
 }
 

--- a/app/table/QueryTable.tsx
+++ b/app/table/QueryTable.tsx
@@ -12,6 +12,7 @@ import { getCoreRowModel, useReactTable, type ColumnDef } from '@tanstack/react-
 import React, { useCallback, useMemo, type ComponentType } from 'react'
 
 import {
+  PAGE_SIZE,
   useApiQuery,
   type ApiError,
   type ApiListMethods,
@@ -26,6 +27,8 @@ import { EmptyMessage } from '~/ui/lib/EmptyMessage'
 import { TableEmptyBox } from '~/ui/lib/Table'
 
 import { Table } from './Table'
+
+export { PAGE_SIZE }
 
 interface UseQueryTableResult<Item extends Record<string, unknown>> {
   Table: ComponentType<QueryTableProps<Item>>
@@ -58,8 +61,6 @@ type QueryTableProps<Item> = {
   emptyState: React.ReactElement
   columns: ColumnDef<Item, any>[]
 }
-
-export const PAGE_SIZE = 25
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const makeQueryTable = <Item extends Record<string, unknown>>(

--- a/app/table/QueryTable2.tsx
+++ b/app/table/QueryTable2.tsx
@@ -39,7 +39,7 @@ export function useQueryTable<TItem extends { id: string }>({
   const queryResult = useQuery(queryOptions)
   // only ensure prefetched if we're on the first page
   if (currentPage === undefined) ensurePrefetched(queryResult, queryOptions.queryKey)
-  const { data } = queryResult
+  const { data, isPlaceholderData } = queryResult
   const tableData = useMemo(() => data?.items || [], [data])
 
   const firstItemId = tableData?.[0].id
@@ -69,6 +69,9 @@ export function useQueryTable<TItem extends { id: string }>({
         nextPage={data?.nextPage}
         onNext={goToNextPage}
         onPrev={goToPrevPage}
+        // I can't believe how well this works, but it exactly matches when
+        // we want to show the spinner. Cached page changes don't need it.
+        loading={isPlaceholderData}
       />
     </>
   )

--- a/app/table/QueryTable2.tsx
+++ b/app/table/QueryTable2.tsx
@@ -1,0 +1,84 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
+ */
+import { useQuery, type QueryKey, type QueryOptions } from '@tanstack/react-query'
+import { getCoreRowModel, useReactTable, type ColumnDef } from '@tanstack/react-table'
+import React, { useCallback, useMemo } from 'react'
+
+import { ensure, type ApiError } from '@oxide/api'
+
+import { Pagination } from '~/components/Pagination'
+import { usePagination } from '~/hooks/use-pagination'
+import { EmptyMessage } from '~/ui/lib/EmptyMessage'
+import { TableEmptyBox } from '~/ui/lib/Table'
+
+import { Table } from './Table'
+
+export const PAGE_SIZE = 25
+
+type QueryTableProps<TItem> = {
+  optionsFn: (
+    limit: number,
+    page_token?: string
+  ) => QueryOptions<{ items: TItem[]; nextPage?: string }, ApiError> & {
+    queryKey: QueryKey
+  }
+  pageSize?: number
+  rowHeight?: 'small' | 'large'
+  emptyState: React.ReactElement
+  // React Table does the same in the type of `columns` on `useReactTable`
+  // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+  columns: ColumnDef<TItem, any>[]
+}
+
+export function useQueryTable<TItem>({
+  optionsFn,
+  pageSize = PAGE_SIZE,
+  rowHeight = 'small',
+  emptyState,
+  columns,
+}: QueryTableProps<TItem>) {
+  const { currentPage, goToNextPage, goToPrevPage, hasPrev } = usePagination()
+  const queryResult = useQuery(optionsFn(pageSize, currentPage))
+  // only ensure prefetched if we're on the first page
+  if (currentPage === undefined) ensure(queryResult)
+  const { data, isLoading } = queryResult
+  const tableData = useMemo(() => data?.items || [], [data])
+
+  // TODO: need a better function that takes name or ID. sleds in the sleds
+  // table have no name, for example
+  // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+  const getRowId = useCallback((row: any) => row.name, [])
+
+  const table = useReactTable({
+    columns,
+    data: tableData,
+    getRowId,
+    getCoreRowModel: getCoreRowModel(),
+    manualPagination: true,
+  })
+
+  const isEmpty = tableData.length === 0 && !hasPrev
+
+  const tableElement = isLoading ? null : isEmpty ? (
+    <TableEmptyBox>{emptyState || <EmptyMessage title="No results" />}</TableEmptyBox>
+  ) : (
+    <>
+      <Table table={table} rowHeight={rowHeight} />
+      <Pagination
+        pageSize={pageSize}
+        hasNext={tableData.length === pageSize}
+        hasPrev={hasPrev}
+        nextPage={data?.nextPage}
+        onNext={goToNextPage}
+        onPrev={goToPrevPage}
+      />
+    </>
+  )
+
+  return { table: tableElement, query: queryResult }
+}

--- a/app/table/QueryTable2.tsx
+++ b/app/table/QueryTable2.tsx
@@ -7,7 +7,7 @@
  */
 import { useQuery } from '@tanstack/react-query'
 import { getCoreRowModel, useReactTable, type ColumnDef } from '@tanstack/react-table'
-import React, { useMemo } from 'react'
+import React, { useEffect, useMemo } from 'react'
 
 import { ensurePrefetched, type PaginatedQuery, type ResultsPage } from '@oxide/api'
 
@@ -39,8 +39,13 @@ export function useQueryTable<TItem extends { id: string }>({
   const queryResult = useQuery(queryOptions)
   // only ensure prefetched if we're on the first page
   if (currentPage === undefined) ensurePrefetched(queryResult, queryOptions.queryKey)
-  const { data, isLoading } = queryResult
+  const { data } = queryResult
   const tableData = useMemo(() => data?.items || [], [data])
+
+  const firstItemId = tableData?.[0].id
+  useEffect(() => {
+    document.querySelector('#scroll-container')?.scrollTo(0, 0)
+  }, [firstItemId])
 
   const table = useReactTable({
     columns,
@@ -52,7 +57,7 @@ export function useQueryTable<TItem extends { id: string }>({
 
   const isEmpty = tableData.length === 0 && !hasPrev
 
-  const tableElement = isLoading ? null : isEmpty ? (
+  const tableElement = isEmpty ? (
     <TableEmptyBox>{emptyState || <EmptyMessage title="No results" />}</TableEmptyBox>
   ) : (
     <>

--- a/app/table/QueryTable2.tsx
+++ b/app/table/QueryTable2.tsx
@@ -7,7 +7,7 @@
  */
 import { useQuery, type QueryKey, type QueryOptions } from '@tanstack/react-query'
 import { getCoreRowModel, useReactTable, type ColumnDef } from '@tanstack/react-table'
-import React, { useCallback, useMemo } from 'react'
+import React, { useMemo } from 'react'
 
 import { ensure, type ApiError } from '@oxide/api'
 
@@ -35,7 +35,8 @@ type QueryTableProps<TItem> = {
   columns: ColumnDef<TItem, any>[]
 }
 
-export function useQueryTable<TItem>({
+// require ID only so we can use it in getRowId
+export function useQueryTable<TItem extends { id: string }>({
   optionsFn,
   pageSize = PAGE_SIZE,
   rowHeight = 'small',
@@ -49,15 +50,10 @@ export function useQueryTable<TItem>({
   const { data, isLoading } = queryResult
   const tableData = useMemo(() => data?.items || [], [data])
 
-  // TODO: need a better function that takes name or ID. sleds in the sleds
-  // table have no name, for example
-  // eslint-disable-next-line  @typescript-eslint/no-explicit-any
-  const getRowId = useCallback((row: any) => row.name, [])
-
   const table = useReactTable({
     columns,
     data: tableData,
-    getRowId,
+    getRowId: (row) => row.id,
     getCoreRowModel: getCoreRowModel(),
     manualPagination: true,
   })

--- a/app/table/QueryTable2.tsx
+++ b/app/table/QueryTable2.tsx
@@ -27,6 +27,8 @@ type QueryTableProps<TItem> = {
   columns: ColumnDef<TItem, any>[]
 }
 
+const resetScroll = () => document.querySelector('#scroll-container')?.scrollTo(0, 0)
+
 // require ID only so we can use it in getRowId
 export function useQueryTable<TItem extends { id: string }>({
   query,
@@ -43,9 +45,7 @@ export function useQueryTable<TItem extends { id: string }>({
   const tableData = useMemo(() => data?.items || [], [data])
 
   const firstItemId = tableData?.[0].id
-  useEffect(() => {
-    document.querySelector('#scroll-container')?.scrollTo(0, 0)
-  }, [firstItemId])
+  useEffect(resetScroll, [firstItemId])
 
   const table = useReactTable({
     columns,

--- a/app/ui/lib/Pagination.tsx
+++ b/app/ui/lib/Pagination.tsx
@@ -50,7 +50,8 @@ export const Pagination = ({
 }: PaginationProps) => {
   return (
     <>
-      <div
+      <nav
+        aria-label="Pagination"
         className={cn(
           'flex items-center justify-between text-mono-sm text-default bg-default',
           className
@@ -91,7 +92,7 @@ export const Pagination = ({
             />
           </button>
         </span>
-      </div>
+      </nav>
     </>
   )
 }

--- a/app/ui/lib/Pagination.tsx
+++ b/app/ui/lib/Pagination.tsx
@@ -9,6 +9,8 @@ import cn from 'classnames'
 
 import { DirectionLeftIcon, DirectionRightIcon } from '@oxide/design-system/icons/react'
 
+import { Spinner } from './Spinner'
+
 interface PageInputProps {
   number: number
   className?: string
@@ -34,6 +36,7 @@ export interface PaginationProps {
   onNext: (nextPage: string) => void
   onPrev: () => void
   className?: string
+  loading?: boolean
 }
 export const Pagination = ({
   pageSize,
@@ -43,6 +46,7 @@ export const Pagination = ({
   onNext,
   onPrev,
   className,
+  loading,
 }: PaginationProps) => {
   return (
     <>
@@ -55,7 +59,8 @@ export const Pagination = ({
         <span className="flex-inline grow text-tertiary">
           rows per page <PageInput number={pageSize} />
         </span>
-        <span className="flex space-x-3">
+        <span className="flex items-center space-x-3">
+          {loading && <Spinner />}
           <button
             type="button"
             className={cn(

--- a/mock-api/snapshot.ts
+++ b/mock-api/snapshot.ts
@@ -14,7 +14,7 @@ import { disks } from './disk'
 import type { Json } from './json-type'
 import { project } from './project'
 
-const generatedSnapshots: Json<Snapshot>[] = Array.from({ length: 25 }, (_, i) =>
+const generatedSnapshots: Json<Snapshot>[] = Array.from({ length: 80 }, (_, i) =>
   generateSnapshot(i)
 )
 
@@ -91,7 +91,7 @@ export const snapshots: Json<Snapshot>[] = [
 function generateSnapshot(index: number): Json<Snapshot> {
   return {
     id: uuid(),
-    name: `disk-1-snapshot-${index + 6}`,
+    name: `disk-1-snapshot-${index + 7}`,
     description: '',
     project_id: project.id,
     time_created: new Date().toISOString(),

--- a/test/e2e/pagination.e2e.ts
+++ b/test/e2e/pagination.e2e.ts
@@ -5,34 +5,65 @@
  *
  * Copyright Oxide Computer Company
  */
-import { expect, test } from '@playwright/test'
+import { expect, test, type Page } from '@playwright/test'
 
-import { expectRowVisible } from './utils'
+import { expectScrollTop, scrollTo } from './utils'
+
+// expectRowVisible is too have for all this
+const expectCell = (page: Page, name: string) =>
+  expect(page.getByRole('cell', { name, exact: true })).toBeVisible()
 
 test('pagination', async ({ page }) => {
   await page.goto('/projects/mock-project/snapshots')
 
   const table = page.getByRole('table')
-  const rows = page.getByRole('row')
+  const rows = table.getByRole('rowgroup').last().getByRole('row')
   const nextButton = page.getByRole('button', { name: 'next' })
   const prevButton = page.getByRole('button', { name: 'prev', exact: true })
+  const spinner = page.getByLabel('Pagination').getByLabel('Spinner')
 
-  await expect(rows).toHaveCount(26)
-  await expectRowVisible(table, { name: 'snapshot-1' })
-  await expectRowVisible(table, { name: 'disk-1-snapshot-24' })
+  await expect(spinner).toBeHidden()
+  await expect(prevButton).toBeDisabled() // we're on the first page
+
+  await expectCell(page, 'snapshot-1')
+  await expectCell(page, 'disk-1-snapshot-25')
+  await expect(rows).toHaveCount(25)
+
+  await scrollTo(page, 100)
 
   await nextButton.click()
-  await expect(rows).toHaveCount(7)
-  await expectRowVisible(table, { name: 'disk-1-snapshot-25' })
-  await expectRowVisible(table, { name: 'disk-1-snapshot-30' })
+
+  // spinner goes while the data is fetching...
+  await expect(spinner).toBeVisible()
+  await expectScrollTop(page, 100) // scroll resets to top on page change
+  // ...and goes away roughly when scroll resets
+  await expect(spinner).toBeHidden()
+  await expectScrollTop(page, 0) // scroll resets to top on page change
+
+  await expectCell(page, 'disk-1-snapshot-26')
+  await expectCell(page, 'disk-1-snapshot-50')
+  await expect(rows).toHaveCount(25)
+
+  await nextButton.click()
+  await expectCell(page, 'disk-1-snapshot-51')
+  await expectCell(page, 'disk-1-snapshot-75')
+  await expect(rows).toHaveCount(25)
+
+  await nextButton.click()
+  await expectCell(page, 'disk-1-snapshot-76')
+  await expectCell(page, 'disk-1-snapshot-86')
+  await expect(rows).toHaveCount(11)
+  await expect(nextButton).toBeDisabled() // no more pages
+
+  await scrollTo(page, 250)
 
   await prevButton.click()
-  await expect(rows).toHaveCount(26)
-  await expectRowVisible(table, { name: 'snapshot-1' })
-  await expectRowVisible(table, { name: 'disk-1-snapshot-24' })
+  await expect(spinner).toBeHidden({ timeout: 10 }) // no spinner, cached page
+  await expect(rows).toHaveCount(25)
+  await expectCell(page, 'disk-1-snapshot-51')
+  await expectCell(page, 'disk-1-snapshot-75')
+  await expectScrollTop(page, 0) // scroll resets to top on prev too
 
   await nextButton.click()
-  await expect(nextButton).toBeDisabled() // no more pages
+  await expect(spinner).toBeHidden({ timeout: 10 }) // no spinner, cached page
 })
-
-// TODO: test scroll to top on page change

--- a/test/e2e/pagination.e2e.ts
+++ b/test/e2e/pagination.e2e.ts
@@ -34,3 +34,5 @@ test('pagination', async ({ page }) => {
   await nextButton.click()
   await expect(nextButton).toBeDisabled() // no more pages
 })
+
+// TODO: test scroll to top on page change

--- a/test/e2e/scroll-restore.e2e.ts
+++ b/test/e2e/scroll-restore.e2e.ts
@@ -5,18 +5,9 @@
  *
  * Copyright Oxide Computer Company
  */
-import { expect, test, type Page } from './utils'
+import { expect, test } from '@playwright/test'
 
-async function expectScrollTop(page: Page, expected: number) {
-  const container = page.getByTestId('scroll-container')
-  const getScrollTop = () => container.evaluate((el: HTMLElement) => el.scrollTop)
-  await expect.poll(getScrollTop).toBe(expected)
-}
-
-async function scrollTo(page: Page, to: number) {
-  const container = page.getByTestId('scroll-container')
-  await container.evaluate((el: HTMLElement, to) => el.scrollTo(0, to), to)
-}
+import { expectScrollTop, scrollTo } from './utils'
 
 test('scroll restore', async ({ page }) => {
   // open small window to make scrolling easier

--- a/test/e2e/snapshots.e2e.ts
+++ b/test/e2e/snapshots.e2e.ts
@@ -28,7 +28,7 @@ test('Click through snapshots', async ({ page }) => {
 test('Confirm delete snapshot', async ({ page }) => {
   await page.goto('/projects/mock-project/snapshots')
 
-  const row = page.getByRole('row', { name: 'disk-1-snapshot-6' })
+  const row = page.getByRole('row', { name: 'disk-1-snapshot-7' })
 
   // scroll a little so the dropdown menu isn't behind the pagination bar
   await page.getByRole('table').click() // focus the content pane

--- a/test/e2e/utils.ts
+++ b/test/e2e/utils.ts
@@ -232,3 +232,14 @@ export async function chooseFile(
     buffer: size === 'large' ? bigFile : smallFile,
   })
 }
+
+export async function expectScrollTop(page: Page, expected: number) {
+  const container = page.getByTestId('scroll-container')
+  const getScrollTop = () => container.evaluate((el: HTMLElement) => el.scrollTop)
+  await expect.poll(getScrollTop).toBe(expected)
+}
+
+export async function scrollTo(page: Page, to: number) {
+  const container = page.getByTestId('scroll-container')
+  await container.evaluate((el: HTMLElement, to) => el.scrollTo(0, to), to)
+}


### PR DESCRIPTION
This is built on top of the `queryOptions` work in #2566. The types in `QueryTable` have always bothered me, as does returning a component instead of an element, but I could never figure out how to fix it.

https://github.com/oxidecomputer/console/blob/0f922b2ed3af596beae37adaae4ecff545002ed0/app/table/QueryTable.tsx#L65-L77

This change:

* Fixes the types so we don't use `any`
* Uses a much more intuitive mechanism to enforce that we can only use QueryTable with list endpoints (simply require `TData extends { items: TItem[] }`)
* Returns the React Query query result containing the data, so in cases where we are currently making a second `useApiQuery` call where we painstaking ensure the params match (see below), we don't have to do that anymore
* Keeps previous page around while loading next page, preventing blank screen flash, and adds a small loading spinner (see #1861)

https://github.com/oxidecomputer/console/blob/0f922b2ed3af596beae37adaae4ecff545002ed0/app/pages/ProjectsPage.tsx#L64-L67

The new file is 80 lines instead of 120 and strictly better across the board. There are only 20 `useQueryTable` calls in the app. It would be pretty quick to convert them all. We could do that here or merge this and convert in batches.