### PR TITLE
Fix e2e flake by not consuming abort signal in `apiq` query options helper

### DIFF
--- a/app/api/hooks.ts
+++ b/app/api/hooks.ts
@@ -108,7 +108,7 @@ export const getApiQueryOptions =
     queryOptions({
       queryKey: [method, params],
       // no catch, let unexpected errors bubble up
-      queryFn: ({ signal }) => api[method](params, { signal }).then(handleResult(method)),
+      queryFn: () => api[method](params).then(handleResult(method)),
       // In the case of 404s, let the error bubble up to the error boundary so
       // we can say Not Found. If you need to allow a 404 and want it to show
       // up as `error` state instead, pass `useErrorBoundary: false` as an


### PR DESCRIPTION
## Short version

Passing React Query's abort signal into our API `fetch` calls means the calls get aborted when queries get canceled due to being unmounted. One inconvenient time for this to happen is when React [Strict Mode](https://react.dev/reference/react/StrictMode) does its thing in dev mode, causing an unmount and remount in the middle of a prefetch in a loader, which doesn't itself blow up because `prefetchQuery` eats errors, but components that expect prefetched data do blow up because the prefetch failed to populate the query cache. There isn't much advantage to canceling queries, so we can fix this by just not passing the signal through.

## Medium version

With #2597 we started using an options helper with `prefetchQuery` that passes the abort `signal` from React Query through into our API calls, which means they get aborted when RQ cancels a query. The existing `prefetchQuery` did not pass through the `signal`.

React's strict mode does everything twice (in development mode only) in order to surface things that should be cleaned up and redone between renders, and when it unmounts and remounts the firewall rules query, that causes RQ to cancel the fetch, which was causing our API call to abort, which means it wasn't in the query cache when `usePrefetchedQuery` expects it to be. I assume it only happens some of the time because of a race, though I don't understand yet what is racing. It's not a race with the request completing because lowering the mock API's [random latency of 200-400ms](https://github.com/oxidecomputer/console/blob/0b5220a1ce8a95dbd3b1dcac902a0d68927bb459/app/msw-mock-api.ts#L66) to 50-100ms does not seem to affect the rate of failure.

In any case, after reading the React Query doc on [Query Cancellation](https://tanstack.com/query/v5/docs/framework/react/guides/query-cancellation), I don't think we actually ever need to pass through the abort signal, whether for prefetches or regular queries. There's very little advantage to canceling a request that's already in flight unless you're trying to avoid downloading some big response. Mutations might make more sense to cancel. We take advantage of this during image upload, for example, where we have 6 requests in flight. It makes sense to cancel outstanding ones rather than letting them complete. Mutations are unaffected by this `apiq` helper — for now we are still using the old `useApiMutation` for all mutations.

## The story of my pain

Beginning with #2597 (though I didn't notice for a few days) we started having a test flake in the create VPC e2e test ([example failure](https://github.com/oxidecomputer/console/actions/runs/12263567952/job/34216144123)). It was reproducible locally in multiple browsers. It failed about half the time with a prefetch error after the transition to VPC detail for a newly created VPC (line 40).

https://github.com/oxidecomputer/console/blob/0b5220a1ce8a95dbd3b1dcac902a0d68927bb459/test/e2e/networking.e2e.ts#L33-L40

The error showed up as a failure of the firewall rules prefetch to seed the cache. The query was there after the prefetch call but stuck in `pending`:

![error shot](https://github.com/user-attachments/assets/49e9ea08-8883-4de0-97b5-dca5c8062843)

It turned out this one line from #2597 was enough to cause the problem.


```diff
 VpcFirewallRulesTab.loader = async ({ params }: LoaderFunctionArgs) => {
   const { project, vpc } = getVpcSelector(params)
-  await apiQueryClient.prefetchQuery('vpcFirewallRulesView', { query: { project, vpc } })
+  await queryClient.prefetchQuery(apiq('vpcFirewallRulesView', { query: { project, vpc } }))
   return null
 }
```

See if you can spot the difference between the two implementations involved:

### `apiq`

https://github.com/oxidecomputer/console/blob/0b5220a1ce8a95dbd3b1dcac902a0d68927bb459/app/api/hooks.ts#L111

### `apiQueryClient.prefetchQuery`

https://github.com/oxidecomputer/console/blob/0b5220a1ce8a95dbd3b1dcac902a0d68927bb459/app/api/hooks.ts#L317

### CancelledError

The cause was hard to figure out with `prefetchQuery` because that function [eats all errors](https://github.com/TanStack/query/blob/1eebfc9d3355c411b16146cc8df76c18e63d59ad/packages/query-core/src/queryClient.ts#L429-L438) with a `.catch(noop)`. To see what was actually going wrong, I changed it to a `fetchQuery`, which does through errors if they happen, and showed me this was a `CancelledError` coming out RQ cleaning up a subscribe due to `commitDoubleInvokeEffectsInDEV`, is a strict mode thing.

<details>
<summary><code>CancelledError</code> stack trace</summary>
    
```
Error: CancelledError

CancelledError — retryer.ts:62
cancel — retryer.ts:84
removeObserver — query.ts:329
destroy — queryObserver.ts:143
onUnsubscribe — queryObserver.ts:119
(anonymous function) — subscribable.ts:15
safelyCallDestroy — react-dom.development.js:22971
commitHookEffectListUnmount — react-dom.development.js:23139
invokePassiveEffectUnmountInDEV — react-dom.development.js:25246
invokeEffectsInDev — react-dom.development.js:27390
commitDoubleInvokeEffectsInDEV — react-dom.development.js:27363
flushPassiveEffectsImpl — react-dom.development.js:27095
flushPassiveEffects — react-dom.development.js:27023
commitRootImpl — react-dom.development.js:26974
commitRoot — react-dom.development.js:26721
performSyncWorkOnRoot — react-dom.development.js:26156
flushSyncCallbacks — react-dom.development.js:12042
(anonymous function) — react-dom.development.js:25690
```

</details>