### PR TITLE
Fix affinity test flake due to missing column memoization

### DIFF
--- a/app/pages/project/instances/AntiAffinityCard.tsx
+++ b/app/pages/project/instances/AntiAffinityCard.tsx
@@ -122,8 +122,9 @@ export function AntiAffinityCard() {
     [instance, project, removeMember]
   )
 
-  const antiAffinityCols = useColsWithActions(
-    [
+  // has to be memoized to avoid extra renders on instance poll closing the menu
+  const cols = useMemo(
+    () => [
       colHelper.accessor('name', {
         cell: makeLinkCell((antiAffinityGroup) =>
           pb.antiAffinityGroup({ project, antiAffinityGroup })
@@ -131,14 +132,13 @@ export function AntiAffinityCard() {
       }),
       ...staticCols,
     ],
-    makeActions,
-    'Copy group ID'
+    [project]
   )
 
   const [isModalOpen, setIsModalOpen] = useState(false)
 
   const antiAffinityTable = useReactTable({
-    columns: antiAffinityCols,
+    columns: useColsWithActions(cols, makeActions, 'Copy group ID'),
     data: memberGroups.items,
     getCoreRowModel: getCoreRowModel(),
   })


### PR DESCRIPTION
Charlie and I spent some time on this after noticing pretty frequent failure locally — guess it was just a coincidence that it worked in recent PRs and main commits. We were not memoizing the columns of the affinity groups table on the instance settings tab, so any render (caused, e.g., by instance state polling) would reset an open row actions menu. Related to #2618 and #1091.