### PR TITLE
Test flake: scroll image combobox into view

### DIFF
--- a/test/e2e/instance-create.e2e.ts
+++ b/test/e2e/instance-create.e2e.ts
@@ -392,6 +392,7 @@ test('maintains selected values even when changing tabs', async ({ page }) => {
   await page.goto('/projects/mock-project/instances-new')
   await page.getByRole('textbox', { name: 'Name', exact: true }).fill(instanceName)
   const imageSelectCombobox = page.getByRole('combobox', { name: 'Image' })
+  await imageSelectCombobox.scrollIntoViewIfNeeded()
   // Filter the combobox for a particular silo image
   await imageSelectCombobox.fill('arch')
   // select the image


### PR DESCRIPTION
Got a test flake on main that I don't think I've seen before. The trace shows it failing to click on this combobox behind the bottom bar.

<img width="1683" alt="image" src="https://github.com/user-attachments/assets/ef958d0f-ef77-42ed-9af6-411d8caa3426" />

Scrolling puts it right in the middle, so I expect it will help.

<img width="970" alt="image" src="https://github.com/user-attachments/assets/e99ce6bc-8980-488f-b174-9bf0f7eaf4af" />



```
    Retry #2 ───────────────────────────────────────────────────────────────────────────────────────

    Test timeout of 60000ms exceeded.

    Error: locator.click: Test timeout of 60000ms exceeded.
    Call log:
      - waiting for getByRole('option', { name: 'arch-2022-06-01' })
        - locator resolved to <div role="option" tabindex="-1" data-focus="" data-active="" aria-selected="false" data-headlessui-state="active focus" id="headlessui-combobox-option-«r2i»" class="relative border-b border-secondary last:border-0">…</div>
      - attempting click action
        2 × waiting for element to be visible, enabled and stable
          - element is visible, enabled and stable
          - scrolling into view if needed
          - done scrolling
          - <div class="flex h-20 items-center gutter">…</div> from <div id="root">…</div> subtree intercepts pointer events
        - retrying click action
        - waiting 20ms
        2 × waiting for element to be visible, enabled and stable
          - element is visible, enabled and stable
          - scrolling into view if needed
          - done scrolling
          - <div class="flex h-20 items-center gutter">…</div> from <div id="root">…</div> subtree intercepts pointer events
        - retrying click action
          - waiting 100ms
        85 × waiting for element to be visible, enabled and stable
           - element is visible, enabled and stable
           - scrolling into view if needed
           - done scrolling
           - <div class="flex h-20 items-center gutter">…</div> from <div id="root">…</div> subtree intercepts pointer events
         - retrying click action
           - waiting 500ms


      396 |   await imageSelectCombobox.fill('arch')
      397 |   // select the image
    > 398 |   await page.getByRole('option', { name: arch }).click()
          |                                                  ^
      399 |   // expect to find name of the image on page
      400 |   await expect(imageSelectCombobox).toHaveValue(arch)
      401 |   // change to a different tab
        at /Users/runner/work/console/console/test/e2e/instance-create.e2e.ts:398:50
```