### PR TITLE
Fix target for checkbox on instance create form

### DIFF
--- a/app/forms/instance-create.tsx
+++ b/app/forms/instance-create.tsx
@@ -737,24 +737,21 @@ const AdvancedAccordion = ({
               it is deleted
             </TipIcon>
           </h2>
-          <div className="flex items-start gap-2.5">
-            <Checkbox
-              id="assignEphemeralIp"
-              checked={assignEphemeralIp}
-              onChange={() => {
-                const newExternalIps = assignEphemeralIp
-                  ? externalIps.field.value?.filter((ip) => ip.type !== 'ephemeral')
-                  : [
-                      ...(externalIps.field.value || []),
-                      { type: 'ephemeral', pool: selectedPool || defaultPool },
-                    ]
-                externalIps.field.onChange(newExternalIps)
-              }}
-            />
-            <label htmlFor="assignEphemeralIp" className="text-sans-md text-default">
-              Allocate and attach an ephemeral IP address
-            </label>
-          </div>
+          <Checkbox
+            id="assignEphemeralIp"
+            checked={assignEphemeralIp}
+            onChange={() => {
+              const newExternalIps = assignEphemeralIp
+                ? externalIps.field.value?.filter((ip) => ip.type !== 'ephemeral')
+                : [
+                    ...(externalIps.field.value || []),
+                    { type: 'ephemeral', pool: selectedPool || defaultPool },
+                  ]
+              externalIps.field.onChange(newExternalIps)
+            }}
+          >
+            Allocate and attach an ephemeral IP address
+          </Checkbox>
           {assignEphemeralIp && (
             <Listbox
               name="pools"


### PR DESCRIPTION
On the instance-create table, there's a checkbox that has a gap between the checkbox and the label, mostly because we were re-creating something that already works. This update uses the default checkbox / label approach, making it work like other places in the app.
![click_target](https://github.com/user-attachments/assets/2fbbe99b-a085-4cc6-b84e-d43b43368dc3)

It is possible I have missed something, so will poke around a bit more to see if there are more broken checkbox/labels.

Fixes #2807