### PR TITLE
Thinner small rows

### DIFF
--- a/app/components/IpPoolUtilization.tsx
+++ b/app/components/IpPoolUtilization.tsx
@@ -32,7 +32,7 @@ export function IpUtilCell(util: IpPoolUtilization) {
   // a pool already exists with IPv6 ranges, so we might as well show that. also
   // this is nice for e2e testing the utilization logic
   return (
-    <div className="space-y-0.5">
+    <div className="flex gap-4">
       <div>
         <Badge color="neutral" className="mr-2 !normal-case">
           v4

--- a/app/components/IpPoolUtilization.tsx
+++ b/app/components/IpPoolUtilization.tsx
@@ -32,7 +32,7 @@ export function IpUtilCell(util: IpPoolUtilization) {
   // a pool already exists with IPv6 ranges, so we might as well show that. also
   // this is nice for e2e testing the utilization logic
   return (
-    <div className="space-y-1">
+    <div className="space-y-0.5">
       <div>
         <Badge color="neutral" className="mr-2 !normal-case">
           v4

--- a/app/pages/system/networking/IpPoolsPage.tsx
+++ b/app/pages/system/networking/IpPoolsPage.tsx
@@ -112,6 +112,7 @@ export default function IpPoolsPage() {
   const { table, query } = useQueryTable({
     query: ipPoolList(),
     columns,
+    rowHeight: 'large',
     emptyState: <EmptyState />,
   })
   const { data: pools } = query

--- a/app/pages/system/networking/IpPoolsPage.tsx
+++ b/app/pages/system/networking/IpPoolsPage.tsx
@@ -112,7 +112,8 @@ export default function IpPoolsPage() {
   const { table, query } = useQueryTable({
     query: ipPoolList(),
     columns,
-    rowHeight: 'large',
+    // turn this back on if we expect to see IPv6 ranges regularly
+    // rowHeight: 'large',
     emptyState: <EmptyState />,
   })
   const { data: pools } = query

--- a/app/ui/lib/DateTime.tsx
+++ b/app/ui/lib/DateTime.tsx
@@ -9,7 +9,7 @@
 import { toLocaleDateString, toLocaleTimeString } from '~/util/date'
 
 export const DateTime = ({ date, locale }: { date: Date; locale?: string }) => (
-  <time dateTime={date.toISOString()} className="flex flex-wrap gap-x-1">
+  <time dateTime={date.toISOString()} className="flex gap-x-1">
     <span>{toLocaleDateString(date, locale)}</span>
     <span className="text-tertiary">{toLocaleTimeString(date, locale)}</span>
   </time>

--- a/app/ui/lib/Table.tsx
+++ b/app/ui/lib/Table.tsx
@@ -104,8 +104,8 @@ Table.Cell = ({ height = 'small', className, children, ...props }: TableCellProp
   >
     <div
       className={cn(
-        'relative -my-[1px] -mr-[2px] flex items-center border-b border-l p-3 border-secondary',
-        { 'h-12': height === 'small', 'h-16': height === 'large' }
+        'relative -my-[1px] -mr-[2px] flex items-center border-b border-l px-3 py-2 border-secondary',
+        { 'h-11': height === 'small', 'h-14': height === 'large' }
       )}
     >
       {children}


### PR DESCRIPTION
Easter present for @david-crespo. Slightly thinner column cells. I tried `h-10` but that was a bridge too far.

In contrast the taller rows could do with a design pass. In some places at least these could be converted to smaller rows.

<img width="1210" alt="image" src="https://github.com/user-attachments/assets/d04a0488-9b70-463c-b008-ceab34022950" />