### PR TITLE
Full page form spacing

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -9,7 +9,7 @@
     "oxc"
   ],
   "categories": {
-    "correctness": "error",
+    "correctness": "error"
   },
   "rules": {
     // only worry about console.log

--- a/app/forms/instance-create.tsx
+++ b/app/forms/instance-create.tsx
@@ -905,13 +905,11 @@ const PRESETS = [
   { category: 'general', id: 'general-sm', memory: 16, ncpus: 4 },
   { category: 'general', id: 'general-md', memory: 32, ncpus: 8 },
   { category: 'general', id: 'general-lg', memory: 64, ncpus: 16 },
-  { category: 'general', id: 'general-xl', memory: 128, ncpus: 32 },
 
   { category: 'highCPU', id: 'highCPU-xs', memory: 4, ncpus: 2 },
   { category: 'highCPU', id: 'highCPU-sm', memory: 8, ncpus: 4 },
   { category: 'highCPU', id: 'highCPU-md', memory: 16, ncpus: 8 },
   { category: 'highCPU', id: 'highCPU-lg', memory: 32, ncpus: 16 },
-  { category: 'highCPU', id: 'highCPU-xl', memory: 64, ncpus: 32 },
 
   { category: 'highMemory', id: 'highMemory-xs', memory: 16, ncpus: 2 },
   { category: 'highMemory', id: 'highMemory-sm', memory: 32, ncpus: 4 },

--- a/app/ui/lib/Radio.tsx
+++ b/app/ui/lib/Radio.tsx
@@ -40,7 +40,7 @@ export const Radio = ({ children, className, ...inputProps }: RadioProps) => (
 
 const cardLabelStyles = `
   py-2 px-4 text-sans-md border rounded border-default bg-default hover:border-hover
-  peer-focus:ring-2 peer-focus:ring-accent-secondary  w-44
+  peer-focus:ring-2 peer-focus:ring-accent-secondary w-44 text-raise
 
   children:py-3 children:px-3 children:-mx-4 children:border-secondary
   first:children:-mt-2 last:children:-mb-2 cursor-pointer

--- a/app/ui/styles/components/form.css
+++ b/app/ui/styles/components/form.css
@@ -2,7 +2,7 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, you can obtain one at https://mozilla.org/MPL/2.0/.
- *  
+ *
  * Copyright Oxide Computer Company
  */
 
@@ -22,10 +22,7 @@
   @apply space-y-6;
 }
 
-.ox-form.is-side-modal .ox-divider {
+.ox-form .ox-divider,
+.ox-form .ox-divider:not([hidden]) {
   @apply my-10;
-}
-
-.ox-form:not(.is-side-modal) .ox-divider {
-  @apply mb-16 mt-20;
 }

--- a/app/ui/styles/components/form.css
+++ b/app/ui/styles/components/form.css
@@ -22,7 +22,6 @@
   @apply space-y-6;
 }
 
-.ox-form .ox-divider,
-.ox-form .ox-divider:not([hidden]) {
-  @apply my-10;
+.ox-form .ox-divider {
+  @apply !my-10; /* important overrides space-y-* on .ox-form */
 }


### PR DESCRIPTION
One small thing, one small but open for discussion.

1. Tighten divider spacing, side modal and full page form are now the same
2. Removing the highest preset, if the user wants these values they can do so in the custom tab and this wraps awkwardly