### PR TITLE
Fixes padding bug on chart

### DIFF
--- a/app/components/TimeSeriesChart.tsx
+++ b/app/components/TimeSeriesChart.tsx
@@ -154,59 +154,60 @@ export default function TimeSeriesChart({
   const data = useMemo(() => rawData || [], [rawData])
 
   return (
-    <ResponsiveContainer width="100%" height={300}>
-      <AreaChart
-        width={width}
-        height={height}
-        data={data}
-        margin={{ top: 0, right: 8, bottom: 16, left: 0 }}
-        className={cn(className, 'rounded-lg border border-default')}
-      >
-        <CartesianGrid stroke={GRID_GRAY} vertical={false} />
-        <XAxis
-          axisLine={{ stroke: GRID_GRAY }}
-          tickLine={{ stroke: GRID_GRAY }}
-          // TODO: show full given date range in the chart even if the data doesn't fill the range
-          domain={['auto', 'auto']}
-          dataKey="timestamp"
-          interval="preserveStart"
-          scale="time"
-          // TODO: use Date directly as x-axis values
-          type="number"
-          name="Time"
-          ticks={getTicks(data, 5)}
-          tickFormatter={isSameDay(startTime, endTime) ? shortTime : shortDateTime}
-          tick={textMonoMd}
-          tickMargin={8}
-        />
-        <YAxis
-          axisLine={{ stroke: GRID_GRAY }}
-          tickLine={{ stroke: GRID_GRAY }}
-          orientation="right"
-          tick={textMonoMd}
-          tickMargin={8}
-          tickFormatter={yAxisTickFormatter}
-          padding={{ top: 32 }}
-          {...yTicks}
-        />
-        {/* TODO: stop tooltip being focused by default on pageload if nothing else has been clicked */}
-        <Tooltip
-          isAnimationActive={false}
-          content={(props: TooltipProps<number, string>) => renderTooltip(props, unit)}
-          cursor={{ stroke: CURSOR_GRAY, strokeDasharray: '3,3' }}
-          wrapperStyle={{ outline: 'none' }}
-        />
-        <Area
-          dataKey="value"
-          name={title}
-          type={interpolation}
-          stroke={GREEN_600}
-          fill={GREEN_400}
-          isAnimationActive={false}
-          dot={false}
-          activeDot={{ fill: GREEN_800, r: 3, strokeWidth: 0 }}
-        />
-      </AreaChart>
-    </ResponsiveContainer>
+    <div style={{ width: '100%', height: 300 }}>
+      <ResponsiveContainer className={cn(className, 'rounded-lg border border-default')}>
+        <AreaChart
+          width={width}
+          height={height}
+          data={data}
+          margin={{ top: 0, right: 8, bottom: 16, left: 0 }}
+        >
+          <CartesianGrid stroke={GRID_GRAY} vertical={false} />
+          <XAxis
+            axisLine={{ stroke: GRID_GRAY }}
+            tickLine={{ stroke: GRID_GRAY }}
+            // TODO: show full given date range in the chart even if the data doesn't fill the range
+            domain={['auto', 'auto']}
+            dataKey="timestamp"
+            interval="preserveStart"
+            scale="time"
+            // TODO: use Date directly as x-axis values
+            type="number"
+            name="Time"
+            ticks={getTicks(data, 5)}
+            tickFormatter={isSameDay(startTime, endTime) ? shortTime : shortDateTime}
+            tick={textMonoMd}
+            tickMargin={8}
+          />
+          <YAxis
+            axisLine={{ stroke: GRID_GRAY }}
+            tickLine={{ stroke: GRID_GRAY }}
+            orientation="right"
+            tick={textMonoMd}
+            tickMargin={8}
+            tickFormatter={yAxisTickFormatter}
+            padding={{ top: 32 }}
+            {...yTicks}
+          />
+          {/* TODO: stop tooltip being focused by default on pageload if nothing else has been clicked */}
+          <Tooltip
+            isAnimationActive={false}
+            content={(props: TooltipProps<number, string>) => renderTooltip(props, unit)}
+            cursor={{ stroke: CURSOR_GRAY, strokeDasharray: '3,3' }}
+            wrapperStyle={{ outline: 'none' }}
+          />
+          <Area
+            dataKey="value"
+            name={title}
+            type={interpolation}
+            stroke={GREEN_600}
+            fill={GREEN_400}
+            isAnimationActive={false}
+            dot={false}
+            activeDot={{ fill: GREEN_800, r: 3, strokeWidth: 0 }}
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
   )
 }

--- a/app/components/TimeSeriesChart.tsx
+++ b/app/components/TimeSeriesChart.tsx
@@ -154,7 +154,7 @@ export default function TimeSeriesChart({
   const data = useMemo(() => rawData || [], [rawData])
 
   return (
-    <div style={{ width: '100%', height: 300 }}>
+    <div className="h-[300px] w-full">
       <ResponsiveContainer className={cn(className, 'rounded-lg border border-default')}>
         <AreaChart
           width={width}


### PR DESCRIPTION
Before:
<img width="181" alt="image" src="https://github.com/user-attachments/assets/4ea58ce5-f0e3-4187-a10b-a4fb99719429" />

After:
<img width="172" alt="image" src="https://github.com/user-attachments/assets/34d6bcaf-9f13-46c4-b799-83854f407396" />

Applying the border and border to the area chart directly was causing issues.