### PR TITLE
Disable primary NIC delete when multiple NICs present

### DIFF
--- a/app/pages/project/instances/NetworkingTab.tsx
+++ b/app/pages/project/instances/NetworkingTab.tsx
@@ -226,6 +226,8 @@ export default function NetworkingTab() {
     query: { ...instanceSelector, limit: ALL_ISH },
   }).data.items
 
+  const multipleNics = nics.length > 1
+
   const makeActions = useCallback(
     (nic: NicRow): MenuAction[] => {
       const canUpdateNic = instanceCan.updateNic({ runState: nic.instanceState })
@@ -238,7 +240,7 @@ export default function NetworkingTab() {
         // > There is always zero or one primary NIC. There may zero or more secondary NICs (up to 7 today), but only if there is already a primary.
         // > The primary NIC is where we attach all the external networking state, like external addresses, and the VPC information like routes, subnet information, internet gateways, etc.
         // > You may delete any secondary NIC. You may delete the primary NIC only if it's the only NIC (there are no secondary NICs).
-        if (nic.primary && nics.length > 1) {
+        if (nic.primary && multipleNics) {
           return 'This network interface is primary and cannot be deleted while other network interfaces are attached'
         }
         return undefined
@@ -289,7 +291,7 @@ export default function NetworkingTab() {
         },
       ]
     },
-    [deleteNic, editNic, instanceSelector, nics.length]
+    [deleteNic, editNic, instanceSelector, multipleNics]
   )
 
   const columns = useColsWithActions(staticCols, makeActions)

--- a/app/pages/project/instances/NetworkingTab.tsx
+++ b/app/pages/project/instances/NetworkingTab.tsx
@@ -241,7 +241,7 @@ export default function NetworkingTab() {
         // > The primary NIC is where we attach all the external networking state, like external addresses, and the VPC information like routes, subnet information, internet gateways, etc.
         // > You may delete any secondary NIC. You may delete the primary NIC only if it's the only NIC (there are no secondary NICs).
         if (nic.primary && multipleNics) {
-          return 'This network interface is primary and cannot be deleted while other network interfaces are attached'
+          return 'The primary interface can’t be deleted while other interfaces are attached. To delete it, make another interface primary.'
         }
         return undefined
       }

--- a/test/e2e/instance-networking.e2e.ts
+++ b/test/e2e/instance-networking.e2e.ts
@@ -89,7 +89,7 @@ test('Instance networking tab — NIC table', async ({ page }) => {
   await page.getByRole('button', { name: 'Confirm' }).click()
 
   // Now the primary NIC is deletable
-  await clickRowAction(page, 'nic-3', 'Delete')
+  await clickRowAction(page, 'nic-3 primary — 123.45.68.8', 'Delete')
   await page.getByRole('button', { name: 'Confirm' }).click()
   await expect(nic3).toBeHidden()
 })

--- a/test/e2e/instance-networking.e2e.ts
+++ b/test/e2e/instance-networking.e2e.ts
@@ -89,7 +89,7 @@ test('Instance networking tab — NIC table', async ({ page }) => {
   await page.getByRole('button', { name: 'Confirm' }).click()
 
   // Now the primary NIC is deletable
-  await clickRowAction(page, 'nic-3 primary — 123.45.68.8', 'Delete')
+  await clickRowAction(page, 'nic-3', 'Delete')
   await page.getByRole('button', { name: 'Confirm' }).click()
   await expect(nic3).toBeHidden()
 })

--- a/test/e2e/instance-networking.e2e.ts
+++ b/test/e2e/instance-networking.e2e.ts
@@ -78,7 +78,7 @@ test('Instance networking tab — NIC table', async ({ page }) => {
   const nic3 = page.getByRole('cell', { name: 'nic-3' })
   await expect(nic3).toBeVisible()
 
-  // See that the primary NIC can not be deleted when other NICs exist
+  // See that the primary NIC cannot be deleted when other NICs exist
   await openRowActions(page, 'nic-3')
   await page.getByRole('menuitem', { name: 'Delete' }).hover()
   await expect(page.getByText('This network interface is primary and cannot')).toBeVisible()

--- a/test/e2e/instance-networking.e2e.ts
+++ b/test/e2e/instance-networking.e2e.ts
@@ -9,9 +9,9 @@ import { expect, test } from '@playwright/test'
 
 import {
   clickRowAction,
+  clickRowActions,
   expectRowVisible,
   expectVisible,
-  openRowActions,
   stopInstance,
 } from './utils'
 
@@ -79,10 +79,14 @@ test('Instance networking tab — NIC table', async ({ page }) => {
   await expect(nic3).toBeVisible()
 
   // See that the primary NIC cannot be deleted when other NICs exist
-  await openRowActions(page, 'nic-3')
-  await expect(page.getByRole('menuitem', { name: 'Delete' })).toBeDisabled()
-  await page.getByRole('menuitem', { name: 'Delete' }).hover()
+  await clickRowActions(page, 'nic-3')
+  const deleteButton = page.getByRole('menuitem', { name: 'Delete' })
+  await expect(deleteButton).toBeDisabled()
+  await deleteButton.hover()
   await expect(page.getByText('This network interface is primary and cannot')).toBeVisible()
+
+  // close the menu for nic-3, without the next line fails in FF and Safari (but not Chrome)
+  await clickRowActions(page, 'nic-3')
 
   // Delete the non-primary NIC
   await clickRowAction(page, 'my-nic', 'Delete')
@@ -91,9 +95,7 @@ test('Instance networking tab — NIC table', async ({ page }) => {
   await expect(page.getByRole('cell', { name: 'my-nic' })).toBeHidden()
 
   // Now the primary NIC is deletable
-  await openRowActions(page, 'nic-3')
-  await expect(page.getByRole('menuitem', { name: 'Delete' })).toBeEnabled()
-  await page.getByRole('menuitem', { name: 'Delete' }).click()
+  await clickRowAction(page, 'nic-3', 'Delete')
   await page.getByRole('button', { name: 'Confirm' }).click()
   await expect(nic3).toBeHidden()
 })

--- a/test/e2e/instance-networking.e2e.ts
+++ b/test/e2e/instance-networking.e2e.ts
@@ -83,7 +83,7 @@ test('Instance networking tab — NIC table', async ({ page }) => {
   const deleteButton = page.getByRole('menuitem', { name: 'Delete' })
   await expect(deleteButton).toBeDisabled()
   await deleteButton.hover()
-  await expect(page.getByText('This network interface is primary and cannot')).toBeVisible()
+  await expect(page.getByText('The primary interface can’t')).toBeVisible()
 
   // close the menu for nic-3, without the next line fails in FF and Safari (but not Chrome)
   await clickRowActions(page, 'nic-3')

--- a/test/e2e/instance-networking.e2e.ts
+++ b/test/e2e/instance-networking.e2e.ts
@@ -85,12 +85,10 @@ test('Instance networking tab — NIC table', async ({ page }) => {
   await expect(page.getByText('This network interface is primary and cannot')).toBeVisible()
 
   // Delete the non-primary NIC
-  // although we could use clickRowAction here, it can sometimes be flaky if we don't slow it down a bit
-  await openRowActions(page, 'my-nic')
-  await expect(page.getByRole('menuitem', { name: 'Delete' })).toBeEnabled()
-  await page.getByRole('menuitem', { name: 'Delete' }).click()
+  await clickRowAction(page, 'my-nic', 'Delete')
   await expect(page.getByText('Are you sure you want to delete my-nic?')).toBeVisible()
   await page.getByRole('button', { name: 'Confirm' }).click()
+  await expect(page.getByRole('cell', { name: 'my-nic' })).toBeHidden()
 
   // Now the primary NIC is deletable
   await openRowActions(page, 'nic-3')

--- a/test/e2e/instance-networking.e2e.ts
+++ b/test/e2e/instance-networking.e2e.ts
@@ -80,16 +80,22 @@ test('Instance networking tab — NIC table', async ({ page }) => {
 
   // See that the primary NIC cannot be deleted when other NICs exist
   await openRowActions(page, 'nic-3')
+  await expect(page.getByRole('menuitem', { name: 'Delete' })).toBeDisabled()
   await page.getByRole('menuitem', { name: 'Delete' }).hover()
   await expect(page.getByText('This network interface is primary and cannot')).toBeVisible()
 
   // Delete the non-primary NIC
-  await clickRowAction(page, 'my-nic', 'Delete')
+  // although we could use clickRowAction here, it can sometimes be flaky if we don't slow it down a bit
+  await openRowActions(page, 'my-nic')
+  await expect(page.getByRole('menuitem', { name: 'Delete' })).toBeEnabled()
+  await page.getByRole('menuitem', { name: 'Delete' }).click()
   await expect(page.getByText('Are you sure you want to delete my-nic?')).toBeVisible()
   await page.getByRole('button', { name: 'Confirm' }).click()
 
   // Now the primary NIC is deletable
-  await clickRowAction(page, 'nic-3', 'Delete')
+  await openRowActions(page, 'nic-3')
+  await expect(page.getByRole('menuitem', { name: 'Delete' })).toBeEnabled()
+  await page.getByRole('menuitem', { name: 'Delete' }).click()
   await page.getByRole('button', { name: 'Confirm' }).click()
   await expect(nic3).toBeHidden()
 })

--- a/test/e2e/instance.e2e.ts
+++ b/test/e2e/instance.e2e.ts
@@ -7,10 +7,10 @@
  */
 import {
   clickRowAction,
+  clickRowActions,
   closeToast,
   expect,
   expectRowVisible,
-  openRowActions,
   test,
   type Page,
 } from './utils'
@@ -41,7 +41,7 @@ test('can start a failed instance', async ({ page }) => {
   await page.goto('/projects/mock-project/instances')
 
   // check the start button disabled message on a running instance
-  await openRowActions(page, 'db1')
+  await clickRowActions(page, 'db1')
   await page.getByRole('menuitem', { name: 'Start' }).hover()
   await expect(
     page.getByText('Only stopped or failed instances can be started')
@@ -118,14 +118,14 @@ test('can reboot a running instance', async ({ page }) => {
 test('cannot reboot a failed instance', async ({ page }) => {
   await page.goto('/projects/mock-project/instances')
   await expectInstanceState(page, 'you-fail', 'failed')
-  await openRowActions(page, 'you-fail')
+  await clickRowActions(page, 'you-fail')
   await expect(page.getByRole('menuitem', { name: 'Reboot' })).toBeDisabled()
 })
 
 test('cannot reboot a starting instance, or a stopped instance', async ({ page }) => {
   await page.goto('/projects/mock-project/instances')
   await expectInstanceState(page, 'not-there-yet', 'starting')
-  await openRowActions(page, 'not-there-yet')
+  await clickRowActions(page, 'not-there-yet')
   await expect(page.getByRole('menuitem', { name: 'Reboot' })).toBeDisabled()
   // hit escape to close the menu so clickRowAction succeeds
   await page.keyboard.press('Escape')
@@ -136,7 +136,7 @@ test('cannot reboot a starting instance, or a stopped instance', async ({ page }
   await expectInstanceState(page, 'not-there-yet', 'stopping')
   await expectInstanceState(page, 'not-there-yet', 'stopped')
   // reboot is still disabled for a stopped instance
-  await openRowActions(page, 'not-there-yet')
+  await clickRowActions(page, 'not-there-yet')
   await expect(page.getByRole('menuitem', { name: 'Reboot' })).toBeDisabled()
 })
 
@@ -144,13 +144,13 @@ test('cannot resize a running or starting instance', async ({ page }) => {
   await page.goto('/projects/mock-project/instances')
 
   await expectInstanceState(page, 'db1', 'running')
-  await openRowActions(page, 'db1')
+  await clickRowActions(page, 'db1')
   await expect(page.getByRole('menuitem', { name: 'Resize' })).toBeDisabled()
 
   await page.keyboard.press('Escape') // get out of the menu
 
   await expectInstanceState(page, 'not-there-yet', 'starting')
-  await openRowActions(page, 'not-there-yet')
+  await clickRowActions(page, 'not-there-yet')
   await expect(page.getByRole('menuitem', { name: 'Resize' })).toBeDisabled()
 })
 
@@ -254,7 +254,7 @@ async function expectRowMenuStaysOpen(page: Page, rowSelector: string) {
   await expect(menu).toBeHidden()
   await expect(stopped).toBeHidden()
 
-  await openRowActions(page, rowSelector)
+  await clickRowActions(page, rowSelector)
   await expect(stopped).toBeHidden() // still not stopped yet
   await expect(menu).toBeVisible()
 
@@ -300,7 +300,7 @@ test("polling doesn't close row actions: instances", async ({ page }) => {
   await expect(menu).toBeHidden()
   await expect(stopped).toBeHidden()
 
-  await openRowActions(page, 'db1')
+  await clickRowActions(page, 'db1')
   await expect(stopped).toBeHidden() // still not stopped yet
   await expect(menu).toBeVisible()
 

--- a/test/e2e/utils.ts
+++ b/test/e2e/utils.ts
@@ -154,7 +154,7 @@ export async function closeToast(page: Page) {
 export const clipboardText = async (page: Page) =>
   page.evaluate(() => navigator.clipboard.readText())
 
-export const openRowActions = async (page: Page, name: string) => {
+export const clickRowActions = async (page: Page, name: string) => {
   await page
     .getByRole('row', { name, exact: false })
     .getByRole('button', { name: 'Row actions' })
@@ -163,7 +163,7 @@ export const openRowActions = async (page: Page, name: string) => {
 
 /** Select row by `rowName`, click the row actions button, and click `actionName` */
 export async function clickRowAction(page: Page, rowName: string, actionName: string) {
-  await openRowActions(page, rowName)
+  await clickRowActions(page, rowName)
   await page.getByRole('menuitem', { name: actionName }).click()
 }
 


### PR DESCRIPTION
This adds an affordance to the instance networking tab, to prevent the deletion of a primary NIC when there are other NICs present.

As called out in #2652, we prevent the user from deleting the primary NIC when there are other NICs present. As Ben notes,
>There is always zero or one primary NIC. There may zero or more secondary NICs (up to 7 today), but only if there is already a primary. The primary NIC is where we attach all the external networking state, like external addresses, and the VPC information like routes, subnet information, internet gateways, etc.
>
>You may delete any secondary NIC. You may delete the primary NIC only if it's the only NIC (there are no secondary NICs). That's because we need a place to attach that external state -- if you delete a primary, we can only make an unambiguous choice of which secondary to promote if there is zero or one secondary NIC. Instead of trying to decide, and possibly getting it wrong, the user needs to pick.

In the linked issue, one approach was to add a modal, giving the user the ability to promote another NIC to primary. Happy to do a part 2 on this if we want to add that functionality, but wanted to at least disable the action for now.