### PR TITLE
chore: Convert tailwind config to typescript file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@floating-ui/react": "^0.26.23",
         "@headlessui/react": "^2.1.8",
-        "@oxide/design-system": "1.7.3--canary.590d298.0",
+        "@oxide/design-system": "^1.7.3",
         "@radix-ui/react-accordion": "^1.2.0",
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-focus-guards": "1.0.1",
@@ -1725,9 +1725,9 @@
       "license": "MIT"
     },
     "node_modules/@oxide/design-system": {
-      "version": "1.7.3--canary.590d298.0",
-      "resolved": "https://registry.npmjs.org/@oxide/design-system/-/design-system-1.7.3--canary.590d298.0.tgz",
-      "integrity": "sha512-A8euQ/g/x9BPdfnONuy0NMRUvMh7HR8xb4CoLrd6SQloQPIYsHkXMeXhDAWHC46Rtko4KTLvvYQDNq64rSrR4w==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@oxide/design-system/-/design-system-1.7.3.tgz",
+      "integrity": "sha512-Rzl83vWFBjrXqNvNup44klI1SfLcpVXVad8TYgikD2AcvASrt8YRFCy4vw0gQFlWIGHhPCHvbgrt+CGjYi8awg==",
       "license": "MPL 2.0",
       "dependencies": {
         "@floating-ui/react": "^0.25.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@floating-ui/react": "^0.26.23",
         "@headlessui/react": "^2.1.8",
-        "@oxide/design-system": "^1.7.2",
+        "@oxide/design-system": "1.7.3--canary.590d298.0",
         "@radix-ui/react-accordion": "^1.2.0",
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-focus-guards": "1.0.1",
@@ -1725,9 +1725,10 @@
       "license": "MIT"
     },
     "node_modules/@oxide/design-system": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@oxide/design-system/-/design-system-1.7.2.tgz",
-      "integrity": "sha512-irP+7mcZ0Mx0SQ50NcnVbdUQqqOYcqArmWGbYzEas0JnQz7hr0LSm7oUpnyDhJO3GwtUV3n2XUjmCjLgeWR1xA==",
+      "version": "1.7.3--canary.590d298.0",
+      "resolved": "https://registry.npmjs.org/@oxide/design-system/-/design-system-1.7.3--canary.590d298.0.tgz",
+      "integrity": "sha512-A8euQ/g/x9BPdfnONuy0NMRUvMh7HR8xb4CoLrd6SQloQPIYsHkXMeXhDAWHC46Rtko4KTLvvYQDNq64rSrR4w==",
+      "license": "MPL 2.0",
       "dependencies": {
         "@floating-ui/react": "^0.25.1",
         "@headlessui/react": "^1.7.17",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@floating-ui/react": "^0.26.23",
     "@headlessui/react": "^2.1.8",
-    "@oxide/design-system": "^1.7.2",
+    "@oxide/design-system": "1.7.3--canary.590d298.0",
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-focus-guards": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@floating-ui/react": "^0.26.23",
     "@headlessui/react": "^2.1.8",
-    "@oxide/design-system": "1.7.3--canary.590d298.0",
+    "@oxide/design-system": "^1.7.3",
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-focus-guards": "1.0.1",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,20 +6,17 @@
  * Copyright Oxide Computer Company
  */
 
-// @ts-check
+import { type Config } from 'tailwindcss'
+import plugin from 'tailwindcss/plugin'
 
-/** @type {import('tailwindcss/lib/util/createPlugin').default} */
-// @ts-expect-error
-const plugin = require('tailwindcss/plugin')
-const {
-  textUtilities,
-  colorUtilities,
+import {
   borderRadiusTokens,
+  colorUtilities,
   elevationUtilities,
-} = require('@oxide/design-system/styles/dist/tailwind-tokens.js')
+  textUtilities,
+} from '@oxide/design-system/styles/dist/tailwind-tokens.js'
 
-/** @type {import('tailwindcss/tailwind-config').TailwindConfig} */
-module.exports = {
+export default {
   corePlugins: {
     fontFamily: false,
     fontSize: false,
@@ -66,23 +63,13 @@ module.exports = {
     },
   },
   plugins: [
-    plugin(({ addVariant, addUtilities, variants }) => {
+    plugin(({ addVariant, addUtilities }) => {
       addVariant('children', '& > *')
       addVariant('selected', '.is-selected &')
       addVariant('disabled', ['&.visually-disabled', '&:disabled'])
-      addUtilities(
-        Array.from({ length: 12 }, (_, i) => i)
-          .map((i) => ({
-            [`.grid-col-${i}`]: {
-              'grid-column': `${i}`,
-            },
-          }))
-          .reduce((p, c) => ({ ...p, ...c }), {}),
-        variants
-      )
       addUtilities(textUtilities)
       addUtilities(colorUtilities)
       addUtilities(elevationUtilities)
     }),
   ],
-}
+} satisfies Config

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -54,7 +54,7 @@ export default {
       },
     },
     borderRadius: {
-      none: 0,
+      none: '0',
       ...borderRadiusTokens,
     },
     colors: {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -14,7 +14,7 @@ import {
   colorUtilities,
   elevationUtilities,
   textUtilities,
-} from '@oxide/design-system/styles/dist/tailwind-tokens.js'
+} from '@oxide/design-system/styles/dist/tailwind-tokens.ts'
 
 export default {
   corePlugins: {


### PR DESCRIPTION
Our janky old JS file gets rejected by [Node.js v22.12](https://github.com/nodejs/node/releases/tag/v22.12.0), which in theory is supposed to make `require` work _better_, but we're probably doing something ugly. Fortunately we have no need to use `require`.