### PR TITLE
Full tests for row actions menu polling bug

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -114,11 +114,18 @@ module.exports = {
     },
     {
       files: ['*.e2e.ts'],
-      extends: ['plugin:playwright/playwright-test'],
+      extends: ['plugin:playwright/recommended'],
       rules: {
         'playwright/expect-expect': [
           'warn',
-          { assertFunctionNames: ['expectVisible', 'expectRowVisible', 'expectOptions'] },
+          {
+            assertFunctionNames: [
+              'expectVisible',
+              'expectRowVisible',
+              'expectOptions',
+              'expectRowMenuStaysOpen',
+            ],
+          },
         ],
         'playwright/no-force-option': 'off',
       },

--- a/test/e2e/instance-disks.e2e.ts
+++ b/test/e2e/instance-disks.e2e.ts
@@ -7,14 +7,12 @@
  */
 import {
   clickRowAction,
-  closeToast,
   expect,
   expectNoToast,
   expectNotVisible,
   expectRowVisible,
   expectToast,
   expectVisible,
-  openRowActions,
   stopInstance,
   test,
 } from './utils'
@@ -229,46 +227,4 @@ test('Change boot disk', async ({ page }) => {
   await expect(noOtherDisks).toBeVisible()
 
   await expect(page.getByText('Attach a disk to be able to set a boot disk')).toBeVisible()
-})
-
-// silly test but we've reintroduced this bug like 3 times
-test("polling doesn't close row actions menu", async ({ page }) => {
-  await page.goto('/projects/mock-project/instances/db1')
-
-  // stop, but don't wait until the state has changed
-  await page.getByRole('button', { name: 'Stop' }).click()
-  await page.getByRole('button', { name: 'Confirm' }).click()
-  await closeToast(page)
-
-  const menu = page.getByRole('menu')
-  const stopped = page.getByText('statestopped')
-
-  await expect(menu).toBeHidden()
-  await expect(stopped).toBeHidden()
-
-  await openRowActions(page, 'disk-1')
-  await expect(stopped).toBeHidden() // still not stopped yet
-  await expect(menu).toBeVisible()
-
-  // now we're stopped, which means polling has happened, but the
-  // menu remains visible
-  await expect(stopped).toBeVisible()
-  await expect(menu).toBeVisible()
-
-  // now start it so we can check the non-boot disks table
-  await page.getByRole('button', { name: 'Start' }).click()
-  await page.getByRole('button', { name: 'Confirm' }).click()
-  await closeToast(page)
-
-  const running = page.getByText('staterunning') // not running yet
-  await expect(running).toBeHidden()
-  await expect(menu).toBeHidden()
-
-  await openRowActions(page, 'disk-2')
-  await expect(running).toBeHidden() // still not running yet
-  await expect(menu).toBeVisible()
-
-  // state change means polling has happened. menu is still visible
-  await expect(running).toBeVisible()
-  await expect(menu).toBeVisible()
 })


### PR DESCRIPTION
See https://github.com/oxidecomputer/console/pull/2618#issuecomment-2539806844

I was able to get each test to fail by sticking something in a dep array that didn't belong there.