### PR TITLE
tools: Fix safari instance additional disks e2e flake

### DIFF
--- a/test/e2e/instance-create.e2e.ts
+++ b/test/e2e/instance-create.e2e.ts
@@ -14,6 +14,7 @@ import {
   expectRowVisible,
   expectVisible,
   selectOption,
+  sleep,
   test,
   type Page,
 } from './utils'
@@ -550,8 +551,22 @@ test('create instance with additional disks', async ({ page }) => {
   // verify that an existing name can't be used
   await createForm.getByRole('textbox', { name: 'Name', exact: true }).fill('disk-6')
 
-  // this fill fails to happen sometimes, causing test flakes. the assert here
-  // should catch it slightly sooner
+  // If we try to fill the size field too soon after render (unnaturally fast --
+  // a real user would not be able to do it), the value gets quickly overwritten
+  // back to the default of 10, possibly because there are renders already in
+  // flight by the type we fill. This causes test flakes where the field is 10
+  // after we've filled 5 and the disk we're creating ends up with 10 GiB in
+  // the table. The flakes happened in Safari, but by adding a sleep _after_ the
+  // fill but before the check, we can force the failure in every browser.  By
+  // waiting a bit here _before_ the fill, we give those renders a chance to
+  // wrap up before we fill.
+  //
+  // This is a HACK -- logging in instance create and disk create shows that
+  // disk create does seem to render again a few hundred ms after the initial
+  // one, and it appears driven by renders in instance create (specifically the
+  // usePrefetchedApiQuery calls), but I wasn't able to fix it for real.
+  await sleep(1000)
+
   const sizeField = createForm.getByRole('textbox', { name: 'Size (GiB)' })
   await sizeField.fill('5')
   await expect(sizeField).toHaveValue('5')


### PR DESCRIPTION
See #2694.

Will close that in a bit if we stop seeing the flake.