### PR TITLE
Fix instance disk menus closing on poll

### DIFF
--- a/app/pages/project/instances/instance/tabs/StorageTab.tsx
+++ b/app/pages/project/instances/instance/tabs/StorageTab.tsx
@@ -146,10 +146,6 @@ export function Component() {
     [disks.items, instance.bootDiskId]
   )
 
-  // Needed to keep them the same while setting boot disk.
-  // Extracted to keep dep array appropriately zealous.
-  const { ncpus, memory } = instance
-
   const makeBootDiskActions = useCallback(
     (disk: InstanceDisk): MenuAction[] => [
       getSnapshotAction(disk),
@@ -168,8 +164,8 @@ export function Component() {
                 path: { instance: instance.id },
                 body: {
                   bootDisk: undefined,
-                  ncpus,
-                  memory,
+                  ncpus: instance.ncpus,
+                  memory: instance.memory,
                   // this would get unset if we left it out
                   autoRestartPolicy: instance.autoRestartPolicy,
                 },
@@ -200,7 +196,16 @@ export function Component() {
         onActivate() {}, // it's always disabled, so noop is ok
       },
     ],
-    [instanceUpdate, instance, getSnapshotAction, ncpus, memory]
+    [
+      instanceUpdate,
+      // don't put the entire instance in here. it is not referentially
+      // stable across polls, so the menus will close during polling
+      instance.id,
+      instance.autoRestartPolicy,
+      instance.ncpus,
+      instance.memory,
+      getSnapshotAction,
+    ]
   )
 
   const makeOtherDiskActions = useCallback(
@@ -223,8 +228,8 @@ export function Component() {
                 path: { instance: instance.id },
                 body: {
                   bootDisk: disk.id,
-                  ncpus,
-                  memory,
+                  ncpus: instance.ncpus,
+                  memory: instance.memory,
                   // this would get unset if we left it out
                   autoRestartPolicy: instance.autoRestartPolicy,
                 },
@@ -262,7 +267,18 @@ export function Component() {
         },
       },
     ],
-    [detachDisk, instanceUpdate, instance, getSnapshotAction, bootDisks, ncpus, memory]
+    [
+      detachDisk,
+      instanceUpdate,
+      // don't put the entire instance in here. it is not referentially
+      // stable across polls, so the menus will close during polling
+      instance.id,
+      instance.autoRestartPolicy,
+      instance.ncpus,
+      instance.memory,
+      getSnapshotAction,
+      bootDisks,
+    ]
   )
 
   const attachDisk = useApiMutation('instanceDiskAttach', {

--- a/test/e2e/instance.e2e.ts
+++ b/test/e2e/instance.e2e.ts
@@ -240,3 +240,7 @@ test('instance table', async ({ page }) => {
     state: expect.stringMatching(/^starting\d+s$/),
   })
 })
+
+test("polling doesn't close row actions menu", async ({ page }) => {
+  await page.goto('/projects/mock-project/instances/db1')
+})


### PR DESCRIPTION
We've broken this several times by accident, so this time I added a test. Very straightforward.