### PR TITLE
Try to make instance create e2e less flaky

### DIFF
--- a/test/e2e/instance-create.e2e.ts
+++ b/test/e2e/instance-create.e2e.ts
@@ -8,6 +8,7 @@
 import { floatingIp } from '@oxide/api-mocks'
 
 import {
+  closeToast,
   expect,
   expectNotVisible,
   expectRowVisible,
@@ -99,14 +100,7 @@ test('can create an instance', async ({ page }) => {
 
   await page.getByRole('button', { name: 'Create instance' }).click()
 
-  await expect(page).toHaveURL(`/projects/mock-project/instances/${instanceName}/storage`)
-
-  await expectVisible(page, [
-    `h1:has-text("${instanceName}")`,
-    'text=16 vCPUs',
-    'text=64 GiB',
-    'text=from space',
-  ])
+  await closeToast(page)
 
   // instance goes from creating to starting to running as we poll
   const pollingSpinner = page.getByLabel('Spinner')
@@ -115,6 +109,14 @@ test('can create an instance', async ({ page }) => {
   await expect(page.getByText('Starting')).toBeVisible()
   await expect(page.getByText('Running')).toBeVisible()
   await expect(pollingSpinner).toBeHidden()
+
+  // do this after state checks because sometimes it takes too long and we miss 'creating'
+  await expect(page).toHaveURL(`/projects/mock-project/instances/${instanceName}/storage`)
+
+  await expect(page.getByRole('heading', { name: instanceName })).toBeVisible()
+  await expect(page.getByText('16 vCPUs')).toBeVisible()
+  await expect(page.getByText('64 GiB')).toBeVisible()
+  await expect(page.getByText('from space')).toBeVisible()
 
   // boot disk visible, no other disks attached
   await expect(
@@ -194,12 +196,10 @@ test('can create an instance with custom hardware', async ({ page }) => {
 
   await expect(page).toHaveURL(`/projects/mock-project/instances/${instanceName}/storage`)
 
-  await expectVisible(page, [
-    `h1:has-text("${instanceName}")`,
-    'text=29 vCPUs',
-    'text=53 GiB',
-    'text=from space',
-  ])
+  await expect(page.getByRole('heading', { name: instanceName })).toBeVisible()
+  await expect(page.getByText('29 vCPUs')).toBeVisible()
+  await expect(page.getByText('53 GiB')).toBeVisible()
+  await expect(page.getByText('from space')).toBeVisible()
 })
 
 test('automatically updates disk size when larger image selected', async ({ page }) => {


### PR DESCRIPTION
Reordering things so we're less likely to miss the `creating` state in this common flake scenario.

<img width="907" alt="image" src="https://github.com/user-attachments/assets/d31b26e2-0ec9-40ba-afa7-0896bd886633">
