### PR TITLE
Convert old charts to new style

### DIFF
--- a/app/components/RefetchIntervalPicker.tsx
+++ b/app/components/RefetchIntervalPicker.tsx
@@ -6,14 +6,13 @@
  * Copyright Oxide Computer Company
  */
 import cn from 'classnames'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
-import { Refresh16Icon, Time16Icon } from '@oxide/design-system/icons/react'
+import { Refresh16Icon } from '@oxide/design-system/icons/react'
 
 import { Listbox, type ListboxItem } from '~/ui/lib/Listbox'
 import { SpinnerLoader } from '~/ui/lib/Spinner'
 import { useInterval } from '~/ui/lib/use-interval'
-import { toLocaleTimeString } from '~/util/date'
 
 const intervalPresets = {
   Off: undefined,
@@ -37,25 +36,11 @@ type Props = {
   enabled: boolean
   isLoading: boolean
   fn: () => void
-  showLastFetched?: boolean
   className?: string
-  isSlim?: boolean
 }
 
-export function useIntervalPicker({
-  enabled,
-  isLoading,
-  fn,
-  showLastFetched = false,
-  className,
-  isSlim = false,
-}: Props) {
+export function useIntervalPicker({ enabled, isLoading, fn, className }: Props) {
   const [intervalPreset, setIntervalPreset] = useState<IntervalPreset>('10s')
-
-  const [lastFetched, setLastFetched] = useState(new Date())
-  useEffect(() => {
-    if (isLoading) setLastFetched(new Date())
-  }, [isLoading])
 
   const delay = enabled ? intervalPresets[intervalPreset] : null
   useInterval({ fn, delay })
@@ -63,37 +48,29 @@ export function useIntervalPicker({
   return {
     intervalMs: (enabled && intervalPresets[intervalPreset]) || undefined,
     intervalPicker: (
-      <div className={cn('flex items-center justify-between', className)}>
-        {showLastFetched && (
-          <div className="hidden items-center gap-2 text-right text-mono-sm text-tertiary lg+:flex">
-            <Time16Icon className="text-quaternary" /> Refreshed{' '}
-            {toLocaleTimeString(lastFetched)}
-          </div>
-        )}
-        <div className="flex">
-          <button
-            type="button"
-            className={cn(
-              'flex w-10 items-center justify-center rounded-l border-b border-l border-t border-default disabled:cursor-default',
-              isLoading && 'hover:bg-hover',
-              !enabled && 'cursor-not-allowed bg-disabled'
-            )}
-            onClick={fn}
-            disabled={isLoading || !enabled}
-          >
-            <SpinnerLoader isLoading={isLoading}>
-              <Refresh16Icon className="text-secondary" />
-            </SpinnerLoader>
-          </button>
-          <Listbox
-            selected={enabled ? intervalPreset : 'Off'}
-            className={cn('[&_button]:!rounded-l-none', isSlim ? '' : 'w-24')}
-            items={intervalItems}
-            onChange={setIntervalPreset}
-            disabled={!enabled}
-            hideSelected={isSlim}
-          />
-        </div>
+      <div className={cn('flex', className)}>
+        <button
+          type="button"
+          className={cn(
+            'flex w-10 items-center justify-center rounded-l border-b border-l border-t border-default disabled:cursor-default',
+            isLoading && 'hover:bg-hover',
+            !enabled && 'cursor-not-allowed bg-disabled'
+          )}
+          onClick={fn}
+          disabled={isLoading || !enabled}
+        >
+          <SpinnerLoader isLoading={isLoading}>
+            <Refresh16Icon className="text-secondary" />
+          </SpinnerLoader>
+        </button>
+        <Listbox
+          selected={enabled ? intervalPreset : 'Off'}
+          className="[&_button]:!rounded-l-none"
+          items={intervalItems}
+          onChange={setIntervalPreset}
+          disabled={!enabled}
+          hideSelected
+        />
       </div>
     ),
   }

--- a/app/components/SystemMetric.tsx
+++ b/app/components/SystemMetric.tsx
@@ -14,9 +14,7 @@ import {
   type SystemMetricName,
 } from '@oxide/api'
 
-import { Spinner } from '~/ui/lib/Spinner'
-
-import { TimeSeriesChart } from './TimeSeriesChart'
+import { ChartContainer, ChartHeader, TimeSeriesChart } from './TimeSeriesChart'
 
 // The difference between system metric and silo metric is
 //   1. different endpoints
@@ -24,7 +22,7 @@ import { TimeSeriesChart } from './TimeSeriesChart'
 
 type MetricProps = {
   title: string
-  unit?: string
+  unit: string
   startTime: Date
   endTime: Date
   metricName: SystemMetricName
@@ -93,23 +91,17 @@ export function SiloMetric({
   // in the tooltip. could be just once on the end of the x-axis like GCP
 
   return (
-    <div>
-      <h2 className="flex items-center gap-1.5 px-3 text-mono-sm text-default">
-        {title} {unit && <span className="text-tertiary">({unit})</span>}{' '}
-        {(inRange.isPending || beforeStart.isPending) && <Spinner />}
-      </h2>
-      {/* TODO: proper skeleton for empty chart */}
-      <div className="mt-3 h-[300px]">
-        <TimeSeriesChart
-          data={data}
-          title={title}
-          interpolation="stepAfter"
-          startTime={startTime}
-          endTime={endTime}
-          unit={unit !== 'count' ? unit : undefined}
-        />
-      </div>
-    </div>
+    <ChartContainer>
+      <ChartHeader title={title} label={`(${unit})`} />
+      <TimeSeriesChart
+        data={data}
+        title={title}
+        interpolation="stepAfter"
+        startTime={startTime}
+        endTime={endTime}
+        unit={unit !== 'Count' ? unit : undefined}
+      />
+    </ChartContainer>
   )
 }
 
@@ -167,22 +159,16 @@ export function SystemMetric({
   // in the tooltip. could be just once on the end of the x-axis like GCP
 
   return (
-    <div>
-      <h2 className="flex items-center gap-1.5 px-3 text-mono-sm text-default">
-        {title} {unit && <span className="text-tertiary">({unit})</span>}{' '}
-        {(inRange.isPending || beforeStart.isPending) && <Spinner />}
-      </h2>
-      {/* TODO: proper skeleton for empty chart */}
-      <div className="mt-3 h-[300px]">
-        <TimeSeriesChart
-          data={data}
-          title={title}
-          interpolation="stepAfter"
-          startTime={startTime}
-          endTime={endTime}
-          unit={unit !== 'count' ? unit : undefined}
-        />
-      </div>
-    </div>
+    <ChartContainer>
+      <ChartHeader title={title} label={`(${unit})`} />
+      <TimeSeriesChart
+        data={data}
+        title={title}
+        interpolation="stepAfter"
+        startTime={startTime}
+        endTime={endTime}
+        unit={unit !== 'Count' ? unit : undefined}
+      />
+    </ChartContainer>
   )
 }

--- a/app/components/SystemMetric.tsx
+++ b/app/components/SystemMetric.tsx
@@ -103,8 +103,6 @@ export function SiloMetric({
         <TimeSeriesChart
           data={data}
           title={title}
-          width={480}
-          height={240}
           interpolation="stepAfter"
           startTime={startTime}
           endTime={endTime}
@@ -179,8 +177,6 @@ export function SystemMetric({
         <TimeSeriesChart
           data={data}
           title={title}
-          width={480}
-          height={240}
           interpolation="stepAfter"
           startTime={startTime}
           endTime={endTime}

--- a/app/components/TimeSeriesChart.tsx
+++ b/app/components/TimeSeriesChart.tsx
@@ -110,8 +110,6 @@ type TimeSeriesChartProps = {
   className?: string
   data: ChartDatum[] | undefined
   title: string
-  width: number
-  height: number
   interpolation?: 'linear' | 'stepAfter'
   startTime: Date
   endTime: Date
@@ -169,8 +167,6 @@ export function TimeSeriesChart({
   className,
   data: rawData,
   title,
-  width,
-  height,
   interpolation = 'linear',
   startTime,
   endTime,
@@ -228,16 +224,14 @@ export function TimeSeriesChart({
     )
   }
 
+  const margin = { top: 0, right: hasBorder ? 16 : 0, bottom: 0, left: 0 }
+
+  // ResponsiveContainer has default height and width of 100%
+  // https://recharts.org/en-US/api/ResponsiveContainer
   return (
     <div className="h-[300px] w-full">
-      {/* temporary until we migrate the old metrics to the new style */}
       <ResponsiveContainer className={wrapperClass}>
-        <AreaChart
-          width={width}
-          height={height}
-          data={data}
-          margin={{ top: 0, right: hasBorder ? 16 : 0, bottom: 0, left: 0 }}
-        >
+        <AreaChart data={data} margin={margin}>
           <CartesianGrid stroke={GRID_GRAY} vertical={false} />
           <XAxis
             axisLine={{ stroke: GRID_GRAY }}

--- a/app/components/TimeSeriesChart.tsx
+++ b/app/components/TimeSeriesChart.tsx
@@ -7,7 +7,7 @@
  */
 import cn from 'classnames'
 import { format } from 'date-fns'
-import React, { useMemo, type ReactNode } from 'react'
+import { useMemo, type ReactNode } from 'react'
 import {
   Area,
   AreaChart,
@@ -316,7 +316,7 @@ type ChartHeaderProps = {
   title: string
   label: string
   description?: string
-  children?: React.ReactNode
+  children?: ReactNode
 }
 
 export function ChartHeader({ title, label, description, children }: ChartHeaderProps) {

--- a/app/components/TimeSeriesChart.tsx
+++ b/app/components/TimeSeriesChart.tsx
@@ -266,7 +266,7 @@ export function TimeSeriesChart({
           />
           <Area
             dataKey="value"
-            name={title}
+            name={title} // Provides name for value in hover tooltip
             type={interpolation}
             stroke={GREEN_600}
             fill={GREEN_400}

--- a/app/components/TimeSeriesChart.tsx
+++ b/app/components/TimeSeriesChart.tsx
@@ -7,7 +7,7 @@
  */
 import cn from 'classnames'
 import { format } from 'date-fns'
-import { useMemo, type ReactNode } from 'react'
+import React, { useMemo, type ReactNode } from 'react'
 import {
   Area,
   AreaChart,
@@ -21,6 +21,8 @@ import type { TooltipProps } from 'recharts/types/component/Tooltip'
 
 import type { ChartDatum } from '@oxide/api'
 import { Error12Icon } from '@oxide/design-system/icons/react'
+
+import { classed } from '~/util/classed'
 
 // Recharts's built-in ticks behavior is useless and probably broken
 /**
@@ -115,7 +117,6 @@ type TimeSeriesChartProps = {
   endTime: Date
   unit?: string
   yAxisTickFormatter?: (val: number) => string
-  hasBorder?: boolean
   hasError?: boolean
 }
 
@@ -164,7 +165,6 @@ const SkeletonMetric = ({
 )
 
 export function TimeSeriesChart({
-  className,
   data: rawData,
   title,
   interpolation = 'linear',
@@ -172,7 +172,6 @@ export function TimeSeriesChart({
   endTime,
   unit,
   yAxisTickFormatter = (val) => val.toLocaleString(),
-  hasBorder = true,
   hasError = false,
 }: TimeSeriesChartProps) {
   // We use the largest data point +20% for the graph scale. !rawData doesn't
@@ -206,11 +205,9 @@ export function TimeSeriesChart({
   // re-render on every render of the parent when the data is undefined
   const data = useMemo(() => rawData || [], [rawData])
 
-  const wrapperClass = cn(className, hasBorder && 'rounded-lg border border-default')
-
   if (hasError) {
     return (
-      <SkeletonMetric className={wrapperClass}>
+      <SkeletonMetric>
         <MetricsError />
       </SkeletonMetric>
     )
@@ -218,20 +215,18 @@ export function TimeSeriesChart({
 
   if (!data || data.length === 0) {
     return (
-      <SkeletonMetric shimmer className={wrapperClass}>
+      <SkeletonMetric shimmer>
         <MetricsLoadingIndicator />
       </SkeletonMetric>
     )
   }
 
-  const margin = { top: 0, right: hasBorder ? 16 : 0, bottom: 0, left: 0 }
-
   // ResponsiveContainer has default height and width of 100%
   // https://recharts.org/en-US/api/ResponsiveContainer
   return (
-    <div className="h-[300px] w-full">
-      <ResponsiveContainer className={wrapperClass}>
-        <AreaChart data={data} margin={margin}>
+    <div className="px-5 pb-5 pt-8">
+      <ResponsiveContainer height={300}>
+        <AreaChart data={data} margin={{ top: 0, right: 0, bottom: 0, left: 0 }}>
           <CartesianGrid stroke={GRID_GRAY} vertical={false} />
           <XAxis
             axisLine={{ stroke: GRID_GRAY }}
@@ -314,3 +309,27 @@ const MetricsError = () => (
     />
   </>
 )
+
+export const ChartContainer = classed.div`flex w-full grow flex-col rounded-lg border border-default`
+
+type ChartHeaderProps = {
+  title: string
+  label: string
+  description?: string
+  children?: React.ReactNode
+}
+
+export function ChartHeader({ title, label, description, children }: ChartHeaderProps) {
+  return (
+    <div className="flex items-center justify-between border-b px-5 pb-4 pt-5 border-secondary">
+      <div>
+        <h2 className="flex items-baseline gap-1.5">
+          <div className="text-sans-semi-lg">{title}</div>
+          <div className="text-sans-md text-secondary">{label}</div>
+        </h2>
+        <div className="mt-0.5 text-sans-md text-secondary">{description}</div>
+      </div>
+      {children}
+    </div>
+  )
+}

--- a/app/components/oxql-metrics/OxqlMetric.tsx
+++ b/app/components/oxql-metrics/OxqlMetric.tsx
@@ -25,7 +25,7 @@ import * as Dropdown from '~/ui/lib/DropdownMenu'
 import { classed } from '~/util/classed'
 import { links } from '~/util/links'
 
-import { TimeSeriesChart } from '../TimeSeriesChart'
+import { ChartContainer, ChartHeader, TimeSeriesChart } from '../TimeSeriesChart'
 import { HighlightedOxqlQuery, toOxqlStr } from './HighlightedOxqlQuery'
 import {
   composeOxqlData,
@@ -77,15 +77,8 @@ export function OxqlMetric({ title, description, unit, ...queryObj }: OxqlMetric
   const [modalOpen, setModalOpen] = useState(false)
 
   return (
-    <div className="flex w-full grow flex-col rounded-lg border border-default">
-      <div className="flex items-center justify-between border-b px-5 pb-4 pt-5 border-secondary">
-        <div>
-          <h2 className="flex items-baseline gap-1.5">
-            <div className="text-sans-semi-lg">{title}</div>
-            <div className="text-sans-md text-secondary">{label}</div>
-          </h2>
-          <div className="mt-0.5 text-sans-md text-secondary">{description}</div>
-        </div>
+    <ChartContainer>
+      <ChartHeader title={title} label={label} description={description}>
         <MoreActionsMenu label="Instance actions" isSmall>
           <Dropdown.LinkItem to={links.oxqlSchemaDocs(queryObj.metricName)}>
             About this metric
@@ -102,20 +95,17 @@ export function OxqlMetric({ title, description, unit, ...queryObj }: OxqlMetric
         >
           <HighlightedOxqlQuery {...queryObj} />
         </CopyCodeModal>
-      </div>
-      <div className="px-5 pb-5 pt-8">
-        <TimeSeriesChart
-          title={title}
-          startTime={startTime}
-          endTime={endTime}
-          unit={unitForSet}
-          data={data}
-          yAxisTickFormatter={yAxisTickFormatter}
-          hasBorder={false}
-          hasError={!!error}
-        />
-      </div>
-    </div>
+      </ChartHeader>
+      <TimeSeriesChart
+        title={title}
+        startTime={startTime}
+        endTime={endTime}
+        unit={unitForSet}
+        data={data}
+        yAxisTickFormatter={yAxisTickFormatter}
+        hasError={!!error}
+      />
+    </ChartContainer>
   )
 }
 

--- a/app/components/oxql-metrics/OxqlMetric.tsx
+++ b/app/components/oxql-metrics/OxqlMetric.tsx
@@ -111,8 +111,6 @@ export function OxqlMetric({ title, description, unit, ...queryObj }: OxqlMetric
           unit={unitForSet}
           data={data}
           yAxisTickFormatter={yAxisTickFormatter}
-          width={480}
-          height={240}
           hasBorder={false}
           hasError={!!error}
         />

--- a/app/pages/SiloUtilizationPage.tsx
+++ b/app/pages/SiloUtilizationPage.tsx
@@ -114,7 +114,7 @@ export default function SiloUtilizationPage() {
           {...commonProps}
           metricName="cpus_provisioned"
           title="CPU"
-          unit="count"
+          unit="Count"
         />
         <SiloMetric
           {...commonProps}

--- a/app/pages/SiloUtilizationPage.tsx
+++ b/app/pages/SiloUtilizationPage.tsx
@@ -63,8 +63,6 @@ export default function SiloUtilizationPage() {
     isLoading: useIsFetching({ queryKey: ['siloMetric'] }) > 0,
     // sliding the range forward is sufficient to trigger a refetch
     fn: () => onRangeChange(preset),
-    showLastFetched: true,
-    className: 'mb-12',
   })
 
   const commonProps = {
@@ -94,22 +92,23 @@ export default function SiloUtilizationPage() {
 
       <Divider className="my-6" />
 
-      <div className="mb-3 mt-8 flex justify-between gap-3">
-        <Listbox
-          selected={filterId}
-          className="w-64"
-          aria-labelledby="filter-id-label"
-          name="filter-id"
-          items={projectItems}
-          onChange={setFilterId}
-        />
+      <div className="mb-3 mt-8 flex flex-wrap justify-between gap-3">
+        <div className="flex gap-2">
+          {intervalPicker}
 
+          <Listbox
+            selected={filterId}
+            className="w-52"
+            aria-labelledby="filter-id-label"
+            name="filter-id"
+            items={projectItems}
+            onChange={setFilterId}
+          />
+        </div>
         <div className="flex items-center gap-2">{dateTimeRangePicker}</div>
       </div>
 
-      {intervalPicker}
-
-      <div className="mb-12 space-y-12">
+      <div className="mb-3 space-y-4">
         <SiloMetric
           {...commonProps}
           metricName="cpus_provisioned"

--- a/app/pages/project/instances/MetricsTab.tsx
+++ b/app/pages/project/instances/MetricsTab.tsx
@@ -41,7 +41,6 @@ export default function MetricsTab() {
     isLoading: useIsFetching({ queryKey: ['systemTimeseriesQuery'] }) > 0,
     // sliding the range forward is sufficient to trigger a refetch
     fn: () => onRangeChange(preset),
-    isSlim: true,
   })
 
   // memoizing here would be redundant because the only things that cause a

--- a/app/pages/system/UtilizationPage.tsx
+++ b/app/pages/system/UtilizationPage.tsx
@@ -114,8 +114,6 @@ const MetricsTab = () => {
     isLoading: useIsFetching({ queryKey: ['systemMetric'] }) > 0,
     // sliding the range forward is sufficient to trigger a refetch
     fn: () => onRangeChange(preset),
-    showLastFetched: true,
-    className: 'mb-12',
   })
 
   const commonProps = {
@@ -127,22 +125,22 @@ const MetricsTab = () => {
 
   return (
     <>
-      <div className="mb-3 mt-8 flex justify-between gap-3">
-        <Listbox
-          selected={filterId}
-          className="w-64"
-          aria-labelledby="filter-id-label"
-          name="filter-id"
-          items={siloItems}
-          onChange={setFilterId}
-        />
+      <div className="mb-3 mt-8 flex flex-wrap justify-between gap-3">
+        <div className="flex gap-2">
+          {intervalPicker}
 
+          <Listbox
+            selected={filterId}
+            className="w-52"
+            aria-labelledby="filter-id-label"
+            name="filter-id"
+            items={siloItems}
+            onChange={setFilterId}
+          />
+        </div>
         <div className="flex items-center gap-2">{dateTimeRangePicker}</div>
       </div>
-
-      {intervalPicker}
-
-      <div className="mb-12 space-y-12">
+      <div className="mb-4 space-y-4">
         <SystemMetric
           {...commonProps}
           metricName="cpus_provisioned"

--- a/app/pages/system/UtilizationPage.tsx
+++ b/app/pages/system/UtilizationPage.tsx
@@ -147,7 +147,7 @@ const MetricsTab = () => {
           {...commonProps}
           metricName="cpus_provisioned"
           title="CPU"
-          unit="count"
+          unit="Count"
         />
         <SystemMetric
           {...commonProps}


### PR DESCRIPTION
Looking at #2732, #2733, and #2737, I realized we'd benefit from simplifying the chart component, and one source of complexity was the fact that the non-OxQL system and silo utilization charts were styled differently. So here I bring them up to date with the new style and eliminate the props we were using to differentiate.

## Before

<img width="906" alt="image" src="https://github.com/user-attachments/assets/a9122a82-8f60-4e3b-b30f-e91e42a9e9ba" />

## After

<img width="919" alt="image" src="https://github.com/user-attachments/assets/68026f84-7303-41cd-b616-c06bd27a67be" />
