### PR TITLE
minor: longer timeout on image upload cancel state expect

### DIFF
--- a/test/e2e/image-upload.e2e.ts
+++ b/test/e2e/image-upload.e2e.ts
@@ -139,9 +139,9 @@ test.describe('Image upload', () => {
       const progressModal = page.getByRole('dialog', { name: 'Image upload progress' })
       await expect(progressModal).toBeVisible()
 
-      // wait to be in the middle of upload
+      // wait to be in the middle of the specified step
       const uploadStep = page.getByTestId(`upload-step: ${state}`)
-      await expect(uploadStep).toHaveAttribute('data-status', 'running')
+      await expect(uploadStep).toHaveAttribute('data-status', 'running', { timeout: 10000 })
 
       // form is disabled and semi-hidden
       // await expectNotVisible(page, ['role=textbox[name="Name"]'])


### PR DESCRIPTION
Trying to do #2687 

The fact that the failure was due to the step still being `ready` when it was expecting `running` makes me think the upload step is taking _slightly_ too long, and we're running out of time waiting for the step after it.

![Screenshot 2025-02-11 at 3 14 50 PM](https://github.com/user-attachments/assets/6bc26eb6-32bb-4875-bba8-62a79fb824b9)
