### PR TITLE
Prototype: Stop instance disk modal

### DIFF
--- a/app/components/StopInstancePrompt.tsx
+++ b/app/components/StopInstancePrompt.tsx
@@ -1,0 +1,110 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
+ */
+import { useEffect, useState, type ReactNode } from 'react'
+
+import {
+  instanceTransitioning,
+  useApiMutation,
+  useApiQuery,
+  useApiQueryClient,
+  type Instance,
+} from '@oxide/api'
+
+import { HL } from '~/components/HL'
+import { addToast } from '~/stores/toast'
+import { Button } from '~/ui/lib/Button'
+import { Message } from '~/ui/lib/Message'
+
+const POLL_INTERVAL_FAST = 2000 // 2 seconds
+
+type StopInstancePromptProps = {
+  instance: Instance
+  children: ReactNode
+}
+
+export function StopInstancePrompt({ instance, children }: StopInstancePromptProps) {
+  const queryClient = useApiQueryClient()
+  const [isStoppingInstance, setIsStoppingInstance] = useState(false)
+
+  const { data } = useApiQuery(
+    'instanceView',
+    {
+      path: { instance: instance.name },
+      query: { project: instance.projectId },
+    },
+    {
+      refetchInterval:
+        isStoppingInstance || instanceTransitioning(instance) ? POLL_INTERVAL_FAST : false,
+    }
+  )
+
+  const { mutateAsync: stopInstanceAsync } = useApiMutation('instanceStop', {
+    onSuccess: () => {
+      setIsStoppingInstance(true)
+      addToast(
+        <>
+          Stopping instance <HL>{instance.name}</HL>
+        </>
+      )
+    },
+    onError: (error) => {
+      addToast({
+        variant: 'error',
+        title: `Error stopping instance '${instance.name}'`,
+        content: error.message,
+      })
+      setIsStoppingInstance(false)
+    },
+  })
+
+  const handleStopInstance = () => {
+    stopInstanceAsync({
+      path: { instance: instance.name },
+      query: { project: instance.projectId },
+    })
+  }
+
+  const currentInstance = data || instance
+
+  useEffect(() => {
+    if (!data) {
+      return
+    }
+    if (isStoppingInstance && data.runState === 'stopped') {
+      queryClient.invalidateQueries('instanceView')
+      setIsStoppingInstance(false)
+    }
+  }, [isStoppingInstance, data, queryClient])
+
+  if (
+    !currentInstance ||
+    (currentInstance.runState !== 'stopping' && currentInstance.runState !== 'running')
+  ) {
+    return null
+  }
+
+  return (
+    <Message
+      variant="notice"
+      content={
+        <>
+          {children}{' '}
+          <Button
+            size="xs"
+            className="mt-3"
+            variant="notice"
+            onClick={handleStopInstance}
+            loading={isStoppingInstance}
+          >
+            Stop instance
+          </Button>
+        </>
+      }
+    />
+  )
+}

--- a/app/components/form/ModalForm.tsx
+++ b/app/components/form/ModalForm.tsx
@@ -1,0 +1,105 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
+ */
+
+import { useId, type ReactNode } from 'react'
+import type { FieldValues, UseFormReturn } from 'react-hook-form'
+
+import type { ApiError } from '@oxide/api'
+
+import { Message } from '~/ui/lib/Message'
+import { Modal, type ModalProps } from '~/ui/lib/Modal'
+
+type ModalFormProps<TFieldValues extends FieldValues> = {
+  form: UseFormReturn<TFieldValues>
+  /**
+   * A function that returns the fields.
+   *
+   * Implemented as a function so we can pass `control` to the fields in the
+   * calling code. We could do that internally with `cloneElement` instead, but
+   * then in the calling code, the field would not infer `TFieldValues` and
+   * constrain the `name` prop to paths in the values object.
+   */
+  children: ReactNode
+  resourceName: string
+  /** Must be provided with a reason describing why it's disabled */
+  submitDisabled?: string
+
+  // require loading and error so we can't forget to hook them up. there are a
+  // few forms that don't need them, so we'll use dummy values
+
+  /** Error from the API call */
+  submitError: ApiError | null
+  loading: boolean
+
+  /** Only needed if you need to override the default title (Create/Edit ${resourceName}) */
+  subtitle?: ReactNode
+  onSubmit: (values: TFieldValues) => void
+
+  submitLabel?: string
+} & Omit<ModalProps, 'isOpen'>
+
+export function ModalForm<TFieldValues extends FieldValues>({
+  form,
+  children,
+  onDismiss,
+  resourceName,
+  submitDisabled,
+  submitError,
+  title,
+  onSubmit,
+  submitLabel = 'Save',
+  loading,
+  subtitle,
+  width = 'medium',
+  overlay = true,
+}: ModalFormProps<TFieldValues>) {
+  const id = useId()
+
+  const { isSubmitting } = form.formState
+
+  const modalTitle = title || `Create ${resourceName}`
+
+  return (
+    <>
+      <Modal
+        isOpen
+        onDismiss={onDismiss}
+        title={modalTitle}
+        width={width}
+        overlay={overlay}
+      >
+        <Modal.Body>
+          <Modal.Section>
+            {subtitle && <div className="mb-4">{subtitle}</div>}
+            {submitError && (
+              <Message variant="error" title="Error" content={submitError.message} />
+            )}
+            <form
+              id={id}
+              className="ox-form"
+              autoComplete="off"
+              onSubmit={(e) => {
+                if (!onSubmit) return
+                form.handleSubmit(onSubmit)(e)
+              }}
+            >
+              {children}
+            </form>
+          </Modal.Section>
+        </Modal.Body>
+        <Modal.Footer
+          onDismiss={onDismiss}
+          formId={id}
+          actionText={submitLabel}
+          disabled={!!submitDisabled}
+          actionLoading={loading || isSubmitting}
+        />
+      </Modal>
+    </>
+  )
+}

--- a/app/components/form/fields/DisksTableField.tsx
+++ b/app/components/form/fields/DisksTableField.tsx
@@ -10,7 +10,7 @@ import { useController, type Control } from 'react-hook-form'
 
 import type { DiskCreate } from '@oxide/api'
 
-import { AttachDiskSideModalForm } from '~/forms/disk-attach'
+import { AttachDiskModalForm } from '~/forms/disk-attach'
 import { CreateDiskSideModalForm } from '~/forms/disk-create'
 import type { InstanceCreateInput } from '~/forms/instance-create'
 import { Badge } from '~/ui/lib/Badge'
@@ -115,7 +115,7 @@ export function DisksTableField({
         />
       )}
       {showDiskAttach && (
-        <AttachDiskSideModalForm
+        <AttachDiskModalForm
           onDismiss={() => setShowDiskAttach(false)}
           onSubmit={(values) => {
             onChange([...items, { type: 'attach', ...values }])

--- a/app/forms/disk-attach.tsx
+++ b/app/forms/disk-attach.tsx
@@ -8,7 +8,7 @@
 import { useMemo } from 'react'
 import { useForm } from 'react-hook-form'
 
-import { useApiQuery, type ApiError, type Instance } from '@oxide/api'
+import { instanceCan, useApiQuery, type ApiError, type Instance } from '@oxide/api'
 
 import { ComboboxField } from '~/components/form/fields/ComboboxField'
 import { ModalForm } from '~/components/form/ModalForm'
@@ -71,7 +71,7 @@ export function AttachDiskModalForm({
       onSubmit={onSubmit}
       width="medium"
       submitDisabled={
-        instance.runState !== 'stopped' ? 'Instance must be stopped' : undefined
+        !instanceCan.attachDisk(instance) ? 'Instance must be stopped' : undefined
       }
     >
       <StopInstancePrompt instance={instance}>

--- a/app/forms/disk-attach.tsx
+++ b/app/forms/disk-attach.tsx
@@ -11,7 +11,7 @@ import { useForm } from 'react-hook-form'
 import { useApiQuery, type ApiError } from '@oxide/api'
 
 import { ComboboxField } from '~/components/form/fields/ComboboxField'
-import { SideModalForm } from '~/components/form/SideModalForm'
+import { ModalForm } from '~/components/form/ModalForm'
 import { useProjectSelector } from '~/hooks/use-params'
 import { toComboboxItems } from '~/ui/lib/Combobox'
 import { ALL_ISH } from '~/util/consts'
@@ -31,7 +31,7 @@ type AttachDiskProps = {
  * Can be used with either a `setState` or a real mutation as `onSubmit`, hence
  * the optional `loading` and `submitError`
  */
-export function AttachDiskSideModalForm({
+export function AttachDiskModalForm({
   onSubmit,
   onDismiss,
   diskNamesToExclude = [],
@@ -40,7 +40,7 @@ export function AttachDiskSideModalForm({
 }: AttachDiskProps) {
   const { project } = useProjectSelector()
 
-  const { data } = useApiQuery('diskList', {
+  const { data, isPending } = useApiQuery('diskList', {
     query: { project, limit: ALL_ISH },
   })
   const detachedDisks = useMemo(
@@ -54,17 +54,19 @@ export function AttachDiskSideModalForm({
   )
 
   const form = useForm({ defaultValues })
+  const { control } = form
 
   return (
-    <SideModalForm
+    <ModalForm
       form={form}
-      formType="create"
+      onDismiss={onDismiss}
       resourceName="disk"
+      submitLabel="Attach disk"
+      submitError={submitError}
+      loading={loading}
       title="Attach disk"
       onSubmit={onSubmit}
-      loading={loading}
-      submitError={submitError}
-      onDismiss={onDismiss}
+      width="medium"
     >
       <ComboboxField
         label="Disk name"
@@ -72,8 +74,9 @@ export function AttachDiskSideModalForm({
         name="name"
         items={detachedDisks}
         required
-        control={form.control}
+        control={control}
+        isLoading={isPending}
       />
-    </SideModalForm>
+    </ModalForm>
   )
 }

--- a/app/forms/disk-attach.tsx
+++ b/app/forms/disk-attach.tsx
@@ -8,10 +8,11 @@
 import { useMemo } from 'react'
 import { useForm } from 'react-hook-form'
 
-import { useApiQuery, type ApiError } from '@oxide/api'
+import { useApiQuery, type ApiError, type Instance } from '@oxide/api'
 
 import { ComboboxField } from '~/components/form/fields/ComboboxField'
 import { ModalForm } from '~/components/form/ModalForm'
+import { StopInstancePrompt } from '~/components/StopInstancePrompt'
 import { useProjectSelector } from '~/hooks/use-params'
 import { toComboboxItems } from '~/ui/lib/Combobox'
 import { ALL_ISH } from '~/util/consts'
@@ -25,6 +26,7 @@ type AttachDiskProps = {
   diskNamesToExclude?: string[]
   loading?: boolean
   submitError?: ApiError | null
+  instance: Instance
 }
 
 /**
@@ -37,6 +39,7 @@ export function AttachDiskModalForm({
   diskNamesToExclude = [],
   loading = false,
   submitError = null,
+  instance,
 }: AttachDiskProps) {
   const { project } = useProjectSelector()
 
@@ -67,7 +70,13 @@ export function AttachDiskModalForm({
       title="Attach disk"
       onSubmit={onSubmit}
       width="medium"
+      submitDisabled={
+        instance.runState !== 'stopped' ? 'Instance must be stopped' : undefined
+      }
     >
+      <StopInstancePrompt instance={instance}>
+        An instance must be stopped to attach a disk.
+      </StopInstancePrompt>
       <ComboboxField
         label="Disk name"
         placeholder="Select a disk"

--- a/app/pages/project/instances/StorageTab.tsx
+++ b/app/pages/project/instances/StorageTab.tsx
@@ -334,18 +334,7 @@ export default function StorageTab() {
 
       <CardBlock>
         <CardBlock.Header title="Additional disks" titleId="other-disks-label">
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={() => setShowDiskAttach(true)}
-            disabledReason={
-              <>
-                Instance must be <span className="text-raise">stopped</span> to attach a
-                disk
-              </>
-            }
-            disabled={!instanceCan.attachDisk(instance)}
-          >
+          <Button variant="secondary" size="sm" onClick={() => setShowDiskAttach(true)}>
             Attach existing disk
           </Button>
           <Button

--- a/app/pages/project/instances/StorageTab.tsx
+++ b/app/pages/project/instances/StorageTab.tsx
@@ -25,7 +25,7 @@ import { Storage24Icon } from '@oxide/design-system/icons/react'
 
 import { HL } from '~/components/HL'
 import { DiskStateBadge } from '~/components/StateBadge'
-import { AttachDiskSideModalForm } from '~/forms/disk-attach'
+import { AttachDiskModalForm } from '~/forms/disk-attach'
 import { CreateDiskSideModalForm } from '~/forms/disk-create'
 import { getInstanceSelector, useInstanceSelector } from '~/hooks/use-params'
 import { confirmAction } from '~/stores/confirm-action'
@@ -295,13 +295,6 @@ export default function StorageTab() {
       setShowDiskCreate(false)
       setShowDiskAttach(false)
     },
-    onError(err) {
-      addToast({
-        title: 'Failed to attach disk',
-        content: err.message,
-        variant: 'error',
-      })
-    },
   })
 
   const bootDisksTable = useReactTable({
@@ -341,35 +334,33 @@ export default function StorageTab() {
 
       <CardBlock>
         <CardBlock.Header title="Additional disks" titleId="other-disks-label">
-          <div className="flex gap-3">
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() => setShowDiskAttach(true)}
-              disabledReason={
-                <>
-                  Instance must be <span className="text-raise">stopped</span> to attach a
-                  disk
-                </>
-              }
-              disabled={!instanceCan.attachDisk(instance)}
-            >
-              Attach existing disk
-            </Button>
-            <Button
-              size="sm"
-              onClick={() => setShowDiskCreate(true)}
-              disabledReason={
-                <>
-                  Instance must be <span className="text-raise">stopped</span> to create and
-                  attach a disk
-                </>
-              }
-              disabled={!instanceCan.attachDisk(instance)}
-            >
-              Create disk
-            </Button>
-          </div>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => setShowDiskAttach(true)}
+            disabledReason={
+              <>
+                Instance must be <span className="text-raise">stopped</span> to attach a
+                disk
+              </>
+            }
+            disabled={!instanceCan.attachDisk(instance)}
+          >
+            Attach existing disk
+          </Button>
+          <Button
+            size="sm"
+            onClick={() => setShowDiskCreate(true)}
+            disabledReason={
+              <>
+                Instance must be <span className="text-raise">stopped</span> to create and
+                attach a disk
+              </>
+            }
+            disabled={!instanceCan.attachDisk(instance)}
+          >
+            Create disk
+          </Button>
         </CardBlock.Header>
         <CardBlock.Body>
           {otherDisks.length > 0 ? (
@@ -395,13 +386,14 @@ export default function StorageTab() {
         />
       )}
       {showDiskAttach && (
-        <AttachDiskSideModalForm
+        <AttachDiskModalForm
           onDismiss={() => setShowDiskAttach(false)}
           onSubmit={({ name }) => {
             attachDisk.mutate({ ...instancePathQuery, body: { disk: name } })
           }}
           loading={attachDisk.isPending}
           submitError={attachDisk.error}
+          instance={instance}
         />
       )}
     </div>

--- a/app/ui/lib/Button.tsx
+++ b/app/ui/lib/Button.tsx
@@ -13,13 +13,14 @@ import { Spinner } from '~/ui/lib/Spinner'
 import { Tooltip } from '~/ui/lib/Tooltip'
 import { Wrap } from '~/ui/util/wrap'
 
-export const buttonSizes = ['sm', 'icon', 'base'] as const
-export const variants = ['primary', 'secondary', 'ghost', 'danger'] as const
+export const buttonSizes = ['xs', 'sm', 'icon', 'base'] as const
+export const variants = ['primary', 'secondary', 'ghost', 'danger', 'notice'] as const
 
 export type ButtonSize = (typeof buttonSizes)[number]
 export type Variant = (typeof variants)[number]
 
 const sizeStyle: Record<ButtonSize, string> = {
+  xs: 'h-6 px-2 text-mono-xs',
   sm: 'h-8 px-3 text-mono-sm [&>svg]:w-4',
   // meant for buttons that only contain a single icon
   icon: 'h-8 w-8 text-mono-sm [&>svg]:w-4',
@@ -115,7 +116,7 @@ export const Button = ({
             animate={{ opacity: 1, y: '-50%', x: '-50%' }}
             initial={{ opacity: 0, y: 'calc(-50% - 25px)', x: '-50%' }}
             transition={{ type: 'spring', duration: 0.3, bounce: 0 }}
-            className="absolute left-1/2 top-1/2"
+            className="absolute left-1/2 top-1/2 flex items-center justify-center"
           >
             <Spinner variant={variant} />
           </m.span>

--- a/app/ui/styles/components/button.css
+++ b/app/ui/styles/components/button.css
@@ -44,6 +44,10 @@
   @apply hidden;
 }
 
+.btn-notice.ox-button:after {
+  @apply opacity-40;
+}
+
 /**
  * A class to make it very visually obvious that a button style is missing
  */

--- a/app/ui/styles/components/spinner.css
+++ b/app/ui/styles/components/spinner.css
@@ -13,6 +13,11 @@
   animation: rotate 5s linear infinite;
 }
 
+.spinner .path,
+.spinner .bg {
+  stroke: currentColor;
+}
+
 .spinner.spinner-md {
   --radius: 8;
   --circumference: calc(var(--PI) * var(--radius) * 2px);
@@ -27,7 +32,6 @@
   stroke-dasharray: var(--circumference);
   transform-origin: center;
   animation: dash 8s ease-in-out infinite;
-  stroke: var(--content-accent-tertiary);
 }
 
 @media (prefers-reduced-motion) {
@@ -48,24 +52,6 @@
   .spinner-lg .path {
     stroke-dasharray: 50;
   }
-}
-
-.spinner-ghost .bg,
-.spinner-secondary .bg {
-  stroke: var(--content-default);
-}
-
-.spinner-secondary .path {
-  stroke: var(--content-secondary);
-}
-
-.spinner-primary .bg {
-  stroke: var(--content-accent);
-}
-
-.spinner-danger .bg,
-.spinner-danger .path {
-  stroke: var(--content-destructive-tertiary);
 }
 
 @keyframes rotate {


### PR DESCRIPTION
Disabling buttons (with a tooltip) is a pattern I'm not particularly fond of – outside of the lesser accessibility, it adds friction in a situation we can help the user get what they want done.

Rough implementation of an idea I had around letting the user stop the instance inline within the disk attach modal. Can be abstracted to any similar situation that requires something be done first.

The polling to see if the instance state has change is less than ideal perhaps, and might require some more thinking.

![CleanShot 2025-03-05 at 12 25 06](https://github.com/user-attachments/assets/d2d8cd2d-fdaa-459f-9222-de4887352aab)

Interested to hear what you think? Maybe the consensus is that the added friction to stop an instance is necessary (especially since we have a confirm modal elsewhere) because of the consequences of stopping a VM accidentally. And the user still needs to start the instance after attaching.