### PR TITLE
Add confirmation modal for disk detachment

### DIFF
--- a/app/pages/project/instances/instance/tabs/StorageTab.tsx
+++ b/app/pages/project/instances/instance/tabs/StorageTab.tsx
@@ -87,7 +87,7 @@ export function Component() {
     [instanceName, project]
   )
 
-  const { mutate: detachDisk } = useApiMutation('instanceDiskDetach', {
+  const { mutateAsync: detachDisk } = useApiMutation('instanceDiskDetach', {
     onSuccess(disk) {
       queryClient.invalidateQueries('instanceDiskList')
       addToast(<>Disk <HL>{disk.name}</HL> detached</>) // prettier-ignore
@@ -257,9 +257,19 @@ export function Component() {
             detached
           </>
         ),
-        onActivate() {
-          detachDisk({ body: { disk: disk.name }, path: { instance: instance.id } })
-        },
+        onActivate: () =>
+          confirmAction({
+            doAction: () =>
+              detachDisk({ body: { disk: disk.name }, path: { instance: instance.id } }),
+            errorTitle: 'Could not detach disk',
+            modalTitle: 'Confirm detach disk',
+            modalContent: (
+              <p>
+                Are you sure you want to detach <HL>{disk.name}</HL>?
+              </p>
+            ),
+            actionType: 'primary',
+          }),
       },
     ],
     [detachDisk, instanceUpdate, instance, getSnapshotAction, bootDisks, ncpus, memory]

--- a/app/pages/project/instances/instance/tabs/StorageTab.tsx
+++ b/app/pages/project/instances/instance/tabs/StorageTab.tsx
@@ -268,7 +268,7 @@ export function Component() {
                 Are you sure you want to detach <HL>{disk.name}</HL>?
               </p>
             ),
-            actionType: 'primary',
+            actionType: 'danger',
           }),
       },
     ],

--- a/app/pages/project/instances/instance/tabs/StorageTab.tsx
+++ b/app/pages/project/instances/instance/tabs/StorageTab.tsx
@@ -263,11 +263,7 @@ export function Component() {
               detachDisk({ body: { disk: disk.name }, path: { instance: instance.id } }),
             errorTitle: 'Could not detach disk',
             modalTitle: 'Confirm detach disk',
-            modalContent: (
-              <p>
-                Are you sure you want to detach <HL>{disk.name}</HL>?
-              </p>
-            ),
+            modalContent: <p>Are you sure you want to detach <HL>{disk.name}</HL>?</p>, // prettier-ignore
             actionType: 'danger',
           }),
       },

--- a/test/e2e/instance-disks.e2e.ts
+++ b/test/e2e/instance-disks.e2e.ts
@@ -138,6 +138,7 @@ test('Detach disk', async ({ page }) => {
   await expect(successMsg).toBeHidden()
 
   await clickRowAction(page, 'disk-2', 'Detach')
+  await page.getByRole('button', { name: 'Confirm' }).click()
   await expect(successMsg).toBeVisible()
   await expect(row).toBeHidden() // disk row goes away
 })

--- a/test/e2e/instance-disks.e2e.ts
+++ b/test/e2e/instance-disks.e2e.ts
@@ -203,6 +203,7 @@ test('Change boot disk', async ({ page }) => {
 
   // detach disk so there's only one
   await clickRowAction(page, 'disk-2', 'Detach')
+  await page.getByRole('button', { name: 'Confirm' }).click()
 
   await expect(page.getByText('Instance will boot from disk-1')).toBeVisible()
 
@@ -220,6 +221,8 @@ test('Change boot disk', async ({ page }) => {
   await expectRowVisible(otherDisksTable, disk1)
 
   await clickRowAction(page, 'disk-1', 'Detach')
+  await page.getByRole('button', { name: 'Confirm' }).click()
+
   await expect(noBootDisk).toBeVisible()
   await expect(noOtherDisks).toBeVisible()
 


### PR DESCRIPTION
This PR adds a confirmation modal when detaching a disk from an instance.

<img width="463" alt="Screenshot 2024-12-11 at 5 17 11 PM" src="https://github.com/user-attachments/assets/8b2a1896-121f-4b69-8479-ada98d15b8ec" />

Closes #2613