### PR TITLE
Fix metric loading and empty states

### DIFF
--- a/app/components/SystemMetric.tsx
+++ b/app/components/SystemMetric.tsx
@@ -100,6 +100,9 @@ export function SiloMetric({
         startTime={startTime}
         endTime={endTime}
         unit={unit !== 'Count' ? unit : undefined}
+        // note use of loading, not fetching, which is only true on first fetch.
+        // otherwise we get loading states on refetches
+        loading={inRange.isLoading || beforeStart.isLoading}
       />
     </ChartContainer>
   )
@@ -168,6 +171,9 @@ export function SystemMetric({
         startTime={startTime}
         endTime={endTime}
         unit={unit !== 'Count' ? unit : undefined}
+        // note use of loading, not fetching, which is only true on first fetch.
+        // otherwise we get loading states on refetches
+        loading={inRange.isLoading || beforeStart.isLoading}
       />
     </ChartContainer>
   )

--- a/app/components/TimeSeriesChart.tsx
+++ b/app/components/TimeSeriesChart.tsx
@@ -118,6 +118,7 @@ type TimeSeriesChartProps = {
   unit?: string
   yAxisTickFormatter?: (val: number) => string
   hasError?: boolean
+  loading: boolean
 }
 
 const TICK_COUNT = 6
@@ -173,6 +174,7 @@ export function TimeSeriesChart({
   unit,
   yAxisTickFormatter = (val) => val.toLocaleString(),
   hasError = false,
+  loading,
 }: TimeSeriesChartProps) {
   // We use the largest data point +20% for the graph scale. !rawData doesn't
   // mean it's empty (it will never be empty because we fill in artificial 0s at
@@ -213,10 +215,17 @@ export function TimeSeriesChart({
     )
   }
 
-  if (!data || data.length === 0) {
+  if (loading) {
     return (
       <SkeletonMetric shimmer>
         <MetricsLoadingIndicator />
+      </SkeletonMetric>
+    )
+  }
+  if (!data || data.length === 0) {
+    return (
+      <SkeletonMetric>
+        <MetricsEmpty />
       </SkeletonMetric>
     )
   }
@@ -288,16 +297,21 @@ const MetricsLoadingIndicator = () => (
   </div>
 )
 
-const MetricsError = () => (
+const MetricsMessage = ({
+  icon,
+  title,
+  description,
+}: {
+  icon?: React.ReactNode
+  title: React.ReactNode
+  description: React.ReactNode
+}) => (
   <>
     <div className="z-10 flex w-52 flex-col items-center justify-center gap-1">
-      <div className="my-2 flex h-8 w-8 items-center justify-center">
-        <div className="absolute h-8 w-8 rounded-full opacity-20 bg-destructive motion-safe:animate-[ping_2s_cubic-bezier(0,0,0.2,1)_infinite]" />
-        <Error12Icon className="relative h-6 w-6 text-error-tertiary" />
-      </div>
-      <div className="text-semi-lg text-center text-raise">Something went wrong</div>
-      <div className="text-center text-sans-md text-secondary">
-        Please try again. If the problem persists, contact your administrator.
+      <div className="my-2 flex h-8 w-8 items-center justify-center">{icon}</div>
+      <div className="text-semi-lg text-center text-raise">{title}</div>
+      <div className="text-balance text-center text-sans-md text-secondary">
+        {description}
       </div>
     </div>
     <div
@@ -310,6 +324,26 @@ const MetricsError = () => (
   </>
 )
 
+const MetricsError = () => (
+  <MetricsMessage
+    icon={
+      <>
+        <div className="absolute h-8 w-8 rounded-full opacity-20 bg-destructive motion-safe:animate-[ping_2s_cubic-bezier(0,0,0.2,1)_infinite]" />
+        <Error12Icon className="relative h-6 w-6 text-error-tertiary" />
+      </>
+    }
+    title="Something went wrong"
+    description="Please try again. If the problem persists, contact your administrator."
+  />
+)
+
+const MetricsEmpty = () => (
+  <MetricsMessage
+    // icon={<Char className="h-6 w-6 text-secondary" />}
+    title="No data"
+    description="There is no data for this time period."
+  />
+)
 export const ChartContainer = classed.div`flex w-full grow flex-col rounded-lg border border-default`
 
 type ChartHeaderProps = {

--- a/app/components/TimeSeriesChart.tsx
+++ b/app/components/TimeSeriesChart.tsx
@@ -290,7 +290,7 @@ export function TimeSeriesChart({
 }
 
 const MetricsLoadingIndicator = () => (
-  <div className="metrics-loading-indicator">
+  <div className="metrics-loading-indicator" aria-label="Chart loading">
     <span></span>
     <span></span>
     <span></span>
@@ -308,7 +308,7 @@ const MetricsMessage = ({
 }) => (
   <>
     <div className="z-10 flex w-52 flex-col items-center justify-center gap-1">
-      <div className="my-2 flex h-8 w-8 items-center justify-center">{icon}</div>
+      {icon}
       <div className="text-semi-lg text-center text-raise">{title}</div>
       <div className="text-balance text-center text-sans-md text-secondary">
         {description}
@@ -327,10 +327,10 @@ const MetricsMessage = ({
 const MetricsError = () => (
   <MetricsMessage
     icon={
-      <>
+      <div className="my-2 flex h-8 w-8 items-center justify-center">
         <div className="absolute h-8 w-8 rounded-full opacity-20 bg-destructive motion-safe:animate-[ping_2s_cubic-bezier(0,0,0.2,1)_infinite]" />
         <Error12Icon className="relative h-6 w-6 text-error-tertiary" />
-      </>
+      </div>
     }
     title="Something went wrong"
     description="Please try again. If the problem persists, contact your administrator."
@@ -339,8 +339,8 @@ const MetricsError = () => (
 
 const MetricsEmpty = () => (
   <MetricsMessage
-    // icon={<Char className="h-6 w-6 text-secondary" />}
-    title="No data"
+    // mt-3 is a shameful hack to get it vertically centered in the chart
+    title={<div className="mt-3">No data</div>}
     description="There is no data for this time period."
   />
 )

--- a/app/components/oxql-metrics/OxqlMetric.tsx
+++ b/app/components/oxql-metrics/OxqlMetric.tsx
@@ -12,15 +12,14 @@
  */
 
 import { useQuery } from '@tanstack/react-query'
-import { Children, useEffect, useMemo, useState, type ReactNode } from 'react'
+import { Children, useMemo, useState, type ReactNode } from 'react'
 import type { LoaderFunctionArgs } from 'react-router'
 
 import { apiq, queryClient } from '@oxide/api'
 
 import { CopyCodeModal } from '~/components/CopyCode'
 import { MoreActionsMenu } from '~/components/MoreActionsMenu'
-import { getInstanceSelector, useProjectSelector } from '~/hooks/use-params'
-import { useMetricsContext } from '~/pages/project/instances/common'
+import { getInstanceSelector } from '~/hooks/use-params'
 import { LearnMore } from '~/ui/lib/CardBlock'
 import * as Dropdown from '~/ui/lib/DropdownMenu'
 import { classed } from '~/util/classed'
@@ -51,23 +50,33 @@ export type OxqlMetricProps = OxqlQuery & {
 }
 
 export function OxqlMetric({ title, description, unit, ...queryObj }: OxqlMetricProps) {
-  // only start reloading data once an intial dataset has been loaded
-  const { setIsIntervalPickerEnabled } = useMetricsContext()
-  const { project } = useProjectSelector()
   const query = toOxqlStr(queryObj)
-  const { data: metrics, error } = useQuery(
-    apiq('timeseriesQuery', { body: { query }, query: { project } })
+  const {
+    data: metrics,
+    error,
+    isPending,
+  } = useQuery(
+    apiq('systemTimeseriesQuery', { body: { query } })
     // avoid graphs flashing blank while loading when you change the time
     // { placeholderData: (x) => x }
   )
-  useEffect(() => {
-    if (metrics) {
-      // this is too slow right now; disabling until we can make it faster
-      // setIsIntervalPickerEnabled(true)
-    }
-  }, [metrics, setIsIntervalPickerEnabled])
+
+  // HACK: omicron has a bug where it blows up on an attempt to group by on
+  // empty result set because it can't determine whether the data is aligned.
+  // Most likely it should consider empty data sets trivially aligned and just
+  // flow the emptiness on through, but in the meantime we have to detect
+  // this error and pretend it is not an error.
+  // See https://github.com/oxidecomputer/omicron/issues/7715
+  const errorMeansEmpty = error?.message === 'Input tables to a `group_by` must be aligned'
+  const hasError = !!error && !errorMeansEmpty
+
   const { startTime, endTime } = queryObj
-  const { chartData, timeseriesCount } = useMemo(() => composeOxqlData(metrics), [metrics])
+  const { chartData, timeseriesCount } = useMemo(
+    () =>
+      errorMeansEmpty ? { chartData: [], timeseriesCount: 0 } : composeOxqlData(metrics),
+    [metrics, errorMeansEmpty]
+  )
+
   const { data, label, unitForSet, yAxisTickFormatter } = useMemo(() => {
     if (unit === 'Bytes') return getBytesChartProps(chartData)
     if (unit === 'Count') return getCountChartProps(chartData)
@@ -103,7 +112,8 @@ export function OxqlMetric({ title, description, unit, ...queryObj }: OxqlMetric
         unit={unitForSet}
         data={data}
         yAxisTickFormatter={yAxisTickFormatter}
-        hasError={!!error}
+        hasError={hasError}
+        loading={isPending}
       />
     </ChartContainer>
   )

--- a/app/components/oxql-metrics/OxqlMetric.tsx
+++ b/app/components/oxql-metrics/OxqlMetric.tsx
@@ -19,7 +19,7 @@ import { apiq, queryClient } from '@oxide/api'
 
 import { CopyCodeModal } from '~/components/CopyCode'
 import { MoreActionsMenu } from '~/components/MoreActionsMenu'
-import { getInstanceSelector } from '~/hooks/use-params'
+import { getInstanceSelector, useProjectSelector } from '~/hooks/use-params'
 import { LearnMore } from '~/ui/lib/CardBlock'
 import * as Dropdown from '~/ui/lib/DropdownMenu'
 import { classed } from '~/util/classed'
@@ -51,12 +51,13 @@ export type OxqlMetricProps = OxqlQuery & {
 
 export function OxqlMetric({ title, description, unit, ...queryObj }: OxqlMetricProps) {
   const query = toOxqlStr(queryObj)
+  const { project } = useProjectSelector()
   const {
     data: metrics,
     error,
-    isPending,
+    isLoading,
   } = useQuery(
-    apiq('systemTimeseriesQuery', { body: { query } })
+    apiq('timeseriesQuery', { body: { query }, query: { project } })
     // avoid graphs flashing blank while loading when you change the time
     // { placeholderData: (x) => x }
   )
@@ -113,7 +114,8 @@ export function OxqlMetric({ title, description, unit, ...queryObj }: OxqlMetric
         data={data}
         yAxisTickFormatter={yAxisTickFormatter}
         hasError={hasError}
-        loading={isPending}
+        // isLoading only covers first load --- future-proof against the reintroduction of interval refresh
+        loading={isLoading}
       />
     </ChartContainer>
   )

--- a/mock-api/msw/handlers.ts
+++ b/mock-api/msw/handlers.ts
@@ -1620,8 +1620,13 @@ export const handlers = makeHandlers({
     if (query.project === 'other-project') {
       // 1. return only one data point
       const points = Object.values(data.tables[0].timeseries)[0].points
-      points.timestamps = points.timestamps.slice(0, 2)
-      points.values = points.values.slice(0, 2)
+      if (body.query.includes('state == "run"')) {
+        points.timestamps = points.timestamps.slice(0, 2)
+        points.values = points.values.slice(0, 2)
+      } else if (body.query.includes('state == "emulation"')) {
+        points.timestamps = points.timestamps.slice(0, 1)
+        points.values = points.values.slice(0, 1)
+      }
     }
 
     return data

--- a/mock-api/msw/handlers.ts
+++ b/mock-api/msw/handlers.ts
@@ -1614,7 +1614,17 @@ export const handlers = makeHandlers({
 
     // timeseries queries are slower than most other queries
     await delay(1000)
-    return handleOxqlMetrics(body)
+    const data = handleOxqlMetrics(body)
+
+    // we use other-project to test certain response cases
+    if (query.project === 'other-project') {
+      // 1. return only one data point
+      const points = Object.values(data.tables[0].timeseries)[0].points
+      points.timestamps = points.timestamps.slice(0, 2)
+      points.values = points.values.slice(0, 2)
+    }
+
+    return data
   },
   async systemTimeseriesQuery({ cookies, body }) {
     requireFleetViewer(cookies)

--- a/mock-api/oxql-metrics.ts
+++ b/mock-api/oxql-metrics.ts
@@ -280,7 +280,9 @@ export const getMockOxqlInstanceData = (
   state?: OxqlVcpuState
 ): Json<OxqlQueryResult> => {
   const values = state ? mockOxqlVcpuStateValues[state] : mockOxqlValues[name]
-  return {
+  // structuredClone lets us mutate data in the calling code without messing up
+  // the source data
+  return structuredClone({
     tables: [
       {
         name: name,
@@ -310,5 +312,5 @@ export const getMockOxqlInstanceData = (
         },
       },
     ],
-  }
+  })
 }


### PR DESCRIPTION
Closes #2733 by adding an explicit loading prop, pass in `isLoading` from React Query results

Closes #2737 by adding explicit empty state inside `TimeSeriesChart`, distinct from loading

Closes #2738 by explicitly watching for the telltale error message and treating it as an empty success result instead

### Before (Empty results group by error)

<img width="814" alt="image" src="https://github.com/user-attachments/assets/11f9915b-a496-4722-8493-af8872755896" />

### After

<img width="811" alt="image" src="https://github.com/user-attachments/assets/83e51c44-3954-4525-ad18-f27db8f59ef0" />

