### PR TITLE
Fix minitable hover css

### DIFF
--- a/app/ui/styles/components/mini-table.css
+++ b/app/ui/styles/components/mini-table.css
@@ -38,8 +38,7 @@
   & td:last-child > div > button {
     @apply -mx-3 -my-3 flex items-center justify-center px-3 py-3;
   }
-
-  & tr:hover td > div {
+  & td:last-child > div:has(button):hover {
     @apply bg-accent-secondary-hover;
   }
 

--- a/app/ui/styles/components/mini-table.css
+++ b/app/ui/styles/components/mini-table.css
@@ -38,7 +38,7 @@
   & td:last-child > div > button {
     @apply -mx-3 -my-3 flex items-center justify-center px-3 py-3;
   }
-  & td:last-child > div:has(button):hover {
+  & td:last-child > div:has(button:hover, button:focus) {
     @apply bg-accent-secondary-hover;
   }
 


### PR DESCRIPTION
A slight tweak to the CSS on mini-table cells. Previously, we highlighted the entire mini-table row on hover, but we really just want to highlight the div containing the button in the last cell.

With the fix in place, when hovering the mouse over the top row's last cell (though the mouse is removed from the screenshot):
<img width="532" alt="Screenshot 2025-01-27 at 12 29 09 PM" src="https://github.com/user-attachments/assets/66356a1b-10ff-4384-b0d2-9722044393a6" />


Closes #2662
