### PR TITLE
Prevent adding instance to A-A group when not stopped

### DIFF
--- a/app/api/util.ts
+++ b/app/api/util.ts
@@ -131,6 +131,10 @@ const instanceActions = {
   updateNic: ['stopped'],
   // https://github.com/oxidecomputer/omicron/blob/6dd9802/nexus/src/app/instance.rs#L1520-L1522
   serialConsole: ['running', 'rebooting', 'migrating', 'repairing'],
+
+  // https://github.com/oxidecomputer/omicron/blob/5e27bde/nexus/src/app/affinity.rs#L357 checks to see that there's no VMM
+  // TODO: determine whether the intent is only `stopped` or also `failed`
+  addToAntiAffinityGroup: ['stopped'],
 } satisfies Record<string, InstanceState[]>
 
 // setting .states is a cute way to make it ergonomic to call the test function

--- a/app/pages/project/instances/AntiAffinityCard.tsx
+++ b/app/pages/project/instances/AntiAffinityCard.tsx
@@ -13,6 +13,7 @@ import * as R from 'remeda'
 
 import {
   apiq,
+  instanceCan,
   queryClient,
   useApiMutation,
   usePrefetchedQuery,
@@ -151,7 +152,7 @@ export function AntiAffinityCard() {
   })
 
   const getDisabledReason = () => {
-    if (instanceData.runState !== 'stopped') {
+    if (!instanceCan.addToAntiAffinityGroup(instanceData)) {
       return 'This instance must be stopped to add it to a group'
     }
     if (allGroups.items.length === 0) {

--- a/app/pages/project/instances/AntiAffinityCard.tsx
+++ b/app/pages/project/instances/AntiAffinityCard.tsx
@@ -150,21 +150,26 @@ export function AntiAffinityCard() {
     getCoreRowModel: getCoreRowModel(),
   })
 
+  const disabledReason = () => {
+    if (instanceData.runState !== 'stopped') {
+      return 'This instance must be stopped to add it to a group'
+    }
+    if (allGroups.items.length === 0) {
+      return 'No groups found'
+    }
+    if (nonMemberGroups.length === 0) {
+      return 'Instance is already in all groups'
+    }
+    return undefined
+  }
+
   return (
     <CardBlock>
       <CardBlock.Header title="Anti-affinity groups" titleId="anti-affinity-groups-label">
         <Button
           size="sm"
-          disabled={instanceData.runState !== 'stopped' || nonMemberGroups.length === 0}
-          disabledReason={
-            instanceData.runState !== 'stopped'
-              ? 'Only stopped instances can be added to anti-affinity groups'
-              : allGroups.items.length === 0
-                ? 'No groups found'
-                : nonMemberGroups.length === 0
-                  ? 'Instance is already in all groups'
-                  : undefined
-          }
+          disabled={!!disabledReason()}
+          disabledReason={disabledReason()}
           onClick={() => setIsModalOpen(true)}
         >
           Add to group

--- a/app/pages/project/instances/AntiAffinityCard.tsx
+++ b/app/pages/project/instances/AntiAffinityCard.tsx
@@ -150,7 +150,7 @@ export function AntiAffinityCard() {
     getCoreRowModel: getCoreRowModel(),
   })
 
-  const disabledReason = () => {
+  const getDisabledReason = () => {
     if (instanceData.runState !== 'stopped') {
       return 'This instance must be stopped to add it to a group'
     }
@@ -162,14 +162,15 @@ export function AntiAffinityCard() {
     }
     return undefined
   }
+  const disabledReason = getDisabledReason()
 
   return (
     <CardBlock>
       <CardBlock.Header title="Anti-affinity groups" titleId="anti-affinity-groups-label">
         <Button
           size="sm"
-          disabled={!!disabledReason()}
-          disabledReason={disabledReason()}
+          disabled={!!disabledReason}
+          disabledReason={disabledReason}
           onClick={() => setIsModalOpen(true)}
         >
           Add to group

--- a/test/e2e/anti-affinity.e2e.ts
+++ b/test/e2e/anti-affinity.e2e.ts
@@ -180,8 +180,19 @@ test('add and remove instance from group on instance settings', async ({ page })
   // Ensure the group is not initially present
   await expect(groupCell).toBeHidden()
 
-  // add instance to group
-  await page.getByRole('button', { name: 'Add to group' }).click()
+  // Make sure Add to group button is disabled
+  const addToGroupButton = page.getByRole('button', { name: 'Add to group' })
+  await expect(addToGroupButton).toBeDisabled()
+
+  // Stop the instance
+  await page.getByRole('button', { name: 'Stop' }).click()
+  const confirmStopModal = page.getByRole('dialog', { name: 'Confirm stop' })
+  await expect(confirmStopModal).toBeVisible()
+  await confirmStopModal.getByRole('button', { name: 'Confirm' }).click()
+  await expect(confirmStopModal).toBeHidden()
+
+  // Add instance to group
+  await addToGroupButton.click()
   const modal = page.getByRole('dialog', { name: 'Add to anti-affinity group' })
   await expect(modal).toBeVisible()
   await modal.getByRole('combobox', { name: 'Anti-affinity group' }).click()


### PR DESCRIPTION
This sets it so the user can't add the instance to an anti-affinity group when the instance is not stopped.