### PR TITLE
minor: Remove breadcrumbs for instance metrics tabs

### DIFF
--- a/app/pages/project/instances/CpuMetricsTab.tsx
+++ b/app/pages/project/instances/CpuMetricsTab.tsx
@@ -22,8 +22,6 @@ import { Listbox } from '~/ui/lib/Listbox'
 
 import { useMetricsContext } from './common'
 
-export const handle = { crumb: 'CPU' }
-
 export default function CpuMetricsTab() {
   const { project, instance } = useInstanceSelector()
   const { data: instanceData } = usePrefetchedApiQuery('instanceView', {

--- a/app/pages/project/instances/DiskMetricsTab.tsx
+++ b/app/pages/project/instances/DiskMetricsTab.tsx
@@ -38,8 +38,6 @@ export async function clientLoader({ params }: LoaderFunctionArgs) {
 // out here so we don't have to memoize it
 const groupByAttachedInstanceId = { cols: ['attached_instance_id'], op: 'sum' } as const
 
-export const handle = { crumb: 'Disk' }
-
 export default function DiskMetricsTab() {
   const { project, instance } = useInstanceSelector()
   const { data: disks } = usePrefetchedApiQuery('instanceDiskList', {

--- a/app/pages/project/instances/InstancePage.tsx
+++ b/app/pages/project/instances/InstancePage.tsx
@@ -256,7 +256,7 @@ export default function InstancePage() {
       <RouteTabs fullWidth>
         <Tab to={pb.instanceStorage(instanceSelector)}>Storage</Tab>
         <Tab to={pb.instanceNetworking(instanceSelector)}>Networking</Tab>
-        <Tab to={pb.instanceMetrics(instanceSelector)}>Metrics</Tab>
+        <Tab to={pb.instanceCpuMetrics(instanceSelector)}>Metrics</Tab>
         <Tab to={pb.instanceConnect(instanceSelector)}>Connect</Tab>
         <Tab to={pb.instanceSettings(instanceSelector)}>Settings</Tab>
       </RouteTabs>

--- a/app/pages/project/instances/NetworkMetricsTab.tsx
+++ b/app/pages/project/instances/NetworkMetricsTab.tsx
@@ -40,8 +40,6 @@ export async function clientLoader({ params }: LoaderFunctionArgs) {
 
 const groupByInstanceId = { cols: ['instance_id'], op: 'sum' } as const
 
-export const handle = { crumb: 'Network' }
-
 export default function NetworkMetricsTab() {
   const { project, instance } = useInstanceSelector()
   const { data: nics } = usePrefetchedApiQuery('instanceNetworkInterfaceList', {

--- a/app/routes.tsx
+++ b/app/routes.tsx
@@ -308,7 +308,6 @@ export const routes = createRoutesFromElements(
                       import('./pages/project/instances/NetworkMetricsTab').then(convert)
                     }
                     path="network"
-                    handle={{ crumb: 'Network' }}
                   />
                 </Route>
                 <Route

--- a/app/util/__snapshots__/path-builder.spec.ts.snap
+++ b/app/util/__snapshots__/path-builder.spec.ts.snap
@@ -148,38 +148,8 @@ exports[`breadcrumbs 2`] = `
       "label": "Metrics",
       "path": "/projects/p/instances/i/metrics",
     },
-    {
-      "label": "CPU",
-      "path": "/projects/p/instances/i/metrics/cpu",
-    },
   ],
   "instanceDiskMetrics (/projects/p/instances/i/metrics/disk)": [
-    {
-      "label": "Projects",
-      "path": "/projects",
-    },
-    {
-      "label": "p",
-      "path": "/projects/p/instances",
-    },
-    {
-      "label": "Instances",
-      "path": "/projects/p/instances",
-    },
-    {
-      "label": "i",
-      "path": "/projects/p/instances/i/storage",
-    },
-    {
-      "label": "Metrics",
-      "path": "/projects/p/instances/i/metrics",
-    },
-    {
-      "label": "Disk",
-      "path": "/projects/p/instances/i/metrics/disk",
-    },
-  ],
-  "instanceMetrics (/projects/p/instances/i/metrics)": [
     {
       "label": "Projects",
       "path": "/projects",
@@ -221,10 +191,6 @@ exports[`breadcrumbs 2`] = `
     {
       "label": "Metrics",
       "path": "/projects/p/instances/i/metrics",
-    },
-    {
-      "label": "Network",
-      "path": "/projects/p/instances/i/metrics/network",
     },
   ],
   "instanceNetworking (/projects/p/instances/i/networking)": [

--- a/app/util/path-builder.spec.ts
+++ b/app/util/path-builder.spec.ts
@@ -50,7 +50,6 @@ test('path builder', () => {
         "instanceConnect": "/projects/p/instances/i/connect",
         "instanceCpuMetrics": "/projects/p/instances/i/metrics/cpu",
         "instanceDiskMetrics": "/projects/p/instances/i/metrics/disk",
-        "instanceMetrics": "/projects/p/instances/i/metrics",
         "instanceNetworkMetrics": "/projects/p/instances/i/metrics/network",
         "instanceNetworking": "/projects/p/instances/i/networking",
         "instanceSettings": "/projects/p/instances/i/settings",

--- a/app/util/path-builder.ts
+++ b/app/util/path-builder.ts
@@ -14,6 +14,8 @@ const projectBase = ({ project }: PP.Project) => `${pb.projects()}/${project}`
 const instanceBase = ({ project, instance }: PP.Instance) =>
   `${pb.instances({ project })}/${instance}`
 const vpcBase = ({ project, vpc }: PP.Vpc) => `${pb.vpcs({ project })}/${vpc}`
+const instanceMetricsBase = ({ project, instance }: PP.Instance) =>
+  `${instanceBase({ project, instance })}/metrics`
 
 export const pb = {
   projects: () => `/projects`,
@@ -39,11 +41,9 @@ export const pb = {
    */
   instance: (params: PP.Instance) => pb.instanceStorage(params),
 
-  instanceMetrics: (params: PP.Instance) => `${instanceBase(params)}/metrics`,
-  instanceCpuMetrics: (params: PP.Instance) => `${instanceBase(params)}/metrics/cpu`,
-  instanceDiskMetrics: (params: PP.Instance) => `${instanceBase(params)}/metrics/disk`,
-  instanceNetworkMetrics: (params: PP.Instance) =>
-    `${instanceBase(params)}/metrics/network`,
+  instanceCpuMetrics: (params: PP.Instance) => `${instanceMetricsBase(params)}/cpu`,
+  instanceDiskMetrics: (params: PP.Instance) => `${instanceMetricsBase(params)}/disk`,
+  instanceNetworkMetrics: (params: PP.Instance) => `${instanceMetricsBase(params)}/network`,
   instanceStorage: (params: PP.Instance) => `${instanceBase(params)}/storage`,
   instanceConnect: (params: PP.Instance) => `${instanceBase(params)}/connect`,
   instanceNetworking: (params: PP.Instance) => `${instanceBase(params)}/networking`,


### PR DESCRIPTION
I think having the crumb at the top change when you change tabs feels excessive. I also removed plain `/metrics` as a path in path-builder and had the tab link straight to the CPU tab. This eliminates a loader call that could cause the loading bar to flash twice.

<img width="1087" alt="image" src="https://github.com/user-attachments/assets/831a57b7-a085-41d8-a3b4-7191c1e947da" />
