### PR TITLE
Gateway route links to router instead of route edit form

### DIFF
--- a/app/pages/project/vpcs/internet-gateway-edit.tsx
+++ b/app/pages/project/vpcs/internet-gateway-edit.tsx
@@ -51,15 +51,15 @@ function RouteRows({ project, vpc, gateway }: PP.VpcInternetGateway) {
 
   return matchingRoutes.map(([router, route]) => (
     <Table.Row key={route.id}>
-      <Table.Cell className="!bg-raise">{router}</Table.Cell>
-      <Table.Cell className="bg-raise">
+      <Table.Cell className="!bg-raise">
         <Link
-          to={pb.vpcRouterRouteEdit({ project, vpc, router, route: route.name })}
+          to={pb.vpcRouter({ project, vpc, router })}
           className="link-with-underline text-sans-md"
         >
-          {route.name}
+          {router}
         </Link>
       </Table.Cell>
+      <Table.Cell className="!bg-raise">{route.name}</Table.Cell>
     </Table.Row>
   ))
 }

--- a/test/e2e/vpcs.e2e.ts
+++ b/test/e2e/vpcs.e2e.ts
@@ -408,9 +408,9 @@ test('internet gateway shows proper list of routes targeting it', async ({ page 
   await expect(table.locator('tbody >> tr')).toHaveCount(2)
 
   // click on the new-route link to go to the detail page
-  await sidemodal.getByRole('link', { name: 'new-route' }).click()
+  await sidemodal.getByRole('link', { name: 'mock-custom-router' }).first().click()
   // expect to be on the view page
   await expect(page).toHaveURL(
-    '/projects/mock-project/vpcs/mock-vpc/routers/mock-custom-router/routes/new-route/edit'
+    '/projects/mock-project/vpcs/mock-vpc/routers/mock-custom-router'
   )
 })


### PR DESCRIPTION
Less jarring to link to the router than to an open form. Also makes it easier to get back with keyboard shortcuts because they're not eaten by the form.

<img width="479" alt="image" src="https://github.com/user-attachments/assets/5df6723b-c031-460d-a7a0-0bee82491de3" />
