### PR TITLE
trivial: don't do unnecessary racks fetch on inventory page

### DIFF
--- a/app/layouts/SystemLayout.tsx
+++ b/app/layouts/SystemLayout.tsx
@@ -42,8 +42,6 @@ export async function clientLoader() {
     .then(() => true)
     .catch(() => false)
 
-  // TODO: make sure 404 is the desired behavior. This situation should be
-  // pretty unlikely.
   if (!isFleetViewer) throw trigger404
 
   return null

--- a/app/pages/system/inventory/InventoryPage.tsx
+++ b/app/pages/system/inventory/InventoryPage.tsx
@@ -6,7 +6,6 @@
  * Copyright Oxide Computer Company
  */
 
-import { getListQFn, queryClient, usePrefetchedQuery } from '@oxide/api'
 import { Servers16Icon, Servers24Icon } from '@oxide/design-system/icons/react'
 
 import { DocsPopover } from '~/components/DocsPopover'
@@ -16,21 +15,9 @@ import { PageHeader, PageTitle } from '~/ui/lib/PageHeader'
 import { docLinks } from '~/util/links'
 import { pb } from '~/util/path-builder'
 
-const rackList = getListQFn('rackList', {})
-
-export async function clientLoader() {
-  await queryClient.prefetchQuery(rackList.optionsFn())
-  return null
-}
-
 export const handle = makeCrumb('Inventory', pb.sledInventory())
 
 export default function InventoryPage() {
-  const { data: racks } = usePrefetchedQuery(rackList.optionsFn())
-  const rack = racks?.items[0]
-
-  if (!rack) return null
-
   return (
     <>
       <PageHeader>


### PR DESCRIPTION
This was added in #1341, when it was actually used to display metadata about the rack on the page. We removed that display but didn't remove the fetch.