### PR TITLE
Use EmptyCell when we'd have an empty cell in InstanceLinkCell

### DIFF
--- a/app/table/cells/InstanceLinkCell.tsx
+++ b/app/table/cells/InstanceLinkCell.tsx
@@ -11,7 +11,7 @@ import { useApiQuery } from '@oxide/api'
 import { useProjectSelector } from '~/hooks/use-params'
 import { pb } from '~/util/path-builder'
 
-import { SkeletonCell } from './EmptyCell'
+import { EmptyCell, SkeletonCell } from './EmptyCell'
 import { LinkCell } from './LinkCell'
 
 export const InstanceLinkCell = ({ instanceId }: { instanceId?: string }) => {
@@ -23,7 +23,7 @@ export const InstanceLinkCell = ({ instanceId }: { instanceId?: string }) => {
   )
 
   // has to be after the hooks because hooks can't be executed conditionally
-  if (!instanceId) return null
+  if (!instanceId) return <EmptyCell />
   if (!instance) return <SkeletonCell />
 
   return (

--- a/test/e2e/disks.e2e.ts
+++ b/test/e2e/disks.e2e.ts
@@ -29,7 +29,7 @@ test('List disks and snapshot', async ({ page }) => {
     state: 'attached',
   })
   await expectRowVisible(table, {
-    'Attached to': '',
+    'Attached to': '—',
     name: 'disk-3',
     size: '6 GiB',
     state: 'detached',


### PR DESCRIPTION
This was something I noticed when working on #2630, but figured I'd handle separately, as it isn't relevant to that PR.

This PR just modifies the InstanceLinkCell component to use an EmptyCell when appropriate.

Here's the before:
<img width="991" alt="Screenshot 2024-12-18 at 3 46 31 PM" src="https://github.com/user-attachments/assets/250835dd-0967-43a5-8425-32c8e0f4631a" />

Here's the after:
<img width="1002" alt="Screenshot 2024-12-18 at 3 46 03 PM" src="https://github.com/user-attachments/assets/051b7588-1e45-4c49-9417-5ce01cd9e885" />