### PR TITLE
Add text-raise class to FieldLabels

### DIFF
--- a/app/forms/idp/shared.tsx
+++ b/app/forms/idp/shared.tsx
@@ -41,7 +41,7 @@ export function MetadataSourceField({
   } = useController({ control, name: 'idpMetadataSource' })
   return (
     <fieldset>
-      <legend id="metadata-source-legend" className="mb-2 text-sans-md">
+      <legend id="metadata-source-legend" className="mb-2 text-sans-md text-raise">
         Metadata source
       </legend>
       {/* TODO: probably need some help text here */}

--- a/app/pages/project/instances/AutoRestartCard.tsx
+++ b/app/pages/project/instances/AutoRestartCard.tsx
@@ -156,7 +156,7 @@ type FormMetaProps = {
 
 const FormMeta = ({ label, tip, children }: FormMetaProps) => (
   <div>
-    <div className="mb-2 flex items-center gap-1 border-b pb-2 text-sans-md border-secondary">
+    <div className="mb-2 flex items-center gap-1 border-b pb-2 text-sans-md text-raise border-secondary">
       <div>{label}</div>
       {tip && <TipIcon>{tip}</TipIcon>}
     </div>

--- a/app/ui/lib/FieldLabel.tsx
+++ b/app/ui/lib/FieldLabel.tsx
@@ -27,7 +27,11 @@ export const FieldLabel = ({
   const Component = as || 'label'
   return (
     <div className={cn(className, 'flex h-4 items-center space-x-2')}>
-      <Component id={id} className="flex items-center text-sans-md" htmlFor={htmlFor}>
+      <Component
+        id={id}
+        className="flex items-center text-sans-md text-raise"
+        htmlFor={htmlFor}
+      >
         {children}
         {optional && (
           // Announcing this optional text is unnecessary as the required attribute on the


### PR DESCRIPTION
This adds the `text-raise` class to the FieldLabel component, which is used for many/most of the input labels.

Turns this …
<img width="560" alt="Screenshot 2025-04-09 at 4 36 16 PM" src="https://github.com/user-attachments/assets/acb945e3-8132-46ee-a763-9ed55a2bfa03" />

to this …
<img width="543" alt="Screenshot 2025-04-09 at 4 36 26 PM" src="https://github.com/user-attachments/assets/df6042ee-feee-45fc-8f13-66c46eb04e4b" />


Closes #2787, I believe, but Ben let me know if I misunderstood that.