### PR TITLE
Tighten spacing and more consistent with other layouts

### DIFF
--- a/app/components/RefetchIntervalPicker.tsx
+++ b/app/components/RefetchIntervalPicker.tsx
@@ -6,14 +6,13 @@
  * Copyright Oxide Computer Company
  */
 import cn from 'classnames'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
-import { Refresh16Icon, Time16Icon } from '@oxide/design-system/icons/react'
+import { Refresh16Icon } from '@oxide/design-system/icons/react'
 
 import { Listbox, type ListboxItem } from '~/ui/lib/Listbox'
 import { SpinnerLoader } from '~/ui/lib/Spinner'
 import { useInterval } from '~/ui/lib/use-interval'
-import { toLocaleTimeString } from '~/util/date'
 
 const intervalPresets = {
   Off: undefined,
@@ -37,25 +36,11 @@ type Props = {
   enabled: boolean
   isLoading: boolean
   fn: () => void
-  showLastFetched?: boolean
   className?: string
-  isSlim?: boolean
 }
 
-export function useIntervalPicker({
-  enabled,
-  isLoading,
-  fn,
-  showLastFetched = false,
-  className,
-  isSlim = false,
-}: Props) {
+export function useIntervalPicker({ enabled, isLoading, fn, className }: Props) {
   const [intervalPreset, setIntervalPreset] = useState<IntervalPreset>('10s')
-
-  const [lastFetched, setLastFetched] = useState(new Date())
-  useEffect(() => {
-    if (isLoading) setLastFetched(new Date())
-  }, [isLoading])
 
   const delay = enabled ? intervalPresets[intervalPreset] : null
   useInterval({ fn, delay })
@@ -63,37 +48,29 @@ export function useIntervalPicker({
   return {
     intervalMs: (enabled && intervalPresets[intervalPreset]) || undefined,
     intervalPicker: (
-      <div className={cn('flex items-center justify-between', className)}>
-        {showLastFetched && (
-          <div className="hidden items-center gap-2 text-right text-mono-sm text-tertiary lg+:flex">
-            <Time16Icon className="text-quaternary" /> Refreshed{' '}
-            {toLocaleTimeString(lastFetched)}
-          </div>
-        )}
-        <div className="flex">
-          <button
-            type="button"
-            className={cn(
-              'flex w-10 items-center justify-center rounded-l border-b border-l border-t border-default disabled:cursor-default',
-              isLoading && 'hover:bg-hover',
-              !enabled && 'cursor-not-allowed bg-disabled'
-            )}
-            onClick={fn}
-            disabled={isLoading || !enabled}
-          >
-            <SpinnerLoader isLoading={isLoading}>
-              <Refresh16Icon className="text-secondary" />
-            </SpinnerLoader>
-          </button>
-          <Listbox
-            selected={enabled ? intervalPreset : 'Off'}
-            className={cn('[&_button]:!rounded-l-none', isSlim ? '' : 'w-24')}
-            items={intervalItems}
-            onChange={setIntervalPreset}
-            disabled={!enabled}
-            hideSelected={isSlim}
-          />
-        </div>
+      <div className={cn('flex', className)}>
+        <button
+          type="button"
+          className={cn(
+            'flex w-10 items-center justify-center rounded-l border-b border-l border-t border-default disabled:cursor-default',
+            isLoading && 'hover:bg-hover',
+            !enabled && 'cursor-not-allowed bg-disabled'
+          )}
+          onClick={fn}
+          disabled={isLoading || !enabled}
+        >
+          <SpinnerLoader isLoading={isLoading}>
+            <Refresh16Icon className="text-secondary" />
+          </SpinnerLoader>
+        </button>
+        <Listbox
+          selected={enabled ? intervalPreset : 'Off'}
+          className="[&_button]:!rounded-l-none"
+          items={intervalItems}
+          onChange={setIntervalPreset}
+          disabled={!enabled}
+          hideSelected
+        />
       </div>
     ),
   }

--- a/app/pages/SiloUtilizationPage.tsx
+++ b/app/pages/SiloUtilizationPage.tsx
@@ -63,8 +63,6 @@ export default function SiloUtilizationPage() {
     isLoading: useIsFetching({ queryKey: ['siloMetric'] }) > 0,
     // sliding the range forward is sufficient to trigger a refetch
     fn: () => onRangeChange(preset),
-    showLastFetched: true,
-    className: 'mb-12',
   })
 
   const commonProps = {
@@ -94,20 +92,21 @@ export default function SiloUtilizationPage() {
 
       <Divider className="my-6" />
 
-      <div className="mb-3 mt-8 flex justify-between gap-3">
-        <Listbox
-          selected={filterId}
-          className="w-64"
-          aria-labelledby="filter-id-label"
-          name="filter-id"
-          items={projectItems}
-          onChange={setFilterId}
-        />
+      <div className="mb-3 mt-8 flex flex-wrap justify-between gap-3">
+        <div className="flex gap-2">
+          {intervalPicker}
 
+          <Listbox
+            selected={filterId}
+            className="w-52"
+            aria-labelledby="filter-id-label"
+            name="filter-id"
+            items={projectItems}
+            onChange={setFilterId}
+          />
+        </div>
         <div className="flex items-center gap-2">{dateTimeRangePicker}</div>
       </div>
-
-      {intervalPicker}
 
       <div className="mb-12 space-y-12">
         <SiloMetric

--- a/app/pages/SiloUtilizationPage.tsx
+++ b/app/pages/SiloUtilizationPage.tsx
@@ -108,7 +108,7 @@ export default function SiloUtilizationPage() {
         <div className="flex items-center gap-2">{dateTimeRangePicker}</div>
       </div>
 
-      <div className="mb-12 space-y-12">
+      <div className="mb-3 space-y-4">
         <SiloMetric
           {...commonProps}
           metricName="cpus_provisioned"

--- a/app/pages/project/instances/MetricsTab.tsx
+++ b/app/pages/project/instances/MetricsTab.tsx
@@ -41,7 +41,6 @@ export default function MetricsTab() {
     isLoading: useIsFetching({ queryKey: ['systemTimeseriesQuery'] }) > 0,
     // sliding the range forward is sufficient to trigger a refetch
     fn: () => onRangeChange(preset),
-    isSlim: true,
   })
 
   // memoizing here would be redundant because the only things that cause a

--- a/app/pages/system/UtilizationPage.tsx
+++ b/app/pages/system/UtilizationPage.tsx
@@ -114,8 +114,6 @@ const MetricsTab = () => {
     isLoading: useIsFetching({ queryKey: ['systemMetric'] }) > 0,
     // sliding the range forward is sufficient to trigger a refetch
     fn: () => onRangeChange(preset),
-    showLastFetched: true,
-    className: 'mb-12',
   })
 
   const commonProps = {
@@ -127,22 +125,22 @@ const MetricsTab = () => {
 
   return (
     <>
-      <div className="mb-3 mt-8 flex justify-between gap-3">
-        <Listbox
-          selected={filterId}
-          className="w-64"
-          aria-labelledby="filter-id-label"
-          name="filter-id"
-          items={siloItems}
-          onChange={setFilterId}
-        />
+      <div className="mb-3 mt-8 flex flex-wrap justify-between gap-3">
+        <div className="flex gap-2">
+          {intervalPicker}
 
+          <Listbox
+            selected={filterId}
+            className="w-52"
+            aria-labelledby="filter-id-label"
+            name="filter-id"
+            items={siloItems}
+            onChange={setFilterId}
+          />
+        </div>
         <div className="flex items-center gap-2">{dateTimeRangePicker}</div>
       </div>
-
-      {intervalPicker}
-
-      <div className="mb-12 space-y-12">
+      <div className="mb-4 space-y-4">
         <SystemMetric
           {...commonProps}
           metricName="cpus_provisioned"


### PR DESCRIPTION
Making more consistent with other chart layouts. Also means we can simplify the interval picker.

<img width="985" alt="image" src="https://github.com/user-attachments/assets/cabfca00-ca6d-4c38-952a-6524f0df8087" />
