### PR TITLE
Update default blockSize to 4096 for new blank disks

### DIFF
--- a/app/forms/disk-create.tsx
+++ b/app/forms/disk-create.tsx
@@ -41,7 +41,7 @@ import { bytesToGiB, GiB } from '~/util/units'
 
 const blankDiskSource: DiskSource = {
   type: 'blank',
-  blockSize: 512,
+  blockSize: 4096,
 }
 
 const defaultValues: DiskCreate = {


### PR DESCRIPTION
This sets the default block size to 4096 when creating a new blank disk.

<img width="474" alt="Screenshot 2025-01-22 at 10 27 39 AM" src="https://github.com/user-attachments/assets/58e2b060-b8ac-4b69-8bb2-a063d66b834b" />

Closes #2653
