### PR TITLE
Lighten solid neutral badge bg

### DIFF
--- a/app/ui/lib/Badge.tsx
+++ b/app/ui/lib/Badge.tsx
@@ -36,7 +36,7 @@ export const badgeColors: Record<BadgeVariant, Record<BadgeColor, string>> = {
     default: 'bg-accent text-inverse',
     destructive: 'bg-destructive text-inverse',
     notice: 'bg-notice text-inverse',
-    neutral: 'bg-[--base-neutral-600] text-inverse',
+    neutral: 'bg-[--base-neutral-700] text-inverse',
     purple: 'bg-[--base-purple-700] text-inverse',
     blue: 'bg-info text-inverse',
   },


### PR DESCRIPTION
I find it a little dim.

## Before

<img src="https://github.com/user-attachments/assets/5d8ebed9-5489-4100-88ee-578db7d00e2d" width="310"/>

![Screenshot 2024-12-13 at 9 53 49 PM](https://github.com/user-attachments/assets/df195bd1-2265-4d05-a898-356a3abbb2e8)

## After

<img src="https://github.com/user-attachments/assets/2b59edfb-f052-43f2-97d9-0a03e3e1a554" width="311" />

![Screenshot 2024-12-13 at 9 53 37 PM](https://github.com/user-attachments/assets/abdbb0b8-4567-4941-b4a5-31426daad68c)

I think it makes #2624 look better too, that's why I thought of it.

<img width="565" alt="image" src="https://github.com/user-attachments/assets/336d70a9-dbfd-4b10-bfcd-963aa939a419" />

