### PR TITLE
minor: Lengthen instance creating state so e2es are less likely to miss it

### DIFF
--- a/mock-api/msw/handlers.ts
+++ b/mock-api/msw/handlers.ts
@@ -574,7 +574,7 @@ export const handlers = makeHandlers({
 
     setTimeout(() => {
       newInstance.run_state = 'starting'
-    }, 500)
+    }, 1000)
 
     setTimeout(() => {
       newInstance.run_state = 'running'

--- a/test/e2e/instance-serial.e2e.ts
+++ b/test/e2e/instance-serial.e2e.ts
@@ -17,7 +17,8 @@ test('serial console can connect while starting', async ({ page }) => {
   await page.getByRole('button', { name: 'Create instance' }).click()
 
   // now go starting to its serial console page while it's starting up
-  await expect(page).toHaveURL('/projects/mock-project/instances/abc/storage')
+  // don't check for URL before clicking because it takes too long, causing
+  // us to miss the creating state
   await page.getByRole('tab', { name: 'Connect' }).click()
   await page.getByRole('main').getByRole('link', { name: 'Connect' }).click()
 


### PR DESCRIPTION
Trying to improve this flake.

```
    Error: Timed out 5000ms waiting for expect(locator).toBeVisible()

    Locator: getByText('Waiting for the instance to start')
    Expected: visible
    Received: <element(s) not found>
    Call log:
      - expect.toBeVisible with timeout 5000ms
      - waiting for getByText('Waiting for the instance to start')


      25 |   // the instance is running. skip the check for "creating" because it can
      26 |   // go by quickly
    > 27 |   await expect(page.getByText('Waiting for the instance to start')).toBeVisible()
         |                                                                     ^
      28 |   await expect(page.getByText('The instance is starting')).toBeVisible()
      29 |   await expect(page.getByText('The instance is')).toBeHidden()
      30 |
        at /Users/runner/work/console/console/test/e2e/instance-serial.e2e.ts:27:69

    attachment #1: trace (application/zip) ─────────────────────────────────────────────────────────
    test-results/instance-serial.e2e.ts-ser-4b5df--can-connect-while-starting-safari-retry1/trace.zip
    Usage:

        npx playwright show-trace test-results/instance-serial.e2e.ts-ser-4b5df--can-connect-while-starting-safari-retry1/trace.zip
```