### PR TITLE
Content token shuffle

### DIFF
--- a/app/components/AccordionItem.tsx
+++ b/app/components/AccordionItem.tsx
@@ -30,8 +30,8 @@ export const AccordionItem = ({ children, isOpen, label, value }: AccordionItemP
     <Accordion.Item value={value}>
       <Accordion.Header className="max-w-lg">
         <Accordion.Trigger className="group flex w-full items-center justify-between border-t py-2 text-sans-xl border-secondary [&>svg]:data-[state=open]:rotate-90">
-          <div className="text-secondary">{label}</div>
-          <DirectionRightIcon className="transition-all text-secondary" />
+          <div className="text-raise">{label}</div>
+          <DirectionRightIcon className="transition-all text-default" />
         </Accordion.Trigger>
       </Accordion.Header>
       <Accordion.Content

--- a/app/components/AttachFloatingIpModal.tsx
+++ b/app/components/AttachFloatingIpModal.tsx
@@ -18,7 +18,7 @@ import { Slash } from '~/ui/lib/Slash'
 
 function FloatingIpLabel({ fip }: { fip: FloatingIp }) {
   return (
-    <div className="text-tertiary selected:text-accent-secondary">
+    <div className="text-secondary selected:text-accent-secondary">
       <div>{fip.name}</div>
       <div className="flex gap-0.5">
         <div>{fip.ip}</div>

--- a/app/components/CapacityBar.tsx
+++ b/app/components/CapacityBar.tsx
@@ -54,8 +54,8 @@ function TitleCell({ icon, title, unit }: TitleCellProps) {
     <div>
       <div className="flex grow items-center">
         <span className="mr-2 flex h-4 w-4 items-center text-accent">{icon}</span>
-        <span className="!normal-case text-mono-sm text-secondary">{title}</span>
-        <span className="ml-1 !normal-case text-mono-sm text-quaternary">({unit})</span>
+        <span className="!normal-case text-mono-sm text-default">{title}</span>
+        <span className="ml-1 !normal-case text-mono-sm text-tertiary">({unit})</span>
       </div>
     </div>
   )
@@ -65,8 +65,8 @@ function PctCell({ pct }: { pct: number }) {
   // NaN happens when both top and bottom are 0
   if (Number.isNaN(pct)) {
     return (
-      <div className="flex -translate-y-0.5 items-baseline text-quaternary">
-        <div className="font-light text-sans-2xl">—</div>
+      <div className="flex -translate-y-0.5 items-baseline text-tertiary">
+        <div className="font-light text-sans-2xl text-raise">—</div>
         <div className="text-sans-xl">%</div>
       </div>
     )
@@ -75,8 +75,8 @@ function PctCell({ pct }: { pct: number }) {
   const [wholeNumber, decimal] = splitDecimal(pct)
   return (
     <div className="flex -translate-y-0.5 items-baseline">
-      <div className="font-light text-sans-2xl">{wholeNumber}</div>
-      <div className="text-sans-xl text-quaternary">{decimal}%</div>
+      <div className="font-light text-sans-2xl text-raise">{wholeNumber}</div>
+      <div className="text-sans-xl text-tertiary">{decimal}%</div>
     </div>
   )
 }
@@ -102,8 +102,8 @@ type ValueCellProps = {
 function ValueCell({ label, value, unit }: ValueCellProps) {
   return (
     <div className="p-3 text-mono-sm">
-      <div className="mb-px text-quaternary">{label}</div>
-      <div className="!normal-case text-secondary">
+      <div className="mb-px text-tertiary">{label}</div>
+      <div className="!normal-case text-default">
         <BigNum num={value} />
         {unit}
       </div>

--- a/app/components/DocsPopover.tsx
+++ b/app/components/DocsPopover.tsx
@@ -26,7 +26,7 @@ export const DocsPopoverLink = ({ href, linkText }: DocsPopoverLinkProps) => (
     rel="noreferrer"
   >
     <div className="mx-2 border-b py-1.5 border-secondary">
-      <div className="relative -ml-2 inline-block rounded py-1 pl-2 pr-7 text-sans-md !text-raise group-hover:bg-tertiary">
+      <div className="relative -ml-2 inline-block rounded py-1 pl-2 pr-7 text-sans-md text-raise group-hover:bg-tertiary">
         <span className="inline-block max-w-[300px] truncate align-middle">{linkText}</span>
         <OpenLink12Icon className="absolute top-1.5 ml-2 translate-y-[1px] text-secondary" />
       </div>
@@ -45,7 +45,7 @@ export const DocsPopover = ({ heading, icon, summary, links }: DocsPopoverProps)
   return (
     <Popover>
       <PopoverButton className={cn(buttonStyle({ size: 'sm', variant: 'ghost' }), 'w-8')}>
-        <Info16Icon aria-label="Links to docs" className="shrink-0 text-tertiary" />
+        <Info16Icon aria-label="Links to docs" className="shrink-0" />
       </PopoverButton>
       <PopoverPanel
         // DocsPopoverPanel needed for enter animation

--- a/app/components/DocsPopover.tsx
+++ b/app/components/DocsPopover.tsx
@@ -26,9 +26,9 @@ export const DocsPopoverLink = ({ href, linkText }: DocsPopoverLinkProps) => (
     rel="noreferrer"
   >
     <div className="mx-2 border-b py-1.5 border-secondary">
-      <div className="relative -ml-2 inline-block rounded py-1 pl-2 pr-7 text-sans-md !text-default group-hover:bg-tertiary">
+      <div className="relative -ml-2 inline-block rounded py-1 pl-2 pr-7 text-sans-md !text-raise group-hover:bg-tertiary">
         <span className="inline-block max-w-[300px] truncate align-middle">{linkText}</span>
-        <OpenLink12Icon className="absolute top-1.5 ml-2 translate-y-[1px] text-tertiary" />
+        <OpenLink12Icon className="absolute top-1.5 ml-2 translate-y-[1px] text-secondary" />
       </div>
     </div>
   </a>
@@ -45,11 +45,11 @@ export const DocsPopover = ({ heading, icon, summary, links }: DocsPopoverProps)
   return (
     <Popover>
       <PopoverButton className={cn(buttonStyle({ size: 'sm', variant: 'ghost' }), 'w-8')}>
-        <Info16Icon aria-label="Links to docs" className="shrink-0" />
+        <Info16Icon aria-label="Links to docs" className="shrink-0 text-tertiary" />
       </PopoverButton>
       <PopoverPanel
         // DocsPopoverPanel needed for enter animation
-        className="DocsPopoverPanel z-10 w-96 rounded-lg border bg-raise border-secondary elevation-1"
+        className="DocsPopoverPanel z-10 w-96 rounded-lg border bg-raise border-secondary elevation-2"
         anchor={{ to: 'bottom end', gap: 12 }}
       >
         <div className="px-4">
@@ -57,10 +57,10 @@ export const DocsPopover = ({ heading, icon, summary, links }: DocsPopoverProps)
             <div className="mr-1 flex items-center text-accent-secondary">{icon}</div>
             Learn about {heading}
           </h2>
-          <p className="mb-3 mt-2 text-sans-md text-secondary">{summary}</p>
+          <p className="mb-3 mt-2 text-sans-md text-default">{summary}</p>
         </div>
         <div className="border-t pb-1 border-secondary">
-          <h3 className="mb-1 mt-3 px-4 text-mono-sm text-quaternary">Guides</h3>
+          <h3 className="mb-1 mt-3 px-4 text-mono-sm text-tertiary">Guides</h3>
           {links.map((link) => (
             <DocsPopoverLink key={link.href} {...link} />
           ))}

--- a/app/components/EquivalentCliCommand.tsx
+++ b/app/components/EquivalentCliCommand.tsx
@@ -37,7 +37,7 @@ export function EquivalentCliCommand({ command }: { command: string }) {
       <Modal isOpen={isOpen} onDismiss={handleDismiss} title="CLI command">
         <Modal.Section>
           <pre className="flex w-full rounded border px-4 py-3 !normal-case !tracking-normal text-mono-md bg-default border-secondary">
-            <div className="mr-2 select-none text-quaternary">$</div>
+            <div className="mr-2 select-none text-tertiary">$</div>
             {command}
           </pre>
         </Modal.Section>

--- a/app/components/ErrorBoundary.tsx
+++ b/app/components/ErrorBoundary.tsx
@@ -24,7 +24,7 @@ function ErrorFallback({ error }: Props) {
   return (
     <ErrorPage>
       <h1 className="text-sans-2xl">Something went wrong</h1>
-      <p className="text-tertiary">
+      <p className="text-secondary">
         Please try again. If the problem persists, contact your administrator.
       </p>
     </ErrorPage>

--- a/app/components/ErrorPage.tsx
+++ b/app/components/ErrorPage.tsx
@@ -34,9 +34,9 @@ export function ErrorPage({ children }: Props) {
       <div className="relative flex w-full justify-between">
         <Link
           to="/"
-          className="flex items-center p-6 text-mono-sm text-secondary hover:text-default"
+          className="flex items-center p-6 text-mono-sm text-default hover:text-raise"
         >
-          <PrevArrow12Icon title="Select" className="mr-2 text-tertiary" />
+          <PrevArrow12Icon title="Select" className="mr-2 text-secondary" />
           Back to console
         </Link>
         <SignOutButton className="mr-6 mt-4" />
@@ -57,7 +57,7 @@ export function NotFound() {
   return (
     <ErrorPage>
       <h1 className="text-sans-2xl">Page not found</h1>
-      <p className="text-tertiary">
+      <p className="text-secondary">
         The page you are looking for doesn&apos;t exist or you may not have access to it.
       </p>
     </ErrorPage>

--- a/app/components/ExternalIps.tsx
+++ b/app/components/ExternalIps.tsx
@@ -27,7 +27,7 @@ export function ExternalIps({ project, instance }: InstanceSelector) {
     <div className="flex items-center gap-1">
       {intersperse(
         ips.map((eip) => <CopyableIp ip={eip.ip} key={eip.ip} />),
-        <span className="text-quinary"> / </span>
+        <span className="text-quaternary"> / </span>
       )}
     </div>
   )

--- a/app/components/HL.tsx
+++ b/app/components/HL.tsx
@@ -10,7 +10,7 @@ import { classed } from '~/util/classed'
 // note parent with secondary text color must have 'group' on it for
 // this to work. see Toast for an example
 export const HL = classed.span`
-  text-sans-md text-default 
+  text-sans-md text-raise
   group-[.text-accent-secondary]:text-accent
   group-[.text-error-secondary]:text-error
   group-[.text-info-secondary]:text-info

--- a/app/components/IpPoolUtilization.tsx
+++ b/app/components/IpPoolUtilization.tsx
@@ -12,8 +12,8 @@ import { BigNum } from '~/ui/lib/BigNum'
 
 const IpUtilFrac = (props: { allocated: number | bigint; capacity: number | bigint }) => (
   <>
-    <BigNum className="text-default" num={props.allocated} /> /{' '}
-    <BigNum className="text-tertiary" num={props.capacity} />
+    <BigNum className="text-raise" num={props.allocated} /> /{' '}
+    <BigNum className="text-secondary" num={props.capacity} />
   </>
 )
 

--- a/app/components/ListPlusCell.tsx
+++ b/app/components/ListPlusCell.tsx
@@ -37,7 +37,7 @@ export const ListPlusCell = ({
   const rest = array.slice(numInCell)
   const content = (
     <div>
-      <div className="mb-2 text-sans-semi-md text-default">{tooltipTitle}</div>
+      <div className="mb-2 text-sans-semi-md text-raise">{tooltipTitle}</div>
       <div className="flex flex-col items-start gap-2">{...rest}</div>
     </div>
   )

--- a/app/components/MoreActionsMenu.tsx
+++ b/app/components/MoreActionsMenu.tsx
@@ -24,7 +24,7 @@ export const MoreActionsMenu = ({ actions, label }: MoreActionsMenuProps) => {
         aria-label={label}
         className="flex h-8 w-8 items-center justify-center rounded border border-default hover:bg-tertiary"
       >
-        <More12Icon className="text-secondary" />
+        <More12Icon />
       </DropdownMenu.Trigger>
       <DropdownMenu.Content className="mt-2">
         {actions.map((a) => (

--- a/app/components/MoreActionsMenu.tsx
+++ b/app/components/MoreActionsMenu.tsx
@@ -24,7 +24,7 @@ export const MoreActionsMenu = ({ actions, label }: MoreActionsMenuProps) => {
         aria-label={label}
         className="flex h-8 w-8 items-center justify-center rounded border border-default hover:bg-tertiary"
       >
-        <More12Icon className="text-tertiary" />
+        <More12Icon className="text-secondary" />
       </DropdownMenu.Trigger>
       <DropdownMenu.Content className="mt-2">
         {actions.map((a) => (

--- a/app/components/RefetchIntervalPicker.tsx
+++ b/app/components/RefetchIntervalPicker.tsx
@@ -54,8 +54,8 @@ export function useIntervalPicker({ enabled, isLoading, fn }: Props) {
     intervalMs: (enabled && intervalPresets[intervalPreset]) || undefined,
     intervalPicker: (
       <div className="mb-12 flex items-center justify-between">
-        <div className="hidden items-center gap-2 text-right text-mono-sm text-quaternary lg+:flex">
-          <Time16Icon className="text-quinary" /> Refreshed{' '}
+        <div className="hidden items-center gap-2 text-right text-mono-sm text-tertiary lg+:flex">
+          <Time16Icon className="text-quaternary" /> Refreshed{' '}
           {toLocaleTimeString(lastFetched)}
         </div>
         <div className="flex">
@@ -70,7 +70,7 @@ export function useIntervalPicker({ enabled, isLoading, fn }: Props) {
             disabled={isLoading || !enabled}
           >
             <SpinnerLoader isLoading={isLoading}>
-              <Refresh16Icon className="text-tertiary" />
+              <Refresh16Icon className="text-secondary" />
             </SpinnerLoader>
           </button>
           <Listbox

--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -15,7 +15,7 @@ import { Button } from '~/ui/lib/Button'
 import { Truncate } from '~/ui/lib/Truncate'
 
 const linkStyles =
-  'flex h-7 items-center rounded px-2 text-sans-md hover:bg-hover [&>svg]:mr-2 [&>svg]:text-quinary text-secondary'
+  'flex h-7 items-center rounded px-2 text-sans-md hover:bg-hover [&>svg]:mr-2 [&>svg]:text-quaternary text-default'
 
 // TODO: this probably doesn't go to the docs root. maybe it even opens a
 // menu with links to several relevant docs for the page
@@ -44,10 +44,10 @@ const JumpToButton = () => {
       onClick={openQuickActions}
       className="w-full !px-2"
       // TODO: the more I use innerClassName the wronger it feels
-      innerClassName="w-full justify-between text-quaternary"
+      innerClassName="w-full justify-between text-tertiary"
     >
       <span className="flex items-center">
-        <Action16Icon className="mr-2 text-quinary" /> Jump to
+        <Action16Icon className="mr-2 text-quaternary" /> Jump to
       </span>
       <div className="text-mono-xs">{modKey}+K</div>
     </Button>
@@ -56,7 +56,7 @@ const JumpToButton = () => {
 
 export function Sidebar({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex flex-col border-r text-sans-md text-default border-secondary">
+    <div className="flex flex-col border-r text-sans-md text-raise border-secondary">
       <div className="mx-3 mt-4">
         <JumpToButton />
       </div>
@@ -73,7 +73,7 @@ interface SidebarNav {
 Sidebar.Nav = ({ children, heading }: SidebarNav) => (
   <div className="mx-3 my-4 space-y-1">
     {heading && (
-      <div className="mb-2 text-mono-sm text-quaternary">
+      <div className="mb-2 text-mono-sm text-tertiary">
         <Truncate text={heading} maxLength={24} />
       </div>
     )}

--- a/app/components/SystemMetric.tsx
+++ b/app/components/SystemMetric.tsx
@@ -94,8 +94,8 @@ export function SiloMetric({
 
   return (
     <div>
-      <h2 className="flex items-center gap-1.5 px-3 text-mono-sm text-secondary">
-        {title} {unit && <span className="text-quaternary">({unit})</span>}{' '}
+      <h2 className="flex items-center gap-1.5 px-3 text-mono-sm text-default">
+        {title} {unit && <span className="text-tertiary">({unit})</span>}{' '}
         {(inRange.isPending || beforeStart.isPending) && <Spinner />}
       </h2>
       {/* TODO: proper skeleton for empty chart */}
@@ -172,8 +172,8 @@ export function SystemMetric({
 
   return (
     <div>
-      <h2 className="flex items-center gap-1.5 px-3 text-mono-sm text-secondary">
-        {title} {unit && <span className="text-quaternary">({unit})</span>}{' '}
+      <h2 className="flex items-center gap-1.5 px-3 text-mono-sm text-default">
+        {title} {unit && <span className="text-tertiary">({unit})</span>}{' '}
         {(inRange.isPending || beforeStart.isPending) && <Spinner />}
       </h2>
       {/* TODO: proper skeleton for empty chart */}

--- a/app/components/Terminal.tsx
+++ b/app/components/Terminal.tsx
@@ -105,7 +105,7 @@ export default function Terminal({ ws }: TerminalProps) {
   return (
     <>
       <div className="h-full w-[calc(100%-3rem)] text-mono-code" ref={terminalRef} />
-      <div className="absolute right-0 top-0 space-y-2 text-secondary">
+      <div className="absolute right-0 top-0 space-y-2 text-default">
         <ScrollButton onClick={() => term?.scrollToTop()} aria-label="Scroll to top">
           <DirectionUpIcon aria-hidden />
         </ScrollButton>

--- a/app/components/TimeAgo.tsx
+++ b/app/components/TimeAgo.tsx
@@ -21,13 +21,13 @@ export const TimeAgo = ({
 }): JSX.Element => {
   const content = (
     <div className="flex flex-col">
-      <span className="text-tertiary">{tooltipText}</span>
+      <span className="text-secondary">{tooltipText}</span>
       <span>{toLocaleDateTimeString(datetime)}</span>
     </div>
   )
   return (
     <Tooltip content={content} placement={placement}>
-      <span className="text-sans-sm text-tertiary">{timeAgoAbbr(datetime)}</span>
+      <span className="text-sans-sm text-secondary">{timeAgoAbbr(datetime)}</span>
     </Tooltip>
   )
 }

--- a/app/components/TimeSeriesChart.tsx
+++ b/app/components/TimeSeriesChart.tsx
@@ -84,15 +84,15 @@ function renderTooltip(props: TooltipProps<number, string>, unit?: string) {
   } = payload[0]
   if (!timestamp || typeof value !== 'number') return null
   return (
-    <div className="rounded border outline-0 text-sans-md text-tertiary bg-raise border-secondary elevation-2">
+    <div className="rounded border outline-0 text-sans-md text-secondary bg-raise border-secondary elevation-2">
       <div className="border-b px-3 py-2 pr-6 border-secondary">
         {longDateTime(timestamp)}
       </div>
       <div className="px-3 py-2">
-        <div className="text-tertiary">{name}</div>
-        <div className="text-default">
+        <div className="text-secondary">{name}</div>
+        <div className="text-raise">
           {value.toLocaleString()}
-          {unit && <span className="ml-1 text-tertiary">{unit}</span>}
+          {unit && <span className="ml-1 text-secondary">{unit}</span>}
         </div>
         {/* TODO: unit on value if relevant */}
       </div>

--- a/app/components/TopBar.tsx
+++ b/app/components/TopBar.tsx
@@ -60,7 +60,7 @@ const BigIdenticon = ({ name }: { name: string }) => (
 )
 
 const SystemIcon = () => (
-  <div className={cn(bigIconBox, 'text-quinary bg-tertiary')}>
+  <div className={cn(bigIconBox, 'text-quaternary bg-tertiary')}>
     <Servers16Icon />
   </div>
 )
@@ -88,8 +88,8 @@ function HomeButton({ level }: { level: 'system' | 'silo' }) {
       <div className="flex w-full items-center">
         <div className="mr-2">{config.icon}</div>
         <div className="min-w-0 flex-1">
-          <div className="text-mono-xs text-quaternary">{config.heading}</div>
-          <div className="overflow-hidden text-ellipsis whitespace-nowrap text-sans-md text-secondary">
+          <div className="text-mono-xs text-tertiary">{config.heading}</div>
+          <div className="overflow-hidden text-ellipsis whitespace-nowrap text-sans-md text-raise">
             {config.label}
           </div>
         </div>
@@ -110,8 +110,8 @@ function Breadcrumbs() {
           <Link
             to={path}
             className={cn(
-              'whitespace-nowrap text-sans-md hover:text-secondary',
-              i === crumbs.length - 1 ? 'text-secondary' : 'text-tertiary'
+              'whitespace-nowrap text-sans-md',
+              i === crumbs.length - 1 ? 'text-raise' : 'text-secondary hover:text-default'
             )}
             key={`${label}|${path}`}
           >
@@ -139,8 +139,8 @@ function UserMenu() {
         )}
         aria-label="User menu"
       >
-        <Profile16Icon className="text-quaternary" />
-        <span className="normal-case text-sans-md text-secondary">
+        <Profile16Icon className="text-tertiary" />
+        <span className="normal-case text-sans-md text-default">
           {me.displayName || 'User'}
         </span>
       </DropdownMenu.Trigger>
@@ -161,15 +161,15 @@ function SiloSystemPicker({ level }: { level: 'silo' | 'system' }) {
   return (
     <DropdownMenu.Root>
       <DropdownMenu.Trigger
-        className="flex items-center rounded border px-2 py-1.5 text-sans-md text-secondary border-secondary hover:bg-hover"
+        className="flex items-center rounded border px-2 py-1.5 text-sans-md text-default border-secondary hover:bg-hover"
         aria-label="Switch between system and silo"
       >
-        <div className="flex items-center text-quaternary">
+        <div className="flex items-center text-tertiary">
           {level === 'system' ? <Servers16Icon /> : <Organization16Icon />}
         </div>
         <div className="ml-1.5 mr-3">{level === 'system' ? 'System' : 'Silo'}</div>
         {/* aria-hidden is a tip from the Reach docs */}
-        <SelectArrows6Icon className="text-quinary" aria-hidden />
+        <SelectArrows6Icon className="text-quaternary" aria-hidden />
       </DropdownMenu.Trigger>
       <DropdownMenu.Content className="mt-2 max-h-80 overflow-y-auto" anchor="bottom start">
         <SystemSiloItem to={pb.silos()} label="System" isSelected={level === 'system'} />

--- a/app/components/form/Form.tsx
+++ b/app/components/form/Form.tsx
@@ -83,5 +83,5 @@ export const Form = {
     </Button>
   ),
 
-  Heading: classed.h2`text-content text-sans-2xl`,
+  Heading: classed.h2`text-sans-2xl`,
 }

--- a/app/components/form/fields/ImageSelectField.tsx
+++ b/app/components/form/fields/ImageSelectField.tsx
@@ -82,7 +82,7 @@ export function toImageComboboxItem(
     label: (
       <div className="flex flex-col gap-1">
         <div>{name}</div>
-        <div className="text-tertiary selected:text-accent-secondary">{itemMetadata}</div>
+        <div className="text-secondary selected:text-accent-secondary">{itemMetadata}</div>
       </div>
     ),
   }

--- a/app/components/form/fields/NumberField.tsx
+++ b/app/components/form/fields/NumberField.tsx
@@ -35,7 +35,7 @@ export function NumberField<
     <div className="max-w-lg">
       <div className="mb-2">
         <FieldLabel htmlFor={id} id={`${id}-label`} optional={!required}>
-          {label} {units && <span className="ml-1 text-secondary">({units})</span>}
+          {label} {units && <span className="ml-1 text-default">({units})</span>}
         </FieldLabel>
         {description && (
           <TextInputHint id={`${id}-help-text`} className="mb-2">

--- a/app/components/form/fields/RadioField.tsx
+++ b/app/components/form/fields/RadioField.tsx
@@ -70,7 +70,7 @@ export function RadioField<
       <div className="mb-2">
         {label && (
           <FieldLabel id={`${id}-label`}>
-            {label} {units && <span className="ml-1 text-secondary">({units})</span>}
+            {label} {units && <span className="ml-1 text-default">({units})</span>}
           </FieldLabel>
         )}
         {/* TODO: Figure out where this hint field def should live */}
@@ -129,7 +129,7 @@ export function RadioFieldDyn<
       <div className="mb-2">
         {label && (
           <FieldLabel id={`${id}-label`}>
-            {label} {units && <span className="ml-1 text-secondary">({units})</span>}
+            {label} {units && <span className="ml-1 text-default">({units})</span>}
           </FieldLabel>
         )}
         {/* TODO: Figure out where this hint field def should live */}

--- a/app/components/form/fields/TextField.tsx
+++ b/app/components/form/fields/TextField.tsx
@@ -67,7 +67,7 @@ export function TextField<
     <div className="max-w-lg">
       <div className="mb-2">
         <FieldLabel htmlFor={id} id={`${id}-label`} optional={!required}>
-          {label} {units && <span className="ml-1 text-secondary">({units})</span>}
+          {label} {units && <span className="ml-1 text-default">({units})</span>}
         </FieldLabel>
         {description && (
           <TextInputHint id={`${id}-help-text`} className="mb-2">

--- a/app/components/form/fields/ip-pool-item.tsx
+++ b/app/components/form/fields/ip-pool-item.tsx
@@ -22,7 +22,7 @@ export function toIpPoolItem(p: SiloIpPool) {
         )}
       </div>
       {!!p.description && (
-        <div className="text-tertiary selected:text-accent-secondary">{p.description}</div>
+        <div className="text-secondary selected:text-accent-secondary">{p.description}</div>
       )}
     </div>
   )

--- a/app/forms/disk-create.tsx
+++ b/app/forms/disk-create.tsx
@@ -273,7 +273,7 @@ const SnapshotSelectField = ({ control }: { control: Control<DiskCreate> }) => {
           label: (
             <>
               <div>{i.name}</div>
-              <div className="text-tertiary selected:text-accent-secondary">
+              <div className="text-secondary selected:text-accent-secondary">
                 Created on {toLocaleDateString(i.timeCreated)}
                 <DiskNameFromId disk={i.diskId} /> <Slash /> {formattedSize.value}{' '}
                 {formattedSize.unit}

--- a/app/forms/image-edit.tsx
+++ b/app/forms/image-edit.tsx
@@ -101,7 +101,7 @@ function EditImageSideModalForm({
         </PropertiesTable.Row>
         <PropertiesTable.Row label="Size">
           <span>{bytesToGiB(image.size)}</span>
-          <span className="ml-1 inline-block text-quaternary">GiB</span>
+          <span className="ml-1 inline-block text-tertiary">GiB</span>
         </PropertiesTable.Row>
         <PropertiesTable.Row label="Created">
           <DateTime date={image.timeCreated} />

--- a/app/forms/image-upload.tsx
+++ b/app/forms/image-upload.tsx
@@ -109,9 +109,7 @@ function Step({ children, state, label, className }: StepProps) {
     >
       {/* padding on icon to align it with text since everything is aligned to top */}
       <div className="pt-px">{icon}</div>
-      <div
-        className={cn('w-full space-y-2', state.isError ? 'text-error' : 'text-default')}
-      >
+      <div className={cn('w-full space-y-2', state.isError ? 'text-error' : 'text-raise')}>
         <div>{label}</div>
         {children}
       </div>
@@ -616,14 +614,14 @@ export function Component() {
                 <Step state={syntheticUploadState} label="Upload image file">
                   <div className="rounded-lg border bg-default border-default">
                     <div className="flex justify-between border-b p-3 pb-2 border-b-secondary">
-                      <div className="text-sans-md text-default">{file.name}</div>
+                      <div className="text-sans-md text-raise">{file.name}</div>
                       {/* cancel and/or pause buttons could go here */}
                     </div>
                     <div className="p-3 pt-2">
                       <div className="flex justify-between text-mono-sm">
-                        <div className="!normal-case text-secondary">
+                        <div className="!normal-case text-default">
                           {fsize((uploadProgress / 100) * file.size)}{' '}
-                          <span className="text-quinary">/</span> {fsize(file.size)}
+                          <span className="text-quaternary">/</span> {fsize(file.size)}
                         </div>
                         <div className="text-accent">{uploadProgress}%</div>
                       </div>

--- a/app/forms/instance-create.tsx
+++ b/app/forms/instance-create.tsx
@@ -614,7 +614,7 @@ const isFloating = (
 const FloatingIpLabel = ({ ip }: { ip: FloatingIp }) => (
   <div>
     <div>{ip.name}</div>
-    <div className="flex gap-0.5 text-tertiary selected:text-accent-secondary">
+    <div className="flex gap-0.5 text-secondary selected:text-accent-secondary">
       <div>{ip.ip}</div>
       {ip.description && (
         <>
@@ -749,7 +749,7 @@ const AdvancedAccordion = ({
                 externalIps.field.onChange(newExternalIps)
               }}
             />
-            <label htmlFor="assignEphemeralIp" className="text-sans-md text-secondary">
+            <label htmlFor="assignEphemeralIp" className="text-sans-md text-default">
               Allocate and attach an ephemeral IP address
             </label>
           </div>

--- a/app/pages/DeviceAuthSuccessPage.tsx
+++ b/app/pages/DeviceAuthSuccessPage.tsx
@@ -18,7 +18,7 @@ export function DeviceAuthSuccessPage() {
         <Success12Icon className="relative h-8 w-8 text-accent" />
       </div>
       <h1 className="mt-4 text-sans-2xl text-accent">Device logged in</h1>
-      <p className="mt-1 text-sans-lg text-tertiary">You can close this window</p>
+      <p className="mt-1 text-sans-lg text-secondary">You can close this window</p>
     </div>
   )
 }

--- a/app/pages/DeviceAuthVerifyPage.tsx
+++ b/app/pages/DeviceAuthVerifyPage.tsx
@@ -56,11 +56,13 @@ export function DeviceAuthVerifyPage() {
       }}
     >
       <h1 className="mb-1 text-sans-2xl text-accent">Device Authentication</h1>
-      <p className="mb-8 text-sans-lg text-tertiary">Enter the code shown on your device</p>
+      <p className="mb-8 text-sans-lg text-secondary">
+        Enter the code shown on your device
+      </p>
       <AuthCodeInput
         onChange={(code) => setUserCode(code)}
         containerClassName="flex space-x-2 mb-6"
-        inputClassName="rounded border border-default bg-default w-full aspect-square flex items-center justify-center text-center text-secondary text-mono-md"
+        inputClassName="rounded border border-default bg-default w-full aspect-square flex items-center justify-center text-center text-default text-mono-md"
         length={8}
         dashAfterIdxs={DASH_AFTER_IDXS}
       />

--- a/app/pages/LoginPage.tsx
+++ b/app/pages/LoginPage.tsx
@@ -47,7 +47,7 @@ export function LoginPage() {
           className="flex h-[34px] w-[34px] items-center justify-center rounded text-accent bg-accent-secondary-hover"
           name={silo}
         />
-        <div className="text-sans-2xl text-default">{silo}</div>
+        <div className="text-sans-2xl text-raise">{silo}</div>
       </div>
 
       <hr className="my-6 w-full border-0 border-b border-b-secondary" />

--- a/app/pages/LoginPageSaml.tsx
+++ b/app/pages/LoginPageSaml.tsx
@@ -27,7 +27,7 @@ export function LoginPageSaml() {
           className="flex h-[34px] w-[34px] items-center justify-center rounded text-accent bg-accent-secondary-hover"
           name={silo}
         />
-        <div className="text-sans-2xl text-default">{silo}</div>
+        <div className="text-sans-2xl text-raise">{silo}</div>
       </div>
 
       <hr className="my-6 w-full border-0 border-b border-b-secondary" />

--- a/app/pages/project/images/ImagesPage.tsx
+++ b/app/pages/project/images/ImagesPage.tsx
@@ -171,7 +171,7 @@ const PromoteImageModal = ({ onDismiss, imageName }: PromoteModalProps) => {
         <Modal.Section>
           <p>
             Are you sure you want to promote{' '}
-            <span className="text-sans-semi-md text-default">{imageName}</span>?
+            <span className="text-sans-semi-md text-raise">{imageName}</span>?
           </p>
           <Message
             variant="info"

--- a/app/pages/project/instances/InstancesPage.tsx
+++ b/app/pages/project/instances/InstancesPage.tsx
@@ -98,7 +98,7 @@ export function InstancesPage() {
         header: 'CPU',
         cell: (info) => (
           <>
-            {info.getValue()} <span className="ml-1 text-quaternary">vCPU</span>
+            {info.getValue()} <span className="ml-1 text-tertiary">vCPU</span>
           </>
         ),
       }),
@@ -108,7 +108,7 @@ export function InstancesPage() {
           const memory = filesize(info.getValue(), { output: 'object', base: 2 })
           return (
             <>
-              {memory.value} <span className="ml-1 text-quaternary">{memory.unit}</span>
+              {memory.value} <span className="ml-1 text-tertiary">{memory.unit}</span>
             </>
           )
         },
@@ -220,7 +220,7 @@ export function InstancesPage() {
             content="Auto-refresh is more frequent after instance actions"
             delay={150}
           >
-            <span className="text-sans-sm text-tertiary">
+            <span className="text-sans-sm text-secondary">
               Updated {toLocaleTimeString(new Date(dataUpdatedAt))}
             </span>
           </Tooltip>

--- a/app/pages/project/instances/InstancesPage.tsx
+++ b/app/pages/project/instances/InstancesPage.tsx
@@ -213,7 +213,7 @@ export function InstancesPage() {
       </PageHeader>
       {/* Avoid changing justify-end on TableActions for this one case. We can
        * fix this properly when we add refresh and filtering for all tables. */}
-      <TableActions className="!-mt-6 !justify-between">
+      <TableActions className="!justify-between">
         <div className="flex items-center gap-2">
           <RefreshButton onClick={refetchInstances} />
           <Tooltip

--- a/app/pages/project/instances/instance/InstancePage.tsx
+++ b/app/pages/project/instances/instance/InstancePage.tsx
@@ -196,12 +196,12 @@ export function InstancePage() {
       <PropertiesTable.Group className="-mt-8 mb-16">
         <PropertiesTable>
           <PropertiesTable.Row label="cpu">
-            <span className="text-secondary">{instance.ncpus}</span>
-            <span className="ml-1 text-quaternary"> vCPUs</span>
+            <span className="text-default">{instance.ncpus}</span>
+            <span className="ml-1 text-tertiary"> vCPUs</span>
           </PropertiesTable.Row>
           <PropertiesTable.Row label="ram">
-            <span className="text-secondary">{memory.value}</span>
-            <span className="ml-1 text-quaternary"> {memory.unit}</span>
+            <span className="text-default">{memory.value}</span>
+            <span className="ml-1 text-tertiary"> {memory.unit}</span>
           </PropertiesTable.Row>
           <PropertiesTable.Row label="state">
             <div className="flex">
@@ -230,7 +230,7 @@ export function InstancePage() {
         </PropertiesTable>
         <PropertiesTable>
           <PropertiesTable.Row label="description">
-            <span className="text-secondary">
+            <span className="text-default">
               <Truncate text={instance.description} maxLength={40} />
             </span>
           </PropertiesTable.Row>
@@ -238,7 +238,7 @@ export function InstancePage() {
             <DateTime date={instance.timeCreated} />
           </PropertiesTable.Row>
           <PropertiesTable.Row label="id">
-            <span className="overflow-hidden text-ellipsis whitespace-nowrap text-secondary">
+            <span className="overflow-hidden text-ellipsis whitespace-nowrap text-default">
               {instance.id}
             </span>
           </PropertiesTable.Row>

--- a/app/pages/project/instances/instance/SerialConsolePage.tsx
+++ b/app/pages/project/instances/instance/SerialConsolePage.tsx
@@ -221,7 +221,7 @@ const CannotConnect = ({ instance }: { instance: Instance }) => (
       <span>The instance is </span>
       <InstanceStateBadge className="ml-1.5" state={instance.runState} />
     </p>
-    <p className="mt-2 text-balance text-center text-secondary">
+    <p className="mt-2 text-balance text-center text-default">
       {isStarting(instance)
         ? 'Waiting for the instance to start before connecting.'
         : 'You can only connect to the serial console on a running instance.'}
@@ -236,6 +236,6 @@ const ErrorSkeleton = () => (
     <p className="flex items-center justify-center text-center text-sans-xl">
       Serial console connection failed
     </p>
-    <p className="mt-2 text-center text-secondary">Please try again.</p>
+    <p className="mt-2 text-center text-default">Please try again.</p>
   </SerialSkeleton>
 )

--- a/app/pages/project/instances/instance/tabs/MetricsTab.tsx
+++ b/app/pages/project/instances/instance/tabs/MetricsTab.tsx
@@ -124,8 +124,8 @@ function DiskMetric({
 
   return (
     <div className="flex w-1/2 grow flex-col">
-      <h2 className="ml-3 flex items-center text-mono-xs text-secondary">
-        {title} <div className="ml-1 normal-case text-quaternary">{label}</div>
+      <h2 className="ml-3 flex items-center text-mono-xs text-default">
+        {title} <div className="ml-1 normal-case text-tertiary">{label}</div>
         {isLoading && <Spinner className="ml-2" />}
       </h2>
       <Suspense fallback={<div className="mt-3 h-[300px]" />}>

--- a/app/pages/project/instances/instance/tabs/NetworkingTab.tsx
+++ b/app/pages/project/instances/instance/tabs/NetworkingTab.tsx
@@ -80,7 +80,7 @@ const SubnetNameFromId = ({ value }: { value: string }) => {
   if (isError) return <Badge color="neutral">Deleted</Badge>
   if (!subnet) return <SkeletonCell /> // loading
 
-  return <span className="text-secondary">{subnet.name}</span>
+  return <span className="text-default">{subnet.name}</span>
 }
 
 export async function loader({ params }: LoaderFunctionArgs) {

--- a/app/pages/project/instances/instance/tabs/StorageTab.tsx
+++ b/app/pages/project/instances/instance/tabs/StorageTab.tsx
@@ -157,7 +157,7 @@ export function Component() {
         label: 'Unset as boot disk',
         disabled: !instanceCan.update({ runState: disk.instanceState }) && (
           <>
-            Instance must be <span className="text-default">stopped</span> before boot disk
+            Instance must be <span className="text-raise">stopped</span> before boot disk
             can be changed
           </>
         ),
@@ -210,7 +210,7 @@ export function Component() {
         label: 'Set as boot disk',
         disabled: !instanceCan.update({ runState: disk.instanceState }) && (
           <>
-            Instance must be <span className="text-default">stopped</span> before boot disk
+            Instance must be <span className="text-raise">stopped</span> before boot disk
             can be changed
           </>
         ),
@@ -253,8 +253,8 @@ export function Component() {
         label: 'Detach',
         disabled: !instanceCan.detachDisk({ runState: disk.instanceState }) && (
           <>
-            Instance must be <span className="text-default">stopped</span> before disk can
-            be detached
+            Instance must be <span className="text-raise">stopped</span> before disk can be
+            detached
           </>
         ),
         onActivate() {
@@ -325,7 +325,7 @@ export function Component() {
           onClick={() => setShowDiskCreate(true)}
           disabledReason={
             <>
-              Instance must be <span className="text-default">stopped</span> to create and
+              Instance must be <span className="text-raise">stopped</span> to create and
               attach a disk
             </>
           }
@@ -339,8 +339,7 @@ export function Component() {
           onClick={() => setShowDiskAttach(true)}
           disabledReason={
             <>
-              Instance must be <span className="text-default">stopped</span> to attach a
-              disk
+              Instance must be <span className="text-raise">stopped</span> to attach a disk
             </>
           }
           disabled={!instanceCan.attachDisk(instance)}

--- a/app/pages/project/instances/instance/tabs/common.tsx
+++ b/app/pages/project/instances/instance/tabs/common.tsx
@@ -8,7 +8,7 @@
 import { intersperse } from '~/util/array'
 
 const white = (s: string) => (
-  <span key={s} className="text-default">
+  <span key={s} className="text-raise">
     {s}
   </span>
 )

--- a/app/pages/project/snapshots/SnapshotsPage.tsx
+++ b/app/pages/project/snapshots/SnapshotsPage.tsx
@@ -41,7 +41,7 @@ const DiskNameFromId = ({ value }: { value: string }) => {
 
   if (!data) return <SkeletonCell />
   if (data.type === 'error') return <Badge color="neutral">Deleted</Badge>
-  return <span className="text-secondary">{data.data.name}</span>
+  return <span className="text-default">{data.data.name}</span>
 }
 
 const EmptyState = () => (

--- a/app/pages/project/vpcs/VpcPage/tabs/VpcFirewallRulesTab.tsx
+++ b/app/pages/project/vpcs/VpcPage/tabs/VpcFirewallRulesTab.tsx
@@ -40,15 +40,15 @@ const colHelper = createColumnHelper<VpcFirewallRule>()
 const staticColumns = [
   colHelper.accessor('priority', {
     header: 'Priority',
-    cell: (info) => <div className="text-secondary">{info.getValue()}</div>,
+    cell: (info) => <div className="text-default">{info.getValue()}</div>,
   }),
   colHelper.accessor('action', {
     header: 'Action',
-    cell: (info) => <div className="text-secondary">{titleCase(info.getValue())}</div>,
+    cell: (info) => <div className="text-default">{titleCase(info.getValue())}</div>,
   }),
   colHelper.accessor('direction', {
     header: 'Direction',
-    cell: (info) => <div className="text-secondary">{titleCase(info.getValue())}</div>,
+    cell: (info) => <div className="text-default">{titleCase(info.getValue())}</div>,
   }),
   colHelper.accessor('targets', {
     header: 'Targets',

--- a/app/pages/settings/ProfilePage.tsx
+++ b/app/pages/settings/ProfilePage.tsx
@@ -53,7 +53,7 @@ export function ProfilePage() {
         Groups
       </TableTitle>
       <Table table={groupsTable} aria-labelledby="groups-label" />
-      <p className="inline-block max-w-md text-sans-md text-secondary">
+      <p className="inline-block max-w-md text-sans-md text-default">
         Your user information is managed by your organization.{' '}
         <span className="md+:block">
           To update your information, contact your administrator.

--- a/app/pages/system/SiloImagesPage.tsx
+++ b/app/pages/system/SiloImagesPage.tsx
@@ -262,7 +262,7 @@ const DemoteImageModal = ({
             className="space-y-4"
           >
             <p>
-              Demoting: <span className="text-sans-semi-md text-default">{image.name}</span>
+              Demoting: <span className="text-sans-semi-md text-raise">{image.name}</span>
             </p>
 
             <Message

--- a/app/pages/system/UtilizationPage.tsx
+++ b/app/pages/system/UtilizationPage.tsx
@@ -248,12 +248,12 @@ const UsageCell = ({
   allocated: number
   unit?: string
 }) => (
-  <div className="flex flex-col text-tertiary">
+  <div className="flex flex-col text-secondary">
     <div>
-      <span className="text-default">{provisioned}</span> /
+      <span className="text-raise">{provisioned}</span> /
     </div>
-    <div className="text-tertiary">
-      {allocated} {unit && <span className="text-quaternary">{unit}</span>}
+    <div className="text-secondary">
+      {allocated} {unit && <span className="text-tertiary">{unit}</span>}
     </div>
   </div>
 )
@@ -272,7 +272,7 @@ const AvailableCell = ({
     <div className="flex w-full items-center justify-between">
       <div>
         {round(allocated - provisioned, 2)}
-        {unit && <span className="text-tertiary"> {unit}</span>}
+        {unit && <span className="text-secondary"> {unit}</span>}
       </div>
       {/* We only show the ResourceMeter if the percent crosses the warning threshold (66%) */}
       {usagePercent > 66 && (

--- a/app/pages/system/inventory/sled/SledInstancesTab.tsx
+++ b/app/pages/system/inventory/sled/SledInstancesTab.tsx
@@ -50,8 +50,8 @@ const staticCols = [
       const value = info.getValue()
       return (
         <div className="space-y-0.5">
-          <div className="text-quaternary">{`${value.siloName} / ${value.projectName}`}</div>
-          <div className="text-default">{value.name}</div>
+          <div className="text-tertiary">{`${value.siloName} / ${value.projectName}`}</div>
+          <div className="text-raise">{value.name}</div>
         </div>
       )
     },

--- a/app/pages/system/inventory/sled/SledPage.tsx
+++ b/app/pages/system/inventory/sled/SledPage.tsx
@@ -41,31 +41,31 @@ export function Component() {
       <PropertiesTable.Group className="-mt-8 mb-16">
         <PropertiesTable>
           <PropertiesTable.Row label="sled id">
-            <span className="text-secondary">{sled.id}</span>
+            <span className="text-default">{sled.id}</span>
           </PropertiesTable.Row>
           <PropertiesTable.Row label="part">
-            <span className="text-secondary">{sled.baseboard.part}</span>
+            <span className="text-default">{sled.baseboard.part}</span>
           </PropertiesTable.Row>
           <PropertiesTable.Row label="serial">
-            <span className="text-secondary">{sled.baseboard.serial}</span>
+            <span className="text-default">{sled.baseboard.serial}</span>
           </PropertiesTable.Row>
           <PropertiesTable.Row label="revision">
-            <span className="text-secondary">{sled.baseboard.revision}</span>
+            <span className="text-default">{sled.baseboard.revision}</span>
           </PropertiesTable.Row>
         </PropertiesTable>
         <PropertiesTable>
           <PropertiesTable.Row label="rack id">
-            <span className="text-secondary">{sled.rackId}</span>
+            <span className="text-default">{sled.rackId}</span>
           </PropertiesTable.Row>
           <PropertiesTable.Row label="location">
             <span className="text-disabled">Coming soon</span>
           </PropertiesTable.Row>
           <PropertiesTable.Row label="usable hardware threads">
-            <span className="text-secondary">{sled.usableHardwareThreads}</span>
+            <span className="text-default">{sled.usableHardwareThreads}</span>
           </PropertiesTable.Row>
           <PropertiesTable.Row label="usable physical ram">
-            <span className="pr-0.5 text-secondary">{ram.value}</span>
-            <span className="text-quaternary">{ram.unit}</span>
+            <span className="pr-0.5 text-default">{ram.value}</span>
+            <span className="text-tertiary">{ram.unit}</span>
           </PropertiesTable.Row>
         </PropertiesTable>
       </PropertiesTable.Group>

--- a/app/pages/system/silos/SiloPage.tsx
+++ b/app/pages/system/silos/SiloPage.tsx
@@ -111,15 +111,15 @@ export function Component() {
             </TableEmptyBox>
           ) : (
             <>
-              <p className="mb-4 text-secondary">
+              <p className="mb-4 text-default">
                 Silo roles can automatically grant a fleet role.
               </p>
               <ul className="space-y-3">
                 {roleMapPairs.map(([siloRole, fleetRole]) => (
                   <li key={siloRole + '|' + fleetRole} className="flex items-center">
                     <Badge>Silo {siloRole}</Badge>
-                    <NextArrow12Icon className="mx-3 text-secondary" aria-label="maps to" />
-                    <span className="text-sans-md text-secondary">Fleet {fleetRole}</span>
+                    <NextArrow12Icon className="mx-3 text-default" aria-label="maps to" />
+                    <span className="text-sans-md text-default">Fleet {fleetRole}</span>
                   </li>
                 ))}
               </ul>

--- a/app/pages/system/silos/SiloQuotasTab.tsx
+++ b/app/pages/system/silos/SiloQuotasTab.tsx
@@ -26,7 +26,7 @@ import { classed } from '~/util/classed'
 import { links } from '~/util/links'
 import { bytesToGiB, GiB } from '~/util/units'
 
-const Unit = classed.span`ml-1 text-tertiary`
+const Unit = classed.span`ml-1 text-secondary`
 
 export function SiloQuotasTab() {
   const { silo } = useSiloSelector()

--- a/app/table/cells/EmptyCell.tsx
+++ b/app/table/cells/EmptyCell.tsx
@@ -8,6 +8,6 @@
 
 import { classed } from '~/util/classed'
 
-export const EmptyCell = () => <span className="text-sans-md text-quinary">&mdash;</span>
+export const EmptyCell = () => <span className="text-sans-md text-quaternary">&mdash;</span>
 
 export const SkeletonCell = classed.div`h-4 w-12 rounded bg-tertiary motion-safe:animate-pulse`

--- a/app/table/cells/InstanceResourceCell.tsx
+++ b/app/table/cells/InstanceResourceCell.tsx
@@ -16,10 +16,10 @@ export const InstanceResourceCell = ({ value }: Props) => {
   return (
     <div className="space-y-0.5">
       <div>
-        {value.ncpus} <span className="text-quaternary">vCPU</span>
+        {value.ncpus} <span className="text-tertiary">vCPU</span>
       </div>
       <div>
-        {memory.value} <span className="text-quaternary">{memory.unit}</span>
+        {memory.value} <span className="text-tertiary">{memory.unit}</span>
       </div>
     </div>
   )

--- a/app/table/cells/TwoLineCell.tsx
+++ b/app/table/cells/TwoLineCell.tsx
@@ -14,7 +14,7 @@ interface TwoLineCellProps {
 
 export const TwoLineCell = ({ value, detailsClass }: TwoLineCellProps) => (
   <div className="space-y-0.5">
-    <div className="text-secondary">{value[0]}</div>
-    <div className={cn('text-tertiary', detailsClass)}>{value[1]}</div>
+    <div className="text-default">{value[0]}</div>
+    <div className={cn('text-secondary', detailsClass)}>{value[1]}</div>
   </div>
 )

--- a/app/table/columns/action-col.tsx
+++ b/app/table/columns/action-col.tsx
@@ -73,7 +73,7 @@ export const RowActions = ({ id, copyIdLabel = 'Copy ID', actions }: RowActionsP
         aria-label="Row actions"
         onClick={(e) => e.stopPropagation()}
       >
-        <More12Icon className="text-secondary" />
+        <More12Icon />
       </DropdownMenu.Trigger>
       {/* offset moves menu in from the right so it doesn't align with the table border */}
       <DropdownMenu.Content anchor={{ to: 'bottom end', offset: -6 }} className="-mt-2">

--- a/app/table/columns/action-col.tsx
+++ b/app/table/columns/action-col.tsx
@@ -73,7 +73,7 @@ export const RowActions = ({ id, copyIdLabel = 'Copy ID', actions }: RowActionsP
         aria-label="Row actions"
         onClick={(e) => e.stopPropagation()}
       >
-        <More12Icon className="text-tertiary" />
+        <More12Icon className="text-secondary" />
       </DropdownMenu.Trigger>
       {/* offset moves menu in from the right so it doesn't align with the table border */}
       <DropdownMenu.Content anchor={{ to: 'bottom end', offset: -6 }} className="-mt-2">

--- a/app/table/columns/common.tsx
+++ b/app/table/columns/common.tsx
@@ -22,8 +22,8 @@ function dateCell(info: Info<Date>) {
 function sizeCell(info: Info<number>) {
   const size = filesize(info.getValue(), { base: 2, output: 'object' })
   return (
-    <span className="text-secondary">
-      {size.value} <span className="text-quaternary">{size.unit}</span>
+    <span className="text-default">
+      {size.value} <span className="text-tertiary">{size.unit}</span>
     </span>
   )
 }

--- a/app/ui/lib/ActionMenu.tsx
+++ b/app/ui/lib/ActionMenu.tsx
@@ -137,7 +137,7 @@ export function ActionMenu(props: ActionMenuProps) {
               {input.length > 0 && (
                 <button
                   type="button"
-                  className="flex items-center py-6 pl-6 pr-4 text-secondary"
+                  className="flex items-center py-6 pl-6 pr-4 text-default"
                   onClick={() => {
                     setInput('')
                     inputRef.current?.focus()
@@ -150,7 +150,7 @@ export function ActionMenu(props: ActionMenuProps) {
               <button
                 type="button"
                 onClick={onDismiss}
-                className="flex h-full items-center border-l px-6 align-middle text-mono-sm text-secondary border-secondary"
+                className="flex h-full items-center border-l px-6 align-middle text-mono-sm text-default border-secondary"
               >
                 Dismiss
               </button>
@@ -166,7 +166,7 @@ export function ActionMenu(props: ActionMenuProps) {
                   <ul ref={ulRef}>
                     {allGroups.map(([label, items]) => (
                       <div key={label}>
-                        <h3 className="sticky top-0 z-20 h-[32px] px-4 py-2 text-mono-sm text-secondary bg-tertiary">
+                        <h3 className="sticky top-0 z-20 h-[32px] px-4 py-2 text-mono-sm text-default bg-tertiary">
                           {label}
                         </h3>
                         {items.map((item) => (
@@ -186,7 +186,7 @@ export function ActionMenu(props: ActionMenuProps) {
                             <li
                               role="option"
                               className={cn(
-                                'box-border block h-full w-full cursor-pointer select-none overflow-visible border p-4 text-sans-md text-secondary bg-raise border-secondary hover:bg-hover',
+                                'box-border block h-full w-full cursor-pointer select-none overflow-visible border p-4 text-sans-md text-default bg-raise border-secondary hover:bg-hover',
                                 item.value === selectedItem?.value &&
                                   'text-accent bg-accent-secondary hover:bg-accent-secondary-hover'
                               )}
@@ -204,7 +204,7 @@ export function ActionMenu(props: ActionMenuProps) {
                     ))}
                   </ul>
                 </div>
-                <div className="flex justify-between rounded-b-[3px] px-4 py-2 text-secondary bg-tertiary">
+                <div className="flex justify-between rounded-b-[3px] px-4 py-2 text-default bg-tertiary">
                   <ActionMenuHotkey keys={['Enter']} action="submit" />
                   <ActionMenuHotkey keys={['Arrow Up', 'Arrow Down']} action="select" />
                   <ActionMenuHotkey keys={['Esc']} action="close" />
@@ -229,12 +229,12 @@ export const ActionMenuHotkey = ({ keys, action }: ActionMenuHotkeyProps) => (
       {keys.map((hotkey) => (
         <kbd
           key={hotkey}
-          className="mr-1 inline-block rounded border border-[rgba(255,255,255,.15)] px-2 py-1 text-mono-xs text-default"
+          className="mr-1 inline-block rounded border border-[rgba(255,255,255,.15)] px-2 py-1 text-mono-xs text-raise"
         >
           {hotkey}
         </kbd>
       ))}
     </div>
-    <span className="text-sans-sm text-tertiary">to {action}</span>
+    <span className="text-sans-sm text-secondary">to {action}</span>
   </div>
 )

--- a/app/ui/lib/AuthCodeInput.tsx
+++ b/app/ui/lib/AuthCodeInput.tsx
@@ -64,7 +64,7 @@ function getPrevInputSibling(el: Element): HTMLInputElement | null {
 }
 
 const Dash = () => (
-  <span className="flex items-center px-1 text-quinary">
+  <span className="flex items-center px-1 text-quaternary">
     {/* sorry about this margin. it must be done */}
     <span className="mb-0.5">&ndash;</span>
   </span>

--- a/app/ui/lib/Badge.tsx
+++ b/app/ui/lib/Badge.tsx
@@ -28,7 +28,7 @@ export const badgeColors: Record<BadgeVariant, Record<BadgeColor, string>> = {
     default: `ring-1 ring-inset bg-accent-secondary text-accent ring-[rgba(var(--base-green-800-rgb),0.15)]`,
     destructive: `ring-1 ring-inset bg-destructive-secondary text-destructive ring-[rgba(var(--base-red-800-rgb),0.15)]`,
     notice: `ring-1 ring-inset bg-notice-secondary text-notice ring-[rgba(var(--base-yellow-800-rgb),0.15)]`,
-    neutral: `ring-1 ring-inset bg-secondary text-secondary ring-[rgba(var(--base-neutral-700-rgb),0.15)]`,
+    neutral: `ring-1 ring-inset bg-secondary text-default ring-[rgba(var(--base-neutral-700-rgb),0.15)]`,
     purple: `ring-1 ring-inset bg-[var(--base-purple-200)] text-[var(--base-purple-700)] ring-[rgba(var(--base-purple-800-rgb),0.15)]`,
     blue: `ring-1 ring-inset bg-info-secondary text-info ring-[rgba(var(--base-blue-800-rgb),0.15)]`,
   },

--- a/app/ui/lib/Badge.tsx
+++ b/app/ui/lib/Badge.tsx
@@ -29,15 +29,15 @@ export const badgeColors: Record<BadgeVariant, Record<BadgeColor, string>> = {
     destructive: `ring-1 ring-inset bg-destructive-secondary text-destructive ring-[rgba(var(--base-red-800-rgb),0.15)]`,
     notice: `ring-1 ring-inset bg-notice-secondary text-notice ring-[rgba(var(--base-yellow-800-rgb),0.15)]`,
     neutral: `ring-1 ring-inset bg-secondary text-default ring-[rgba(var(--base-neutral-700-rgb),0.15)]`,
-    purple: `ring-1 ring-inset bg-[var(--base-purple-200)] text-[var(--base-purple-700)] ring-[rgba(var(--base-purple-800-rgb),0.15)]`,
+    purple: `ring-1 ring-inset bg-[--base-purple-200] text-[--base-purple-700] ring-[rgba(var(--base-purple-800-rgb),0.15)]`,
     blue: `ring-1 ring-inset bg-info-secondary text-info ring-[rgba(var(--base-blue-800-rgb),0.15)]`,
   },
   solid: {
     default: 'bg-accent text-inverse',
     destructive: 'bg-destructive text-inverse',
     notice: 'bg-notice text-inverse',
-    neutral: 'bg-inverse-tertiary text-inverse',
-    purple: 'bg-[var(--base-purple-700)] text-inverse',
+    neutral: 'bg-[--base-neutral-600] text-inverse',
+    purple: 'bg-[--base-purple-700] text-inverse',
     blue: 'bg-info text-inverse',
   },
 }

--- a/app/ui/lib/CalendarCell.tsx
+++ b/app/ui/lib/CalendarCell.tsx
@@ -86,7 +86,7 @@ export function CalendarCell({ state, date }: CalendarCellProps) {
             ? isInvalid
               ? 'text-error bg-error-secondary'
               : 'text-accent-secondary bg-accent-secondary'
-            : 'text-tertiary hover:bg-tertiary',
+            : 'text-secondary hover:bg-tertiary',
           isRoundedLeft && 'rounded-l',
           isRoundedRight && 'rounded-r',
           // Hover state for non-selected cells.

--- a/app/ui/lib/CalendarGrid.tsx
+++ b/app/ui/lib/CalendarGrid.tsx
@@ -29,7 +29,7 @@ export function CalendarGrid({ state, ...props }: CalendarGridProps) {
         <thead {...headerProps}>
           <tr>
             {weekDays.map((day, index) => (
-              <th className="h-8 w-10 text-center text-mono-md text-quaternary" key={index}>
+              <th className="h-8 w-10 text-center text-mono-md text-tertiary" key={index}>
                 {day}
               </th>
             ))}

--- a/app/ui/lib/Checkbox.tsx
+++ b/app/ui/lib/Checkbox.tsx
@@ -56,6 +56,6 @@ export const Checkbox = ({
       {indeterminate && <Indeterminate />}
     </span>
 
-    {children && <span className="ml-2.5 text-sans-md text-secondary">{children}</span>}
+    {children && <span className="ml-2.5 text-sans-md text-default">{children}</span>}
   </label>
 )

--- a/app/ui/lib/Combobox.tsx
+++ b/app/ui/lib/Combobox.tsx
@@ -138,7 +138,7 @@ export const Combobox = ({
       value: query,
       label: (
         <>
-          <span className="text-secondary">Custom:</span> {query}
+          <span className="text-default">Custom:</span> {query}
         </>
       ),
       selectedLabel: query,
@@ -225,7 +225,7 @@ export const Combobox = ({
               placeholder={placeholder}
               disabled={disabled || isLoading}
               className={cn(
-                `h-10 w-full rounded !border-none px-3 py-2 !outline-none text-sans-md text-default placeholder:text-quaternary`,
+                `h-10 w-full rounded !border-none px-3 py-2 !outline-none text-sans-md text-raise placeholder:text-tertiary`,
                 disabled
                   ? 'cursor-not-allowed text-disabled bg-disabled !border-default'
                   : 'bg-default',
@@ -237,7 +237,7 @@ export const Combobox = ({
                 className="my-1.5 flex items-center border-l px-3 bg-default border-secondary"
                 aria-hidden
               >
-                <SelectArrows6Icon title="Select" className="w-2 text-tertiary" />
+                <SelectArrows6Icon title="Select" className="w-2 text-secondary" />
               </ComboboxButton>
             )}
           </div>

--- a/app/ui/lib/CopyToClipboard.tsx
+++ b/app/ui/lib/CopyToClipboard.tsx
@@ -50,7 +50,7 @@ export const CopyToClipboard = ({
         'relative h-5 w-5 rounded',
         hasCopied
           ? 'text-accent bg-accent-secondary'
-          : 'text-quaternary hover:text-secondary hover:bg-hover',
+          : 'text-tertiary hover:text-default hover:bg-hover',
 
         className
       )}

--- a/app/ui/lib/DateField.tsx
+++ b/app/ui/lib/DateField.tsx
@@ -130,7 +130,7 @@ function DateSegment({
       }}
       className={cn(
         'group box-content rounded px-[1px] text-right tabular-nums outline-none',
-        !readOnly && 'focus:text-default focus:bg-accent-secondary-hover',
+        !readOnly && 'focus:text-raise focus:bg-accent-secondary-hover',
         segment.type === 'timeZoneName' ? 'ml-1 text-sans-sm' : 'text-sans-md'
       )}
       // Segment props turns this into a focusable element
@@ -141,8 +141,8 @@ function DateSegment({
       <span
         aria-hidden="true"
         className={cn(
-          'block w-full text-center text-quinary',
-          !readOnly && 'focus:text-default'
+          'block w-full text-center text-quaternary',
+          !readOnly && 'focus:text-raise'
         )}
         style={{
           visibility: segment.isPlaceholder ? undefined : 'hidden',
@@ -155,8 +155,8 @@ function DateSegment({
       <span
         className={cn(
           segment.type === 'literal' || segment.type === 'timeZoneName'
-            ? 'text-quaternary'
-            : 'text-default',
+            ? 'text-tertiary'
+            : 'text-raise',
           !readOnly && 'group-focus:text-accent'
         )}
       >

--- a/app/ui/lib/DatePicker.tsx
+++ b/app/ui/lib/DatePicker.tsx
@@ -77,7 +77,7 @@ export function DatePicker(props: DatePickerProps) {
             )}
           </div>
           <div className="-ml-px flex h-[calc(100%-12px)] w-10 items-center justify-center rounded-r border-l outline-none border-default">
-            <Calendar16Icon className="h-4 w-4 text-tertiary" />
+            <Calendar16Icon className="h-4 w-4 text-secondary" />
           </div>
         </button>
       </div>

--- a/app/ui/lib/DateRangePicker.tsx
+++ b/app/ui/lib/DateRangePicker.tsx
@@ -77,7 +77,7 @@ export function DateRangePicker(props: DateRangePickerProps) {
             )}
           </div>
           <div className="-ml-px flex h-[calc(100%-12px)] w-10 items-center justify-center rounded-r border-l outline-none border-default">
-            <Calendar16Icon className="h-4 w-4 text-tertiary" />
+            <Calendar16Icon className="h-4 w-4 text-secondary" />
           </div>
         </button>
       </div>
@@ -98,7 +98,7 @@ export function DateRangePicker(props: DateRangePickerProps) {
                 hourCycle={24}
                 className="shrink-0 grow basis-0"
               />
-              <div className="text-quinary">–</div>
+              <div className="text-quaternary">–</div>
               <TimeField
                 label="End time"
                 value={state.timeRange?.end || null}

--- a/app/ui/lib/DateTime.tsx
+++ b/app/ui/lib/DateTime.tsx
@@ -11,6 +11,6 @@ import { toLocaleDateString, toLocaleTimeString } from '~/util/date'
 export const DateTime = ({ date, locale }: { date: Date; locale?: string }) => (
   <time dateTime={date.toISOString()} className="flex flex-wrap gap-x-2">
     <span>{toLocaleDateString(date, locale)}</span>
-    <span className="text-quaternary">{toLocaleTimeString(date, locale)}</span>
+    <span className="text-tertiary">{toLocaleTimeString(date, locale)}</span>
   </time>
 )

--- a/app/ui/lib/DropdownMenu.tsx
+++ b/app/ui/lib/DropdownMenu.tsx
@@ -34,7 +34,11 @@ export function Content({ className, children, anchor = 'bottom end', gap }: Con
     <MenuItems
       anchor={anchor}
       // goofy gap because tailwind hates string interpolation
-      className={cn('DropdownMenuContent', gap === 8 && `[--anchor-gap:8px]`, className)}
+      className={cn(
+        'DropdownMenuContent elevation-2',
+        gap === 8 && `[--anchor-gap:8px]`,
+        className
+      )}
       // necessary to turn off scroll locking so the scrollbar doesn't pop in
       // and out as menu closes and opens
       modal={false}

--- a/app/ui/lib/EmptyMessage.tsx
+++ b/app/ui/lib/EmptyMessage.tsx
@@ -54,4 +54,4 @@ export function EmptyMessage(props: Props) {
   )
 }
 
-export const EMBody = classed.p`mt-1 text-balance text-sans-md text-secondary`
+export const EMBody = classed.p`mt-1 text-balance text-sans-md text-default`

--- a/app/ui/lib/FieldLabel.tsx
+++ b/app/ui/lib/FieldLabel.tsx
@@ -32,7 +32,7 @@ export const FieldLabel = ({
         {optional && (
           // Announcing this optional text is unnecessary as the required attribute on the
           // form will be used
-          <span className="pl-1 text-tertiary" aria-hidden="true">
+          <span className="pl-1 text-secondary" aria-hidden="true">
             (Optional)
           </span>
         )}

--- a/app/ui/lib/FileInput.tsx
+++ b/app/ui/lib/FileInput.tsx
@@ -73,7 +73,7 @@ export const FileInput = forwardRef(
         />
         <div
           className={cn(
-            'z-1 pointer-events-none relative flex flex-col items-center justify-center space-y-2 rounded border px-4 py-6 text-default bg-default',
+            'z-1 pointer-events-none relative flex flex-col items-center justify-center space-y-2 rounded border px-4 py-6 text-raise bg-default',
             dragOver && 'bg-accent-secondary !border-accent-secondary',
             error
               ? '!border-error-secondary group-hover:border-error'
@@ -90,25 +90,25 @@ export const FileInput = forwardRef(
           </div>
           <div className="flex h-8 items-center text-sans-md">
             {file && !dragOver ? (
-              <div className="flex items-center text-default">
+              <div className="flex items-center text-raise">
                 <Truncate text={file.name} maxLength={32} position="middle" />
-                <span className="ml-1 text-quaternary">
+                <span className="ml-1 text-tertiary">
                   ({filesize(file.size, { base: 2, pad: true })})
                 </span>
                 <button
                   type="button"
                   onClick={handleResetInput}
-                  className="pointer-events-auto ml-1 inline-flex rounded p-1 hover:children:text-tertiary"
+                  className="pointer-events-auto ml-1 inline-flex rounded p-1 hover:children:text-secondary"
                   aria-label="Clear file"
                 >
-                  <Error16Icon className="text-quaternary" />
+                  <Error16Icon className="text-tertiary" />
                 </button>
               </div>
             ) : (
               <>
                 Drop a file or click to browse{' '}
                 {accept && (
-                  <span className="ml-1 text-quaternary">
+                  <span className="ml-1 text-tertiary">
                     ({removeLeadingPeriods(accept)})
                   </span>
                 )}

--- a/app/ui/lib/Listbox.tsx
+++ b/app/ui/lib/Listbox.tsx
@@ -118,7 +118,7 @@ export const Listbox = <Value extends string = string>({
                   // selectedLabel is one line, which is what we need when label is a ReactNode
                   selectedItem.selectedLabel || selectedItem.label
                 ) : (
-                  <span className="text-quaternary">
+                  <span className="text-tertiary">
                     {noItems ? noItemsPlaceholder : placeholder}
                   </span>
                 )}
@@ -128,7 +128,7 @@ export const Listbox = <Value extends string = string>({
                 className="flex h-[calc(100%-12px)] items-center border-l px-3 border-secondary"
                 aria-hidden
               >
-                <SelectArrows6Icon title="Select" className="w-2 text-tertiary" />
+                <SelectArrows6Icon title="Select" className="w-2 text-secondary" />
               </div>
             </ListboxButton>
             <ListboxOptions

--- a/app/ui/lib/MiniTable.stories.tsx
+++ b/app/ui/lib/MiniTable.stories.tsx
@@ -19,14 +19,14 @@ export const Default = () => (
         <MiniTable.Cell>disk-1</MiniTable.Cell>
         <MiniTable.Cell>Blank</MiniTable.Cell>
         <MiniTable.Cell>
-          128 <span className="text-secondary">GiB</span>
+          128 <span className="text-default">GiB</span>
         </MiniTable.Cell>
       </MiniTable.Row>
       <MiniTable.Row>
         <MiniTable.Cell>disk-2</MiniTable.Cell>
         <MiniTable.Cell>Blank</MiniTable.Cell>
         <MiniTable.Cell>
-          128 <span className="text-secondary">GiB</span>
+          128 <span className="text-default">GiB</span>
         </MiniTable.Cell>
       </MiniTable.Row>
     </MiniTable.Body>

--- a/app/ui/lib/Modal.tsx
+++ b/app/ui/lib/Modal.tsx
@@ -93,7 +93,7 @@ export function Modal({
                     className="absolute right-2 top-4 flex items-center justify-center rounded p-2 hover:bg-hover"
                     aria-label="Close"
                   >
-                    <Close12Icon className="text-secondary" />
+                    <Close12Icon className="text-default" />
                   </Dialog.Close>
                 </AnimatedDialogContent>
               </Dialog.Portal>
@@ -124,7 +124,7 @@ const ModalTitle = forwardRef<HTMLDivElement, ModalTitleProps>(({ children, id }
 
 Modal.Body = classed.div`py-2 overflow-y-auto`
 
-Modal.Section = classed.div`p-4 space-y-4 border-b border-secondary text-secondary last-of-type:border-none text-sans-md`
+Modal.Section = classed.div`p-4 space-y-4 border-b border-secondary text-default last-of-type:border-none text-sans-md`
 
 /**
  * `formId` and `onAction` are mutually exclusive. If there is a form associated,

--- a/app/ui/lib/ModalLinks.tsx
+++ b/app/ui/lib/ModalLinks.tsx
@@ -17,8 +17,8 @@ export const ModalLinks = ({
   children: ReactNode
 }) => (
   <div>
-    <h3 className="mb-2 text-sans-semi-md text-default">{heading}</h3>
-    <ul className="space-y-1 text-sans-md text-tertiary">{children}</ul>
+    <h3 className="mb-2 text-sans-semi-md text-raise">{heading}</h3>
+    <ul className="space-y-1 text-sans-md text-secondary">{children}</ul>
   </div>
 )
 
@@ -32,7 +32,7 @@ export const ModalLink = ({ to, label }: { to: string; label: string }) => (
       className="group flex items-center space-x-2"
     >
       <OpenLink12Icon className="text-accent group-hover:text-accent" />
-      <span className="group-hover:text-default">{label}</span>
+      <span className="group-hover:text-raise">{label}</span>
     </a>
   </li>
 )

--- a/app/ui/lib/NumberInput.tsx
+++ b/app/ui/lib/NumberInput.tsx
@@ -49,7 +49,7 @@ export const NumberInput = React.forwardRef<
         {...inputProps}
         ref={mergeRefs([forwardedRef, inputRef])}
         className={cn(
-          `w-full rounded border-none px-3 py-[0.6875rem] !outline-offset-1 text-sans-md text-default bg-default placeholder:text-quaternary focus:outline-none disabled:cursor-not-allowed disabled:text-tertiary disabled:bg-disabled`,
+          `w-full rounded border-none px-3 py-[0.6875rem] !outline-offset-1 text-sans-md text-raise bg-default placeholder:text-tertiary focus:outline-none disabled:cursor-not-allowed disabled:text-secondary disabled:bg-disabled`,
           props.error && 'focus-error',
           props.isDisabled && 'text-disabled bg-disabled'
         )}
@@ -77,7 +77,7 @@ function IncrementButton(props: AriaButtonProps<'button'> & { className?: string
       {...buttonProps}
       className={cn(
         'flex h-1/2 w-8 items-center justify-center hover:bg-hover',
-        buttonProps.disabled ? 'text-quaternary bg-disabled' : 'bg-default'
+        buttonProps.disabled ? 'text-tertiary bg-disabled' : 'bg-default'
       )}
       ref={ref}
     >

--- a/app/ui/lib/Pagination.tsx
+++ b/app/ui/lib/Pagination.tsx
@@ -19,7 +19,7 @@ const PageInput = ({ number, className }: PageInputProps) => {
   return (
     <span
       className={cn(
-        'h-4 whitespace-nowrap rounded px-[3px] pb-[3px] pt-[1px] ring-1 ring-inset text-mono-sm text-secondary bg-tertiary ring-secondary',
+        'h-4 whitespace-nowrap rounded px-[3px] pb-[3px] pt-[1px] ring-1 ring-inset text-mono-sm text-default bg-tertiary ring-secondary',
         className
       )}
     >
@@ -53,11 +53,11 @@ export const Pagination = ({
       <nav
         aria-label="Pagination"
         className={cn(
-          'flex items-center justify-between text-mono-sm text-default bg-default',
+          'flex items-center justify-between text-mono-sm text-raise bg-default',
           className
         )}
       >
-        <span className="flex-inline grow text-tertiary">
+        <span className="flex-inline grow text-secondary">
           rows per page <PageInput number={pageSize} />
         </span>
         <span className="flex items-center space-x-3">
@@ -65,21 +65,21 @@ export const Pagination = ({
           <button
             type="button"
             className={cn(
-              hasPrev ? 'text-secondary hover:text-default' : 'text-disabled',
+              hasPrev ? 'text-default hover:text-raise' : 'text-disabled',
               'flex items-center text-mono-sm'
             )}
             disabled={!hasPrev}
             onClick={onPrev}
           >
             <DirectionLeftIcon
-              className={cn('mr-1', hasPrev ? 'text-secondary' : 'text-disabled')}
+              className={cn('mr-1', hasPrev ? 'text-default' : 'text-disabled')}
             />
             prev
           </button>
           <button
             type="button"
             className={cn(
-              hasNext ? 'text-secondary hover:text-default' : 'text-disabled',
+              hasNext ? 'text-default hover:text-raise' : 'text-disabled',
               'flex items-center text-mono-sm'
             )}
             disabled={!hasNext}
@@ -88,7 +88,7 @@ export const Pagination = ({
           >
             next
             <DirectionRightIcon
-              className={cn('ml-1', hasNext ? 'text-secondary' : 'text-disabled')}
+              className={cn('ml-1', hasNext ? 'text-default' : 'text-disabled')}
             />
           </button>
         </span>

--- a/app/ui/lib/PropertiesTable.tsx
+++ b/app/ui/lib/PropertiesTable.tsx
@@ -43,7 +43,7 @@ PropertiesTable.Row = ({ label, children }: PropertiesTableRowProps) => (
     <span className="flex items-center">
       <Badge>{label}</Badge>
     </span>
-    <div className="flex h-11 items-center overflow-hidden whitespace-nowrap pr-4 text-sans-md text-secondary">
+    <div className="flex h-11 items-center overflow-hidden whitespace-nowrap pr-4 text-sans-md text-default">
       {children}
     </div>
   </>

--- a/app/ui/lib/Radio.tsx
+++ b/app/ui/lib/Radio.tsx
@@ -34,7 +34,7 @@ export const Radio = ({ children, className, ...inputProps }: RadioProps) => (
       <div className="pointer-events-none absolute left-1 top-1 hidden h-2 w-2 rounded-full bg-accent peer-checked:block" />
     </span>
 
-    {children && <span className="ml-2.5 text-sans-md text-secondary">{children}</span>}
+    {children && <span className="ml-2.5 text-sans-md text-default">{children}</span>}
   </label>
 )
 
@@ -47,12 +47,12 @@ const cardLabelStyles = `
 
   peer-checked:bg-accent-secondary
   peer-checked:border-accent-secondary peer-checked:hover:border-accent peer-checked:children:border-accent peer-checked:children:border-accent-secondary
-  peer-checked:text-accent peer-checked:[&>*_.text-secondary]:text-accent-secondary
+  peer-checked:text-accent peer-checked:[&>*_.text-default]:text-accent-secondary
 
   peer-disabled:cursor-not-allowed
   peer-disabled:bg-disabled peer-disabled:peer-checked:bg-accent-secondary
   peer-checked:peer-disabled:hover:border-accent-secondary peer-disabled:hover:border-default
-  peer-disabled:[&>*_.text-secondary]:text-disabled peer-disabled:text-disabled peer-disabled:peer-checked:text-accent-disabled peer-disabled:peer-checked:[&>*_.text-secondary]:text-accent-disabled
+  peer-disabled:[&>*_.text-default]:text-disabled peer-disabled:text-disabled peer-disabled:peer-checked:text-accent-disabled peer-disabled:peer-checked:[&>*_.text-default]:text-accent-disabled
 `
 
 export function RadioCard({ children, className, ...inputProps }: RadioProps) {
@@ -70,7 +70,7 @@ export function RadioCard({ children, className, ...inputProps }: RadioProps) {
 
 // TODO: Remove importants after tailwind variantOrder bug fixed
 RadioCard.Unit = ({ children, className, ...props }: ComponentProps<'span'>) => (
-  <span className={cn('!m-0 !p-0 text-secondary', className)} {...props}>
+  <span className={cn('!m-0 !p-0 text-default', className)} {...props}>
     {children}
   </span>
 )

--- a/app/ui/lib/RadioGroup.tsx
+++ b/app/ui/lib/RadioGroup.tsx
@@ -52,7 +52,7 @@ import React from 'react'
 
 import { classed } from '~/util/classed'
 
-export const RadioGroupHint = classed.p`text-base text-secondary text-sans-sm max-w-3xl`
+export const RadioGroupHint = classed.p`text-base text-default text-sans-sm max-w-3xl`
 
 export type RadioGroupProps = {
   // gets passed to all the radios. this is what defines them as a group

--- a/app/ui/lib/RangeCalendar.tsx
+++ b/app/ui/lib/RangeCalendar.tsx
@@ -67,7 +67,7 @@ export const CalendarButton = ({
     onClick={handleClick}
     disabled={isDisabled}
     className={cn(
-      'flex h-8 w-10 items-center justify-center rounded outline-none text-tertiary',
+      'flex h-8 w-10 items-center justify-center rounded outline-none text-secondary',
       isDisabled ? 'text-disabled' : 'hover:bg-tertiary'
     )}
   >

--- a/app/ui/lib/SettingsGroup.tsx
+++ b/app/ui/lib/SettingsGroup.tsx
@@ -27,8 +27,8 @@ export const LearnMore = ({ href, text }: { href: string; text: React.ReactNode 
 
 /** Use size=sm on buttons and links! */
 export const SettingsGroup = {
-  Container: classed.div`w-full max-w-[660px] rounded-lg border text-sans-md text-secondary border-default`,
+  Container: classed.div`w-full max-w-[660px] rounded-lg border text-sans-md text-default border-default`,
   Body: classed.div`p-6`,
-  Title: classed.div`mb-1 text-sans-lg text-default`,
+  Title: classed.div`mb-1 text-sans-lg text-raise`,
   Footer: classed.div`flex items-center justify-between border-t px-6 py-3 border-default h-14`,
 }

--- a/app/ui/lib/SideModal.tsx
+++ b/app/ui/lib/SideModal.tsx
@@ -87,7 +87,7 @@ export function SideModal({
                   aria-describedby={undefined}
                 >
                   <div className="items-top mb-4 mt-8">
-                    <Dialog.Title className="flex w-full items-center justify-between break-words pr-8 text-sans-2xl">
+                    <Dialog.Title className="flex w-full items-center justify-between break-words pr-8 text-sans-2xl text-raise">
                       {title}
                     </Dialog.Title>
                     {subtitle}
@@ -169,7 +169,7 @@ SideModal.Footer = ({ children, error }: { children: ReactNode; error?: boolean 
       className="absolute right-[var(--content-gutter)] top-10 -m-2 flex rounded p-2 hover:bg-hover"
       aria-label="Close"
     >
-      <Close12Icon className="text-secondary" />
+      <Close12Icon className="text-default" />
     </Dialog.Close>
   </footer>
 )

--- a/app/ui/lib/SideModal.tsx
+++ b/app/ui/lib/SideModal.tsx
@@ -148,7 +148,7 @@ function SideModalBody({ children }: { children?: ReactNode }) {
 
 SideModal.Body = SideModalBody
 
-SideModal.Heading = classed.div`text-sans-semi-xl`
+SideModal.Heading = classed.div`text-sans-semi-xl text-raise`
 
 SideModal.Section = classed.div`p-8 space-y-6 border-secondary`
 

--- a/app/ui/lib/Slash.tsx
+++ b/app/ui/lib/Slash.tsx
@@ -6,5 +6,5 @@
  * Copyright Oxide Computer Company
  */
 export const Slash = () => (
-  <span className="mx-1 text-quinary selected:text-accent-disabled">/</span>
+  <span className="mx-1 text-quaternary selected:text-accent-disabled">/</span>
 )

--- a/app/ui/lib/Table.tsx
+++ b/app/ui/lib/Table.tsx
@@ -40,7 +40,7 @@ Table.HeaderRow = (props: TableHeaderRowProps) => <Table.Row {...props} />
 
 export type TableHeaderProps = JSX.IntrinsicElements['thead']
 Table.Header = ({ children, className }: TableHeaderProps) => (
-  <thead className={cn('text-left text-mono-sm text-tertiary', className)}>
+  <thead className={cn('text-left text-mono-sm text-secondary', className)}>
     {children}
   </thead>
 )
@@ -96,7 +96,7 @@ Table.Cell = ({ height = 'small', className, children, ...props }: TableCellProp
   <td
     className={cn(
       className,
-      'pl-0 text-default border-default children:first:border-l-0 children:last:-mr-[1px]'
+      'pl-0 text-raise border-default children:first:border-l-0 children:last:-mr-[1px]'
     )}
     {...props}
   >
@@ -124,4 +124,4 @@ export const TableEmptyBox = classed.div`flex h-full max-h-[480px] items-center 
  * along with a link to more info, and a button to take action on the resource listed in the table.
  */
 export const TableControls = classed.div`mb-4 flex items-end justify-between space-x-8`
-export const TableTitle = classed.div`text-sans-lg text-default`
+export const TableTitle = classed.div`text-sans-lg text-raise`

--- a/app/ui/lib/Table.tsx
+++ b/app/ui/lib/Table.tsx
@@ -115,7 +115,7 @@ Table.Cell = ({ height = 'small', className, children, ...props }: TableCellProp
  * Used _outside_ of the `Table`, this element wraps buttons that sit on top
  * of the table.
  */
-export const TableActions = classed.div`-mt-11 mb-3 flex justify-end gap-2`
+export const TableActions = classed.div`-mt-6 mb-3 flex justify-end gap-2`
 
 export const TableEmptyBox = classed.div`flex h-full max-h-[480px] items-center justify-center rounded-lg border border-secondary p-4`
 

--- a/app/ui/lib/Tag.tsx
+++ b/app/ui/lib/Tag.tsx
@@ -31,7 +31,7 @@ export const tagColors: Record<TagVariant, Partial<Record<TagColor, string>>> = 
     default: 'bg-accent-secondary text-accent',
     destructive: 'bg-destructive-secondary text-destructive',
     notice: 'bg-notice-secondary text-notice',
-    neutral: 'bg-secondary text-secondary',
+    neutral: 'bg-secondary text-default',
   },
 }
 

--- a/app/ui/lib/TextInput.tsx
+++ b/app/ui/lib/TextInput.tsx
@@ -85,7 +85,7 @@ export const TextInput = React.forwardRef<
           type={type}
           value={value}
           className={cn(
-            `w-full rounded border-none px-3 py-[0.6875rem] !outline-offset-1 text-sans-md text-default bg-default placeholder:text-quaternary focus:outline-none disabled:cursor-not-allowed disabled:text-tertiary disabled:bg-disabled`,
+            `w-full rounded border-none px-3 py-[0.6875rem] !outline-offset-1 text-sans-md text-raise bg-default placeholder:text-tertiary focus:outline-none disabled:cursor-not-allowed disabled:text-secondary disabled:bg-disabled`,
             error && 'focus-error',
             fieldClassName,
             disabled && 'text-disabled bg-disabled',
@@ -121,7 +121,7 @@ export const TextInputHint = ({ id, children, className }: HintProps) => (
   <div
     id={id}
     className={cn(
-      'mt-1 text-sans-sm text-tertiary [&_>_a]:underline hover:[&_>_a]:text-default',
+      'mt-1 text-sans-sm text-secondary [&_>_a]:underline hover:[&_>_a]:text-raise',
       className
     )}
   >

--- a/app/ui/lib/TipIcon.tsx
+++ b/app/ui/lib/TipIcon.tsx
@@ -22,7 +22,7 @@ export function TipIcon({ children, className }: TipIconProps) {
         className={cn('inline-flex [&>svg]:pointer-events-none', className)}
         type="button"
       >
-        <Question12Icon className="text-quinary" />
+        <Question12Icon className="text-quaternary" />
       </button>
     </Tooltip>
   )

--- a/app/ui/styles/components/Tabs.css
+++ b/app/ui/styles/components/Tabs.css
@@ -2,7 +2,7 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, you can obtain one at https://mozilla.org/MPL/2.0/.
- *  
+ *
  * Copyright Oxide Computer Company
  */
 
@@ -32,7 +32,7 @@
 }
 
 .ox-tab {
-  @apply h-10 space-x-2 whitespace-nowrap border-b px-1.5 pb-1 pt-2 uppercase !no-underline text-mono-sm text-tertiary border-secondary;
+  @apply h-10 space-x-2 whitespace-nowrap border-b px-1.5 pb-1 pt-2 uppercase !no-underline text-mono-sm text-secondary border-secondary;
 }
 
 .ox-tab[data-state='active'],

--- a/app/ui/styles/components/button.css
+++ b/app/ui/styles/components/button.css
@@ -2,7 +2,7 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, you can obtain one at https://mozilla.org/MPL/2.0/.
- *  
+ *
  * Copyright Oxide Computer Company
  */
 
@@ -22,11 +22,11 @@
 }
 
 .btn-secondary {
-  @apply text-secondary bg-secondary hover:bg-hover disabled:text-quaternary disabled:bg-secondary;
+  @apply text-default bg-secondary hover:bg-hover disabled:text-tertiary disabled:bg-secondary;
 }
 .btn-secondary:disabled > .spinner,
 .btn-secondary.visually-disabled > .spinner {
-  @apply text-secondary;
+  @apply text-default;
 }
 
 .btn-danger {
@@ -38,7 +38,7 @@
 }
 
 .btn-ghost {
-  @apply border text-secondary border-default hover:bg-hover disabled:bg-transparent disabled:text-disabled;
+  @apply border text-default border-default hover:bg-hover disabled:bg-transparent disabled:text-disabled;
 }
 .btn-ghost:after {
   @apply hidden;

--- a/app/ui/styles/components/menu-button.css
+++ b/app/ui/styles/components/menu-button.css
@@ -2,7 +2,7 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, you can obtain one at https://mozilla.org/MPL/2.0/.
- *  
+ *
  * Copyright Oxide Computer Company
  */
 
@@ -11,7 +11,7 @@
   @apply z-topBarDropdown min-w-36 rounded border p-0 bg-raise border-secondary;
 
   & .DropdownMenuItem {
-    @apply block w-full cursor-pointer select-none border-b py-2 pl-3 pr-6 text-left text-sans-md text-secondary border-secondary last:border-b-0;
+    @apply block w-full cursor-pointer select-none border-b py-2 pl-3 pr-6 text-left text-sans-md text-default border-secondary last:border-b-0;
 
     &.destructive {
       @apply text-destructive;

--- a/app/ui/styles/components/menu-list.css
+++ b/app/ui/styles/components/menu-list.css
@@ -2,7 +2,7 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, you can obtain one at https://mozilla.org/MPL/2.0/.
- *  
+ *
  * Copyright Oxide Computer Company
  */
 
@@ -11,7 +11,7 @@
 }
 
 .ox-menu-item {
-  @apply relative cursor-pointer px-3 py-2 text-sans-md text-default;
+  @apply text-raise relative cursor-pointer px-3 py-2 text-sans-md;
 }
 
 .ox-menu-item.is-highlighted {

--- a/app/ui/styles/components/table.css
+++ b/app/ui/styles/components/table.css
@@ -2,7 +2,7 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, you can obtain one at https://mozilla.org/MPL/2.0/.
- *  
+ *
  * Copyright Oxide Computer Company
  */
 
@@ -32,7 +32,7 @@ table.ox-table {
   & td {
     min-width: fit-content;
     white-space: nowrap;
-    @apply text-secondary;
+    @apply text-default;
   }
 
   /*

--- a/app/ui/styles/components/tooltip.css
+++ b/app/ui/styles/components/tooltip.css
@@ -2,12 +2,12 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, you can obtain one at https://mozilla.org/MPL/2.0/.
- *  
+ *
  * Copyright Oxide Computer Company
  */
 
 .ox-tooltip {
-  @apply rounded border p-2 text-sans-md text-secondary bg-raise border-secondary elevation-2;
+  @apply rounded border p-2 text-sans-md text-default bg-raise border-secondary elevation-2;
 }
 
 .ox-tooltip-arrow {

--- a/app/ui/styles/index.css
+++ b/app/ui/styles/index.css
@@ -62,7 +62,7 @@
   /* https://github.com/tailwindlabs/tailwindcss/blob/v2.2.4/src/plugins/css/preflight.css#L57 */
   input::placeholder,
   textarea::placeholder {
-    @apply text-tertiary;
+    @apply text-secondary;
   }
 
   /* https://github.com/tailwindlabs/tailwindcss/blob/v2.2.4/src/plugins/css/preflight.css#L224 */
@@ -84,9 +84,9 @@
   }
 
   .link-with-underline {
-    @apply text-secondary hover:text-default;
+    @apply text-raise;
     text-decoration: underline;
-    text-decoration-color: var(--content-quinary);
+    text-decoration-color: var(--content-quaternary);
 
     &:hover {
       text-decoration-color: var(--content-tertiary);
@@ -149,4 +149,12 @@ textarea[type='text']:focus:not(:focus-visible),
 input[type='radio']:focus:not(:focus-visible),
 input[type='checkbox']:focus:not(:focus-visible) {
   @apply outline-transparent;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5 {
+  @apply text-raise;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@floating-ui/react": "^0.26.23",
         "@headlessui/react": "^2.1.8",
-        "@oxide/design-system": "^1.6.1",
+        "@oxide/design-system": "^1.6.5--canary.f8dd1ac.0",
         "@radix-ui/react-accordion": "^1.2.0",
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-focus-guards": "1.0.1",
@@ -1941,10 +1941,9 @@
       "license": "MIT"
     },
     "node_modules/@oxide/design-system": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@oxide/design-system/-/design-system-1.6.2.tgz",
-      "integrity": "sha512-SWTa7+cMXYvO4OwMfyXb4lgILrgEse4afu957wrEl8++Quf9MivcifrDuim+4t33C5hZtdL6AojdjGd7cTRzNA==",
-      "license": "MPL 2.0",
+      "version": "1.6.5--canary.f8dd1ac.0",
+      "resolved": "https://registry.npmjs.org/@oxide/design-system/-/design-system-1.6.5--canary.f8dd1ac.0.tgz",
+      "integrity": "sha512-yCJ7wy1POPw5tjW4GLeLSdu3VlkVPgAzDgNG8498O3jC9Snw4jw0e35DOFr6BaxOuhrKASfJYrutyM4FziBYaw==",
       "dependencies": {
         "@floating-ui/react": "^0.25.1",
         "@headlessui/react": "^1.7.17",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@floating-ui/react": "^0.26.23",
         "@headlessui/react": "^2.1.8",
-        "@oxide/design-system": "^1.6.5--canary.f8dd1ac.0",
+        "@oxide/design-system": "^1.7.0",
         "@radix-ui/react-accordion": "^1.2.0",
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-focus-guards": "1.0.1",
@@ -1941,9 +1941,9 @@
       "license": "MIT"
     },
     "node_modules/@oxide/design-system": {
-      "version": "1.6.5--canary.f8dd1ac.0",
-      "resolved": "https://registry.npmjs.org/@oxide/design-system/-/design-system-1.6.5--canary.f8dd1ac.0.tgz",
-      "integrity": "sha512-yCJ7wy1POPw5tjW4GLeLSdu3VlkVPgAzDgNG8498O3jC9Snw4jw0e35DOFr6BaxOuhrKASfJYrutyM4FziBYaw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@oxide/design-system/-/design-system-1.7.0.tgz",
+      "integrity": "sha512-ItBwJJFrwkGWyPKKU21YxA4sphTMMqD0V73xyf4cJV5kCeQa2yFkrkuXzAL91zB6DaacDFwUXTfwn8kEawZYvA==",
       "dependencies": {
         "@floating-ui/react": "^0.25.1",
         "@headlessui/react": "^1.7.17",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@floating-ui/react": "^0.26.23",
         "@headlessui/react": "^2.1.8",
-        "@oxide/design-system": "^1.7.0",
+        "@oxide/design-system": "^1.7.2",
         "@radix-ui/react-accordion": "^1.2.0",
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-focus-guards": "1.0.1",
@@ -1941,9 +1941,9 @@
       "license": "MIT"
     },
     "node_modules/@oxide/design-system": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@oxide/design-system/-/design-system-1.7.0.tgz",
-      "integrity": "sha512-ItBwJJFrwkGWyPKKU21YxA4sphTMMqD0V73xyf4cJV5kCeQa2yFkrkuXzAL91zB6DaacDFwUXTfwn8kEawZYvA==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@oxide/design-system/-/design-system-1.7.2.tgz",
+      "integrity": "sha512-irP+7mcZ0Mx0SQ50NcnVbdUQqqOYcqArmWGbYzEas0JnQz7hr0LSm7oUpnyDhJO3GwtUV3n2XUjmCjLgeWR1xA==",
       "dependencies": {
         "@floating-ui/react": "^0.25.1",
         "@headlessui/react": "^1.7.17",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@floating-ui/react": "^0.26.23",
     "@headlessui/react": "^2.1.8",
-    "@oxide/design-system": "^1.7.0",
+    "@oxide/design-system": "^1.7.2",
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-focus-guards": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@floating-ui/react": "^0.26.23",
     "@headlessui/react": "^2.1.8",
-    "@oxide/design-system": "^1.6.1",
+    "@oxide/design-system": "^1.6.5--canary.f8dd1ac.0",
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-focus-guards": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@floating-ui/react": "^0.26.23",
     "@headlessui/react": "^2.1.8",
-    "@oxide/design-system": "^1.6.5--canary.f8dd1ac.0",
+    "@oxide/design-system": "^1.7.0",
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-focus-guards": "1.0.1",


### PR DESCRIPTION
Implementation of https://github.com/oxidecomputer/design-system/pull/93

<img width="866" alt="image" src="https://github.com/user-attachments/assets/e47f84b0-b46c-4be5-bccd-0e53e9f51834">

`content-secondary` -> `content-default` and now becomes the standard text colour.

Old `content-default` dimmed slightly and becomes `content-raise` and used in more places.