### PR TITLE
Debounce `startTime` and `endTime` in date range picker

### DIFF
--- a/app/components/form/fields/DateTimeRangePicker.tsx
+++ b/app/components/form/fields/DateTimeRangePicker.tsx
@@ -34,6 +34,8 @@ const computeStart: Record<RangeKey, (now: DateValue) => DateValue> = {
   last30Days: (now) => now.subtract({ days: 30 }),
 }
 
+const tz = getLocalTimeZone()
+
 // Limitations:
 //   - list of presets is hard-coded
 //   - initial preset can't be "custom"
@@ -55,7 +57,6 @@ export function useDateTimeRangePicker({
   maxValue?: DateValue | undefined
   items?: { label: string; value: RangeKeyAll }[]
 }) {
-  const tz = getLocalTimeZone()
   const now = useMemo(() => getNow(tz), [])
 
   const start = computeStart[initialPreset](now)

--- a/app/components/form/fields/DateTimeRangePicker.tsx
+++ b/app/components/form/fields/DateTimeRangePicker.tsx
@@ -7,6 +7,7 @@
  */
 import { getLocalTimeZone, now as getNow, type DateValue } from '@internationalized/date'
 import { useMemo, useState } from 'react'
+import { useDebounce } from 'use-debounce'
 
 import { DateRangePicker } from '~/ui/lib/DateRangePicker'
 import { Listbox } from '~/ui/lib/Listbox'
@@ -54,7 +55,8 @@ export function useDateTimeRangePicker({
   maxValue?: DateValue | undefined
   items?: { label: string; value: RangeKeyAll }[]
 }) {
-  const now = useMemo(() => getNow(getLocalTimeZone()), [])
+  const tz = getLocalTimeZone()
+  const now = useMemo(() => getNow(tz), [])
 
   const start = computeStart[initialPreset](now)
   const end = now
@@ -64,7 +66,7 @@ export function useDateTimeRangePicker({
 
   const onRangeChange = (newPreset: RangeKeyAll) => {
     if (newPreset !== 'custom') {
-      const now = getNow(getLocalTimeZone())
+      const now = getNow(tz)
       const newStartTime = computeStart[newPreset](now)
       setRange({ start: newStartTime, end: now })
     }
@@ -81,10 +83,13 @@ export function useDateTimeRangePicker({
     items,
   }
 
+  const [startTime] = useDebounce(range.start.toDate(tz), 400)
+  const [endTime] = useDebounce(range.end.toDate(tz), 400)
+
   return {
-    startTime: range.start.toDate(getLocalTimeZone()),
-    endTime: range.end.toDate(getLocalTimeZone()),
-    preset: preset,
+    startTime,
+    endTime,
+    preset,
     onRangeChange: onRangeChange,
     dateTimeRangePicker: <DateTimeRangePicker {...props} />,
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "ts-pattern": "^5.6.2",
         "tslib": "^2.7.0",
         "tunnel-rat": "^0.1.2",
+        "use-debounce": "^10.0.4",
         "uuid": "^10.0.0",
         "zod": "^3.23.8",
         "zustand": "^5.0.3"
@@ -14153,6 +14154,18 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-debounce": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.0.4.tgz",
+      "integrity": "sha512-6Cf7Yr7Wk7Kdv77nnJMf6de4HuDE4dTxKij+RqE9rufDsI6zsbjyAxcH5y2ueJCQAnfgKbzXbZHYlkFwmBlWkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/use-sidecar": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "ts-pattern": "^5.6.2",
     "tslib": "^2.7.0",
     "tunnel-rat": "^0.1.2",
+    "use-debounce": "^10.0.4",
     "uuid": "^10.0.0",
     "zod": "^3.23.8",
     "zustand": "^5.0.3"


### PR DESCRIPTION
I noticed on dogfood it's too easy to overload OxQL by holding the up arrow in the time picker. Input wasn't debounced, so we were firing a request for every value of the input. I couldn't believe how easy this was to do. 400ms seems quite responsive while fully solving the problem.

### Before

![image](https://github.com/user-attachments/assets/a9d4b255-4f44-49dd-a683-94ad6c9eb790)


https://github.com/user-attachments/assets/0c045c78-466d-4426-a7da-a4e60e9da88b

### After


https://github.com/user-attachments/assets/05f1bfcf-ef54-48a2-b05d-98c5b81b050b

