### PR TITLE
Prevent the sidemodal form from immediately erroring when using the action menu

### DIFF
--- a/app/ui/lib/ActionMenu.tsx
+++ b/app/ui/lib/ActionMenu.tsx
@@ -99,6 +99,7 @@ export function ActionMenu(props: ActionMenuProps) {
               if (e.key === KEYS.enter) {
                 if (selectedItem) {
                   selectedItem.onSelect()
+                  e.preventDefault()
                   onDismiss()
                 }
               } else if (e.key === KEYS.down) {

--- a/test/e2e/action-menu.e2e.ts
+++ b/test/e2e/action-menu.e2e.ts
@@ -1,0 +1,29 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
+ */
+import { expect, test, type Page } from '@playwright/test'
+
+import { expectNotVisible } from './utils'
+
+const openActionMenu = async (page: Page) => {
+  // open the action menu (use the sidenav button, as keyboard events aren't reliable in Playwright)
+  await page.getByRole('button', { name: 'JUMP TO' }).click()
+  // make sure the action menu modal is visible
+  await expect(page.getByRole('heading', { name: 'Actions' })).toBeVisible()
+}
+
+test('Ensure that the Enter key in the ActionMenu doesn’t prematurely submit a linked form', async ({
+  page,
+}) => {
+  await page.goto('/system/silos')
+  await openActionMenu(page)
+  // "New silo" is the first item in the list, so we can just hit enter to open the modal
+  await page.keyboard.press('Enter')
+  await expect(page.getByRole('dialog', { name: 'Create silo' })).toBeVisible()
+  // make sure error text is not visible
+  await expectNotVisible(page, [page.getByText('Name is required')])
+})

--- a/test/e2e/action-menu.e2e.ts
+++ b/test/e2e/action-menu.e2e.ts
@@ -13,7 +13,7 @@ const openActionMenu = async (page: Page) => {
   // open the action menu (use the sidenav button, as keyboard events aren't reliable in Playwright)
   await page.getByRole('button', { name: 'JUMP TO' }).click()
   // make sure the action menu modal is visible
-  await expect(page.getByRole('heading', { name: 'Actions' })).toBeVisible()
+  await expect(page.getByText('Enterto submit')).toBeVisible()
 }
 
 test('Ensure that the Enter key in the ActionMenu doesn’t prematurely submit a linked form', async ({

--- a/test/e2e/silos.e2e.ts
+++ b/test/e2e/silos.e2e.ts
@@ -164,6 +164,19 @@ test('Create silo', async ({ page }) => {
   await expect(otherSiloCell).toBeHidden()
 })
 
+test('Open create silo modal from ActionMenu', async ({ page }) => {
+  await page.goto('/system/silos')
+  // open the action menu
+  await page.getByRole('button', { name: 'JUMP TO' }).click()
+  // make sure the action menu modal is visible
+  await expect(page.getByRole('heading', { name: 'Actions' })).toBeVisible()
+  // New silo is the first item in the list, so we can just hit enter to open the modal
+  await page.keyboard.press('Enter')
+  await expect(page.getByRole('dialog', { name: 'Create silo' })).toBeVisible()
+  // make sure error text is not visible
+  await expectNotVisible(page, [page.getByText('Name is required')])
+})
+
 test('Default silo', async ({ page }) => {
   await page.goto('/system/silos')
   await page.getByRole('link', { name: 'myriad' }).click()

--- a/test/e2e/silos.e2e.ts
+++ b/test/e2e/silos.e2e.ts
@@ -164,19 +164,6 @@ test('Create silo', async ({ page }) => {
   await expect(otherSiloCell).toBeHidden()
 })
 
-test('Open create silo modal from ActionMenu', async ({ page }) => {
-  await page.goto('/system/silos')
-  // open the action menu
-  await page.getByRole('button', { name: 'JUMP TO' }).click()
-  // make sure the action menu modal is visible
-  await expect(page.getByRole('heading', { name: 'Actions' })).toBeVisible()
-  // New silo is the first item in the list, so we can just hit enter to open the modal
-  await page.keyboard.press('Enter')
-  await expect(page.getByRole('dialog', { name: 'Create silo' })).toBeVisible()
-  // make sure error text is not visible
-  await expectNotVisible(page, [page.getByText('Name is required')])
-})
-
 test('Default silo', async ({ page }) => {
   await page.goto('/system/silos')
   await page.getByRole('link', { name: 'myriad' }).click()


### PR DESCRIPTION
This adds an `event.preventDefault()` to the Action Menu when the user hits the enter key. This prevents the event from bubbling up and accidentally submitting the form prematurely.

![Screen Recording 2024-12-11 at 4 53 04 PM mov](https://github.com/user-attachments/assets/9fc7c983-9b6f-474e-833a-8457c493d594)

Closes #2584 