### PR TITLE
Regen API client with proper nullable fields

### DIFF
--- a/app/api/__generated__/Api.ts
+++ b/app/api/__generated__/Api.ts
@@ -46,7 +46,7 @@ export type Address = {
   /** The address lot this address is drawn from. */
   addressLot: NameOrId
   /** Optional VLAN ID for this address */
-  vlanId?: number
+  vlanId?: number | null
 }
 
 /**
@@ -114,7 +114,7 @@ export type AddressLotBlockResultsPage = {
   /** list of items on this page of results */
   items: AddressLotBlock[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
@@ -146,7 +146,7 @@ export type AddressLotResultsPage = {
   /** list of items on this page of results */
   items: AddressLot[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
@@ -254,7 +254,7 @@ export type AffinityGroupMemberResultsPage = {
   /** list of items on this page of results */
   items: AffinityGroupMember[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
@@ -264,13 +264,16 @@ export type AffinityGroupResultsPage = {
   /** list of items on this page of results */
   items: AffinityGroup[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
  * Updateable properties of an `AffinityGroup`
  */
-export type AffinityGroupUpdate = { description?: string; name?: Name }
+export type AffinityGroupUpdate = {
+  description?: string | null
+  name?: Name | null
+}
 
 export type BgpMessageHistory = Record<string, unknown>
 
@@ -381,7 +384,7 @@ export type AntiAffinityGroupMemberResultsPage = {
   /** list of items on this page of results */
   items: AntiAffinityGroupMember[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
@@ -391,13 +394,16 @@ export type AntiAffinityGroupResultsPage = {
   /** list of items on this page of results */
   items: AntiAffinityGroup[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
  * Updateable properties of an `AntiAffinityGroup`
  */
-export type AntiAffinityGroupUpdate = { description?: string; name?: Name }
+export type AntiAffinityGroupUpdate = {
+  description?: string | null
+  name?: Name | null
+}
 
 /**
  * Authorization scope for a timeseries.
@@ -444,7 +450,7 @@ export type BfdSessionEnable = {
   /** The negotiated Control packet transmission interval, multiplied by this variable, will be the Detection Time for this session (as seen by the remote system) */
   detectionThreshold: number
   /** Address the Oxide switch will listen on for BFD traffic. If `None` then the unspecified address (0.0.0.0 or ::) is used. */
-  local?: string
+  local?: string | null
   /** Select either single-hop (RFC 5881) or multi-hop (RFC 5883) */
   mode: BfdMode
   /** Address of the remote peer to establish a BFD session with. */
@@ -470,7 +476,7 @@ export type BfdState =
 
 export type BfdStatus = {
   detectionThreshold: number
-  local?: string
+  local?: string | null
   mode: BfdMode
   peer: string
   requiredRx: number
@@ -543,7 +549,7 @@ export type BgpConfig = {
   /** timestamp when this resource was last modified */
   timeModified: Date
   /** Optional virtual routing and forwarding identifier for this BGP configuration. */
-  vrf?: string
+  vrf?: string | null
 }
 
 /**
@@ -556,7 +562,7 @@ export type BgpConfigCreate = {
   description: string
   name: Name
   /** Optional virtual routing and forwarding identifier for this BGP configuration. */
-  vrf?: Name
+  vrf?: Name | null
 }
 
 /**
@@ -566,7 +572,7 @@ export type BgpConfigResultsPage = {
   /** list of items on this page of results */
   items: BgpConfig[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
@@ -627,17 +633,17 @@ export type BgpPeer = {
   /** How often to send keepalive requests (seconds). */
   keepalive: number
   /** Apply a local preference to routes received from this peer. */
-  localPref?: number
+  localPref?: number | null
   /** Use the given key for TCP-MD5 authentication with the peer. */
-  md5AuthKey?: string
+  md5AuthKey?: string | null
   /** Require messages from a peer have a minimum IP time to live field. */
-  minTtl?: number
+  minTtl?: number | null
   /** Apply the provided multi-exit discriminator (MED) updates sent to the peer. */
-  multiExitDiscriminator?: number
+  multiExitDiscriminator?: number | null
   /** Require that a peer has a specified ASN. */
-  remoteAsn?: number
+  remoteAsn?: number | null
   /** Associate a VLAN ID with a peer. */
-  vlanId?: number
+  vlanId?: number | null
 }
 
 export type BgpPeerConfig = { peers: BgpPeer[] }
@@ -971,7 +977,7 @@ export type CertificateResultsPage = {
   /** list of items on this page of results */
   items: Certificate[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
@@ -1379,7 +1385,7 @@ export type DatumType =
   | 'histogram_f32'
   | 'histogram_f64'
 
-export type MissingDatum = { datumType: DatumType; startTime?: Date }
+export type MissingDatum = { datumType: DatumType; startTime?: Date | null }
 
 /**
  * A `Datum` is a single sampled data point from a metric.
@@ -1473,13 +1479,13 @@ export type Disk = {
   /** unique, immutable, system-controlled identifier for each resource */
   id: string
   /** ID of image from which disk was created, if any */
-  imageId?: string
+  imageId?: string | null
   /** unique, mutable, user-controlled identifier for each resource */
   name: Name
   projectId: string
   size: ByteCount
   /** ID of snapshot from which disk was created, if any */
-  snapshotId?: string
+  snapshotId?: string | null
   state: DiskState
   /** timestamp when this resource was created */
   timeCreated: Date
@@ -1528,7 +1534,7 @@ export type DiskResultsPage = {
   /** list of items on this page of results */
   items: Disk[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
@@ -1539,11 +1545,11 @@ export type DiskResultsPage = {
 export type Distributiondouble = {
   bins: number[]
   counts: number[]
-  max?: number
-  min?: number
-  p50?: Quantile
-  p90?: Quantile
-  p99?: Quantile
+  max?: number | null
+  min?: number | null
+  p50?: Quantile | null
+  p90?: Quantile | null
+  p99?: Quantile | null
   squaredMean: number
   sumOfSamples: number
 }
@@ -1556,11 +1562,11 @@ export type Distributiondouble = {
 export type Distributionint64 = {
   bins: number[]
   counts: number[]
-  max?: number
-  min?: number
-  p50?: Quantile
-  p90?: Quantile
-  p99?: Quantile
+  max?: number | null
+  min?: number | null
+  p50?: Quantile | null
+  p90?: Quantile | null
+  p99?: Quantile | null
   squaredMean: number
   sumOfSamples: number
 }
@@ -1570,7 +1576,7 @@ export type Distributionint64 = {
  */
 export type EphemeralIpCreate = {
   /** Name or ID of the IP pool used to allocate an address */
-  pool?: NameOrId
+  pool?: NameOrId | null
 }
 
 export type ExternalIp =
@@ -1582,7 +1588,7 @@ export type ExternalIp =
       /** unique, immutable, system-controlled identifier for each resource */
       id: string
       /** The ID of the instance that this Floating IP is attached to, if it is presently in use. */
-      instanceId?: string
+      instanceId?: string | null
       /** The IP address held by this resource. */
       ip: string
       /** The ID of the IP pool this resource belongs to. */
@@ -1603,7 +1609,7 @@ export type ExternalIp =
  */
 export type ExternalIpCreate =
   /** An IP address providing both inbound and outbound access. The address is automatically-assigned from the provided IP Pool, or the current silo's default pool if not specified. */
-  | { pool?: NameOrId; type: 'ephemeral' }
+  | { pool?: NameOrId | null; type: 'ephemeral' }
   /** An IP address providing both inbound and outbound access. The address is an existing floating IP object assigned to the current project.
 
 The floating IP must not be in use by another instance or service. */
@@ -1616,7 +1622,7 @@ export type ExternalIpResultsPage = {
   /** list of items on this page of results */
   items: ExternalIp[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
@@ -1673,7 +1679,7 @@ export type FieldValue =
  */
 export type FinalizeDisk = {
   /** If specified a snapshot of the disk will be created with the given name during finalization. If not specified, a snapshot for the disk will _not_ be created. A snapshot can be manually created once the disk transitions into the `Detached` state. */
-  snapshotName?: Name
+  snapshotName?: Name | null
 }
 
 export type FleetRole = 'admin' | 'collaborator' | 'viewer'
@@ -1713,7 +1719,7 @@ export type FloatingIp = {
   /** unique, immutable, system-controlled identifier for each resource */
   id: string
   /** The ID of the instance that this Floating IP is attached to, if it is presently in use. */
-  instanceId?: string
+  instanceId?: string | null
   /** The IP address held by this resource. */
   ip: string
   /** The ID of the IP pool this resource belongs to. */
@@ -1749,10 +1755,10 @@ export type FloatingIpAttach = {
 export type FloatingIpCreate = {
   description: string
   /** An IP address to reserve for use as a floating IP. This field is optional: when not set, an address will be automatically chosen from `pool`. If set, then the IP must be available in the resolved `pool`. */
-  ip?: string
+  ip?: string | null
   name: Name
   /** The parent IP pool that a floating IP is pulled from. If unset, the default pool is selected. */
-  pool?: NameOrId
+  pool?: NameOrId | null
 }
 
 /**
@@ -1762,13 +1768,16 @@ export type FloatingIpResultsPage = {
   /** list of items on this page of results */
   items: FloatingIp[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
  * Updateable identity-related parameters
  */
-export type FloatingIpUpdate = { description?: string; name?: Name }
+export type FloatingIpUpdate = {
+  description?: string | null
+  name?: Name | null
+}
 
 /**
  * View of a Group
@@ -1788,7 +1797,7 @@ export type GroupResultsPage = {
   /** list of items on this page of results */
   items: Group[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
@@ -1825,7 +1834,7 @@ export type IdentityProviderResultsPage = {
   /** list of items on this page of results */
   items: IdentityProvider[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 export type IdpMetadataSource =
@@ -1843,7 +1852,7 @@ export type Image = {
   /** human-readable free-form text about a resource */
   description: string
   /** Hash of the image contents, if applicable */
-  digest?: Digest
+  digest?: Digest | null
   /** unique, immutable, system-controlled identifier for each resource */
   id: string
   /** unique, mutable, user-controlled identifier for each resource */
@@ -1851,7 +1860,7 @@ export type Image = {
   /** The family of the operating system like Debian, Ubuntu, etc. */
   os: string
   /** ID of the parent project if the image is a project image */
-  projectId?: string
+  projectId?: string | null
   /** total size in bytes */
   size: ByteCount
   /** timestamp when this resource was created */
@@ -1888,13 +1897,16 @@ export type ImageResultsPage = {
   /** list of items on this page of results */
   items: Image[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
  * Parameters for importing blocks with a bulk write
  */
-export type ImportBlocksBulkWrite = { base64EncodedData: string; offset: number }
+export type ImportBlocksBulkWrite = {
+  base64EncodedData: string
+  offset: number
+}
 
 /**
  * A policy determining when an instance should be automatically restarted by the control plane.
@@ -1918,15 +1930,15 @@ export type Instance = {
   /** The time at which the auto-restart cooldown period for this instance completes, permitting it to be automatically restarted again. If the instance enters the `Failed` state, it will not be restarted until after this time.
 
 If this is not present, then either the instance has never been automatically restarted, or the cooldown period has already expired, allowing the instance to be restarted immediately if it fails. */
-  autoRestartCooldownExpiration?: Date
+  autoRestartCooldownExpiration?: Date | null
   /** `true` if this instance's auto-restart policy will permit the control plane to automatically restart it if it enters the `Failed` state. */
   autoRestartEnabled: boolean
   /** The auto-restart policy configured for this instance, or `null` if no explicit policy has been configured.
 
 This policy determines whether the instance should be automatically restarted by the control plane on failure. If this is `null`, the control plane will use the default policy when determining whether or not to automatically restart this instance, which may or may not allow it to be restarted. The value of the `auto_restart_enabled` field indicates whether the instance will be auto-restarted, based on its current policy or the default if it has no configured policy. */
-  autoRestartPolicy?: InstanceAutoRestartPolicy
+  autoRestartPolicy?: InstanceAutoRestartPolicy | null
   /** the ID of the disk used to boot this Instance, if a specific one is assigned. */
-  bootDiskId?: string
+  bootDiskId?: string | null
   /** human-readable free-form text about a resource */
   description: string
   /** RFC1035-compliant hostname for the Instance. */
@@ -1947,7 +1959,7 @@ This policy determines whether the instance should be automatically restarted by
   /** The timestamp of the most recent time this instance was automatically restarted by the control plane.
 
 If this is not present, then this instance has not been automatically restarted. */
-  timeLastAutoRestarted?: Date
+  timeLastAutoRestarted?: Date | null
   /** timestamp when this resource was last modified */
   timeModified: Date
   timeRunStateUpdated: Date
@@ -1980,7 +1992,7 @@ export type InstanceDiskAttachment =
 export type InstanceNetworkInterfaceCreate = {
   description: string
   /** The IP address for the interface. One will be auto-assigned if not provided. */
-  ip?: string
+  ip?: string | null
   name: Name
   /** The VPC Subnet in which to create the interface. */
   subnetName: Name
@@ -2012,13 +2024,13 @@ export type InstanceCreate = {
 This policy determines whether the instance should be automatically restarted by the control plane on failure. If this is `null`, no auto-restart policy will be explicitly configured for this instance, and the control plane will select the default policy when determining whether the instance can be automatically restarted.
 
 Currently, the global default auto-restart policy is "best-effort", so instances with `null` auto-restart policies will be automatically restarted. However, in the future, the default policy may be configurable through other mechanisms, such as on a per-project basis. In that case, any configured default policy will be used if this is `null`. */
-  autoRestartPolicy?: InstanceAutoRestartPolicy
+  autoRestartPolicy?: InstanceAutoRestartPolicy | null
   /** The disk this instance should boot into. This disk can either be attached if it already exists, or created, if it should be a new disk.
 
 It is strongly recommended to either provide a boot disk at instance creation, or update the instance after creation to set a boot disk.
 
 An instance without an explicit boot disk can be booted: the options are as managed by UEFI, and as controlled by the guest OS, but with some risk.  If this instance later has a disk attached or detached, it is possible that boot options can end up reordered, with the intended boot disk moved after the EFI shell in boot priority. This may result in an instance that only boots to the EFI shell until the desired disk is set as an explicit boot disk and the instance rebooted. */
-  bootDisk?: InstanceDiskAttachment
+  bootDisk?: InstanceDiskAttachment | null
   description: string
   /** The disks to be created or attached for this instance. */
   disks?: InstanceDiskAttachment[]
@@ -2038,7 +2050,7 @@ By default, all instances have outbound connectivity, but no inbound connectivit
   /** An allowlist of SSH public keys to be transferred to the instance via cloud-init during instance creation.
 
 If not provided, all SSH public keys from the user's profile will be sent. If an empty list is provided, no public keys will be transmitted to the instance. */
-  sshPublicKeys?: NameOrId[]
+  sshPublicKeys?: NameOrId[] | null
   /** Should this instance be started upon creation; true by default. */
   start?: boolean
   /** User data for instance initialization systems (such as cloud-init). Must be a Base64-encoded string, as specified in RFC 4648 § 4 (+ and / characters with padding). Maximum 32 KiB unencoded data. */
@@ -2089,7 +2101,7 @@ export type InstanceNetworkInterfaceResultsPage = {
   /** list of items on this page of results */
   items: InstanceNetworkInterface[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
@@ -2098,8 +2110,8 @@ export type InstanceNetworkInterfaceResultsPage = {
  * Note that modifying IP addresses for an interface is not yet supported, a new interface must be created instead.
  */
 export type InstanceNetworkInterfaceUpdate = {
-  description?: string
-  name?: Name
+  description?: string | null
+  name?: Name | null
   /** Make a secondary interface the instance's primary interface.
 
 If applied to a secondary interface, that interface will become the primary on the next reboot of the instance. Note that this may have implications for routing between instances, as the new primary interface will be on a distinct subnet from the previous primary interface.
@@ -2117,7 +2129,7 @@ export type InstanceResultsPage = {
   /** list of items on this page of results */
   items: Instance[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
@@ -2139,11 +2151,11 @@ export type InstanceUpdate = {
 This policy determines whether the instance should be automatically restarted by the control plane on failure. If this is `null`, any explicitly configured auto-restart policy will be unset, and the control plane will select the default policy when determining whether the instance can be automatically restarted.
 
 Currently, the global default auto-restart policy is "best-effort", so instances with `null` auto-restart policies will be automatically restarted. However, in the future, the default policy may be configurable through other mechanisms, such as on a per-project basis. In that case, any configured default policy will be used if this is `null`. */
-  autoRestartPolicy?: InstanceAutoRestartPolicy
+  autoRestartPolicy?: InstanceAutoRestartPolicy | null
   /** Name or ID of the disk the instance should be instructed to boot from.
 
 If not provided, unset the instance's boot disk. */
-  bootDisk?: NameOrId
+  bootDisk?: NameOrId | null
   /** The amount of memory to assign to this instance. */
   memory: ByteCount
   /** The number of CPUs to assign to this instance. */
@@ -2209,7 +2221,7 @@ export type InternetGatewayIpAddressResultsPage = {
   /** list of items on this page of results */
   items: InternetGatewayIpAddress[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
@@ -2248,7 +2260,7 @@ export type InternetGatewayIpPoolResultsPage = {
   /** list of items on this page of results */
   items: InternetGatewayIpPool[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
@@ -2258,7 +2270,7 @@ export type InternetGatewayResultsPage = {
   /** list of items on this page of results */
   items: InternetGateway[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
@@ -2318,7 +2330,7 @@ export type IpPoolRangeResultsPage = {
   /** list of items on this page of results */
   items: IpPoolRange[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
@@ -2328,7 +2340,7 @@ export type IpPoolResultsPage = {
   /** list of items on this page of results */
   items: IpPool[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
@@ -2348,7 +2360,7 @@ export type IpPoolSiloLinkResultsPage = {
   /** list of items on this page of results */
   items: IpPoolSiloLink[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 export type IpPoolSiloUpdate = {
@@ -2359,7 +2371,7 @@ export type IpPoolSiloUpdate = {
 /**
  * Parameters for updating an IP Pool
  */
-export type IpPoolUpdate = { description?: string; name?: Name }
+export type IpPoolUpdate = { description?: string | null; name?: Name | null }
 
 export type Ipv4Utilization = {
   /** The number of IPv4 addresses allocated from this pool */
@@ -2407,19 +2419,19 @@ export type LinkFec =
  */
 export type LldpLinkConfigCreate = {
   /** The LLDP chassis identifier TLV. */
-  chassisId?: string
+  chassisId?: string | null
   /** Whether or not LLDP is enabled. */
   enabled: boolean
   /** The LLDP link description TLV. */
-  linkDescription?: string
+  linkDescription?: string | null
   /** The LLDP link name TLV. */
-  linkName?: string
+  linkName?: string | null
   /** The LLDP management IP TLV. */
-  managementIp?: string
+  managementIp?: string | null
   /** The LLDP system description TLV. */
-  systemDescription?: string
+  systemDescription?: string | null
   /** The LLDP system name TLV. */
-  systemName?: string
+  systemName?: string | null
 }
 
 /**
@@ -2458,15 +2470,15 @@ export type LinkSpeed =
  */
 export type TxEqConfig = {
   /** Main tap */
-  main?: number
+  main?: number | null
   /** Post-cursor tap1 */
-  post1?: number
+  post1?: number | null
   /** Post-cursor tap2 */
-  post2?: number
+  post2?: number | null
   /** Pre-cursor tap1 */
-  pre1?: number
+  pre1?: number | null
   /** Pre-cursor tap2 */
-  pre2?: number
+  pre2?: number | null
 }
 
 /**
@@ -2476,7 +2488,7 @@ export type LinkConfigCreate = {
   /** Whether or not to set autonegotiation */
   autoneg: boolean
   /** The requested forward-error correction method.  If this is not specified, the standard FEC for the underlying media will be applied if it can be determined. */
-  fec?: LinkFec
+  fec?: LinkFec | null
   /** The link-layer discovery protocol (LLDP) configuration for the link. */
   lldp: LldpLinkConfigCreate
   /** Maximum transmission unit for the link. */
@@ -2484,7 +2496,7 @@ export type LinkConfigCreate = {
   /** The speed of the link. */
   speed: LinkSpeed
   /** Optional tx_eq settings */
-  txEq?: TxEqConfig
+  txEq?: TxEqConfig | null
 }
 
 /**
@@ -2492,21 +2504,21 @@ export type LinkConfigCreate = {
  */
 export type LldpLinkConfig = {
   /** The LLDP chassis identifier TLV. */
-  chassisId?: string
+  chassisId?: string | null
   /** Whether or not the LLDP service is enabled. */
   enabled: boolean
   /** The id of this LLDP service instance. */
   id: string
   /** The LLDP link description TLV. */
-  linkDescription?: string
+  linkDescription?: string | null
   /** The LLDP link name TLV. */
-  linkName?: string
+  linkName?: string | null
   /** The LLDP management IP TLV. */
-  managementIp?: IpNet
+  managementIp?: IpNet | null
   /** The LLDP system description TLV. */
-  systemDescription?: string
+  systemDescription?: string | null
   /** The LLDP system name TLV. */
-  systemName?: string
+  systemName?: string | null
 }
 
 /**
@@ -2520,7 +2532,7 @@ export type LldpNeighbor = {
   /** Most recent sighting of this LldpNeighbor */
   lastSeen: Date
   /** The LLDP link description advertised by the neighbor */
-  linkDescription?: string
+  linkDescription?: string | null
   /** The LLDP link name advertised by the neighbor */
   linkName: string
   /** The port on which the neighbor was seen */
@@ -2528,9 +2540,9 @@ export type LldpNeighbor = {
   /** The LLDP management IP(s) advertised by the neighbor */
   managementIp: IpNet[]
   /** The LLDP system description advertised by the neighbor */
-  systemDescription?: string
+  systemDescription?: string | null
   /** The LLDP system name advertised by the neighbor */
-  systemName?: string
+  systemName?: string | null
 }
 
 /**
@@ -2540,7 +2552,7 @@ export type LldpNeighborResultsPage = {
   /** list of items on this page of results */
   items: LldpNeighbor[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
@@ -2584,7 +2596,7 @@ export type LoopbackAddressResultsPage = {
   /** list of items on this page of results */
   items: LoopbackAddress[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
@@ -2599,7 +2611,7 @@ export type MeasurementResultsPage = {
   /** list of items on this page of results */
   items: Measurement[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
@@ -2653,12 +2665,12 @@ export type NetworkInterface = {
  * Each element is an option, where `None` represents a missing sample.
  */
 export type ValueArray =
-  | { type: 'integer'; values: number[] }
-  | { type: 'double'; values: number[] }
-  | { type: 'boolean'; values: boolean[] }
-  | { type: 'string'; values: string[] }
-  | { type: 'integer_distribution'; values: Distributionint64[] }
-  | { type: 'double_distribution'; values: Distributiondouble[] }
+  | { type: 'integer'; values: (number | null)[] }
+  | { type: 'double'; values: (number | null)[] }
+  | { type: 'boolean'; values: (boolean | null)[] }
+  | { type: 'string'; values: (string | null)[] }
+  | { type: 'integer_distribution'; values: (Distributionint64 | null)[] }
+  | { type: 'double_distribution'; values: (Distributiondouble | null)[] }
 
 /**
  * A single list of values, for one dimension of a timeseries.
@@ -2673,7 +2685,11 @@ export type Values = {
 /**
  * Timepoints and values for one timeseries.
  */
-export type Points = { startTimes?: Date[]; timestamps: Date[]; values: Values[] }
+export type Points = {
+  startTimes?: Date[] | null
+  timestamps: Date[]
+  values: Values[]
+}
 
 /**
  * A timeseries contains a timestamped set of values from one source.
@@ -2748,7 +2764,7 @@ export type PhysicalDisk = {
   policy: PhysicalDiskPolicy
   serial: string
   /** The sled to which this disk is attached, if any. */
-  sledId?: string
+  sledId?: string | null
   /** The current state Nexus believes the disk to be in. */
   state: PhysicalDiskState
   /** timestamp when this resource was created */
@@ -2765,7 +2781,7 @@ export type PhysicalDiskResultsPage = {
   /** list of items on this page of results */
   items: PhysicalDisk[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 export type PingStatus = 'ok'
@@ -2797,7 +2813,7 @@ export type Probe = {
  */
 export type ProbeCreate = {
   description: string
-  ipPool?: NameOrId
+  ipPool?: NameOrId | null
   name: Name
   sled: string
 }
@@ -2826,7 +2842,7 @@ export type ProbeInfoResultsPage = {
   /** list of items on this page of results */
   items: ProbeInfo[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
@@ -2857,7 +2873,7 @@ export type ProjectResultsPage = {
   /** list of items on this page of results */
   items: Project[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 export type ProjectRole = 'admin' | 'collaborator' | 'viewer'
@@ -2886,7 +2902,7 @@ export type ProjectRolePolicy = {
 /**
  * Updateable properties of a `Project`
  */
-export type ProjectUpdate = { description?: string; name?: Name }
+export type ProjectUpdate = { description?: string | null; name?: Name | null }
 
 /**
  * View of an Rack
@@ -2907,7 +2923,7 @@ export type RackResultsPage = {
   /** list of items on this page of results */
   items: Rack[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
@@ -2929,7 +2945,7 @@ export type RoleResultsPage = {
   /** list of items on this page of results */
   items: Role[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
@@ -2941,9 +2957,9 @@ export type Route = {
   /** The route gateway. */
   gw: string
   /** Local preference for route. Higher preference indictes precedence within and across protocols. */
-  ribPriority?: number
+  ribPriority?: number | null
   /** VLAN id the gateway is reachable over. */
-  vid?: number
+  vid?: number | null
 }
 
 /**
@@ -3055,17 +3071,17 @@ export type RouterRouteResultsPage = {
   /** list of items on this page of results */
   items: RouterRoute[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
  * Updateable properties of a `RouterRoute`
  */
 export type RouterRouteUpdate = {
-  description?: string
+  description?: string | null
   /** Selects which traffic this routing rule will apply to. */
   destination: RouteDestination
-  name?: Name
+  name?: Name | null
   /** The location that matched packets should be forwarded to. */
   target: RouteTarget
 }
@@ -3079,7 +3095,7 @@ export type SamlIdentityProvider = {
   /** human-readable free-form text about a resource */
   description: string
   /** If set, attributes with this name will be considered to denote a user's group membership, where the values will be the group names. */
-  groupAttributeName?: string
+  groupAttributeName?: string | null
   /** unique, immutable, system-controlled identifier for each resource */
   id: string
   /** IdP's entity id */
@@ -3087,7 +3103,7 @@ export type SamlIdentityProvider = {
   /** unique, mutable, user-controlled identifier for each resource */
   name: Name
   /** Optional request signing public certificate (base64 encoded der file) */
-  publicCert?: string
+  publicCert?: string | null
   /** Service provider endpoint where the idp should send log out requests */
   sloUrl: string
   /** SP's client id */
@@ -3108,14 +3124,14 @@ export type SamlIdentityProviderCreate = {
   acsUrl: string
   description: string
   /** If set, SAML attributes with this name will be considered to denote a user's group membership, where the attribute value(s) should be a comma-separated list of group names. */
-  groupAttributeName?: string
+  groupAttributeName?: string | null
   /** idp's entity id */
   idpEntityId: string
   /** the source of an identity provider metadata descriptor */
   idpMetadataSource: IdpMetadataSource
   name: Name
   /** request signing key pair */
-  signingKeypair?: DerEncodedKeyPair
+  signingKeypair?: DerEncodedKeyPair | null
   /** service provider endpoint where the idp should send log out requests */
   sloUrl: string
   /** sp's client id */
@@ -3187,7 +3203,7 @@ export type SiloCreate = {
   /** If set, this group will be created during Silo creation and granted the "Silo Admin" role. Identity providers can assert that users belong to this group and those users can log in and further initialize the Silo.
 
 Note that if configuring a SAML based identity provider, group_attribute_name must be set for users to be considered part of a group. See `SamlIdentityProviderCreate` for more information. */
-  adminGroupName?: string
+  adminGroupName?: string | null
   description: string
   discoverable: boolean
   identityMode: SiloIdentityMode
@@ -3227,7 +3243,7 @@ export type SiloIpPoolResultsPage = {
   /** list of items on this page of results */
   items: SiloIpPool[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
@@ -3250,7 +3266,7 @@ export type SiloQuotasResultsPage = {
   /** list of items on this page of results */
   items: SiloQuotas[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
@@ -3258,11 +3274,11 @@ export type SiloQuotasResultsPage = {
  */
 export type SiloQuotasUpdate = {
   /** The amount of virtual CPUs available for running instances in the Silo */
-  cpus?: number
+  cpus?: number | null
   /** The amount of RAM (in bytes) available for running instances in the Silo */
-  memory?: ByteCount
+  memory?: ByteCount | null
   /** The amount of storage (in bytes) available for disks or snapshots */
-  storage?: ByteCount
+  storage?: ByteCount | null
 }
 
 /**
@@ -3272,7 +3288,7 @@ export type SiloResultsPage = {
   /** list of items on this page of results */
   items: Silo[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 export type SiloRole = 'admin' | 'collaborator' | 'viewer'
@@ -3329,7 +3345,7 @@ export type SiloUtilizationResultsPage = {
   /** list of items on this page of results */
   items: SiloUtilization[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
@@ -3409,7 +3425,7 @@ export type SledInstance = {
   /** unique, immutable, system-controlled identifier for each resource */
   id: string
   memory: number
-  migrationId?: string
+  migrationId?: string | null
   name: Name
   ncpus: number
   projectName: Name
@@ -3428,7 +3444,7 @@ export type SledInstanceResultsPage = {
   /** list of items on this page of results */
   items: SledInstance[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
@@ -3456,7 +3472,7 @@ export type SledResultsPage = {
   /** list of items on this page of results */
   items: Sled[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 export type SnapshotState = 'creating' | 'ready' | 'faulted' | 'destroyed'
@@ -3498,7 +3514,7 @@ export type SnapshotResultsPage = {
   /** list of items on this page of results */
   items: Snapshot[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
@@ -3538,7 +3554,7 @@ export type SshKeyResultsPage = {
   /** list of items on this page of results */
   items: SshKey[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 export type TypedUuidForSupportBundleKind = string
@@ -3567,7 +3583,7 @@ The record of the bundle still exists for readability, but the only valid operat
 export type SupportBundleInfo = {
   id: TypedUuidForSupportBundleKind
   reasonForCreation: string
-  reasonForFailure?: string
+  reasonForFailure?: string | null
   state: SupportBundleState
   timeCreated: Date
 }
@@ -3579,7 +3595,7 @@ export type SupportBundleInfoResultsPage = {
   /** list of items on this page of results */
   items: SupportBundleInfo[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
@@ -3662,7 +3678,7 @@ export type SwitchPort = {
   /** The name of this switch port. */
   portName: string
   /** The primary settings group of this switch port. Will be `None` until this switch port is configured. */
-  portSettingsId?: string
+  portSettingsId?: string | null
   /** The rack this switch port belongs to. */
   rackId: string
   /** The switch location of this switch port. */
@@ -3682,7 +3698,7 @@ export type SwitchPortAddressConfig = {
   /** The port settings object this address configuration belongs to. */
   portSettingsId: string
   /** An optional VLAN ID */
-  vlanId?: number
+  vlanId?: number | null
 }
 
 /**
@@ -3744,11 +3760,11 @@ export type SwitchPortLinkConfig = {
   /** Whether or not the link has autonegotiation enabled. */
   autoneg: boolean
   /** The requested forward-error correction method.  If this is not specified, the standard FEC for the underlying media will be applied if it can be determined. */
-  fec?: LinkFec
+  fec?: LinkFec | null
   /** The name of this link. */
   linkName: string
   /** The link-layer discovery protocol service configuration id for this link. */
-  lldpLinkConfigId?: string
+  lldpLinkConfigId?: string | null
   /** The maximum transmission unit for this link. */
   mtu: number
   /** The port settings this link configuration belongs to. */
@@ -3756,7 +3772,7 @@ export type SwitchPortLinkConfig = {
   /** The configured speed of the link. */
   speed: LinkSpeed
   /** The tx_eq configuration id for this link. */
-  txEqConfigId?: string
+  txEqConfigId?: string | null
 }
 
 /**
@@ -3766,7 +3782,7 @@ export type SwitchPortResultsPage = {
   /** list of items on this page of results */
   items: SwitchPort[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
@@ -3782,9 +3798,9 @@ export type SwitchPortRouteConfig = {
   /** The port settings object this route configuration belongs to. */
   portSettingsId: string
   /** RIB Priority indicating priority within and across protocols. */
-  ribPriority?: number
+  ribPriority?: number | null
   /** The VLAN identifier for the route. Use this if the gateway is reachable over an 802.1Q tagged L2 segment. */
-  vlanId?: number
+  vlanId?: number | null
 }
 
 /**
@@ -3840,7 +3856,7 @@ export type SwitchPortSettingsResultsPage = {
   /** list of items on this page of results */
   items: SwitchPortSettings[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
@@ -3876,7 +3892,7 @@ export type SwitchPortSettingsView = {
   /** The primary switch port settings handle. */
   settings: SwitchPortSettings
   /** TX equalization settings.  These are optional, and most links will not need them. */
-  txEq: TxEqConfig[]
+  txEq: (TxEqConfig | null)[]
   /** Vlan interface settings. */
   vlanInterfaces: SwitchVlanInterfaceConfig[]
 }
@@ -3888,7 +3904,7 @@ export type SwitchResultsPage = {
   /** list of items on this page of results */
   items: Switch[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
@@ -3974,13 +3990,17 @@ export type TimeseriesSchemaResultsPage = {
   /** list of items on this page of results */
   items: TimeseriesSchema[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
  * A sled that has not been added to an initialized rack yet
  */
-export type UninitializedSled = { baseboard: Baseboard; cubby: number; rackId: string }
+export type UninitializedSled = {
+  baseboard: Baseboard
+  cubby: number
+  rackId: string
+}
 
 /**
  * The unique hardware ID for a sled
@@ -3994,7 +4014,7 @@ export type UninitializedSledResultsPage = {
   /** list of items on this page of results */
   items: UninitializedSled[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
@@ -4033,7 +4053,7 @@ export type UserBuiltinResultsPage = {
   /** list of items on this page of results */
   items: UserBuiltin[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
@@ -4069,13 +4089,16 @@ export type UserResultsPage = {
   /** list of items on this page of results */
   items: User[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
  * Credentials for local user login
  */
-export type UsernamePasswordCredentials = { password: Password; username: UserId }
+export type UsernamePasswordCredentials = {
+  password: Password
+  username: UserId
+}
 
 /**
  * View of the current silo's resource utilization and capacity
@@ -4120,7 +4143,7 @@ export type VpcCreate = {
   /** The IPv6 prefix for this VPC
 
 All IPv6 subnets created from this VPC must be taken from this range, which should be a Unique Local Address in the range `fd00::/48`. The default VPC Subnet will have the first `/64` range from this prefix. */
-  ipv6Prefix?: Ipv6Net
+  ipv6Prefix?: Ipv6Net | null
   name: Name
 }
 
@@ -4153,11 +4176,11 @@ export type VpcFirewallRuleProtocol = 'TCP' | 'UDP' | 'ICMP'
  */
 export type VpcFirewallRuleFilter = {
   /** If present, host filters match the "other end" of traffic from the target’s perspective: for an inbound rule, they match the source of traffic. For an outbound rule, they match the destination. */
-  hosts?: VpcFirewallRuleHostFilter[]
+  hosts?: VpcFirewallRuleHostFilter[] | null
   /** If present, the destination ports or port ranges this rule applies to. */
-  ports?: L4PortRange[]
+  ports?: L4PortRange[] | null
   /** If present, the networking protocols this rule applies to. */
-  protocols?: VpcFirewallRuleProtocol[]
+  protocols?: VpcFirewallRuleProtocol[] | null
 }
 
 export type VpcFirewallRuleStatus = 'disabled' | 'enabled'
@@ -4246,7 +4269,7 @@ export type VpcResultsPage = {
   /** list of items on this page of results */
   items: Vpc[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 export type VpcRouterKind = 'system' | 'custom'
@@ -4282,20 +4305,23 @@ export type VpcRouterResultsPage = {
   /** list of items on this page of results */
   items: VpcRouter[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
  * Updateable properties of a `VpcRouter`
  */
-export type VpcRouterUpdate = { description?: string; name?: Name }
+export type VpcRouterUpdate = {
+  description?: string | null
+  name?: Name | null
+}
 
 /**
  * A VPC subnet represents a logical grouping for instances that allows network traffic between them, within a IPv4 subnetwork or optionally an IPv6 subnetwork.
  */
 export type VpcSubnet = {
   /** ID for an attached custom router. */
-  customRouterId?: string
+  customRouterId?: string | null
   /** human-readable free-form text about a resource */
   description: string
   /** unique, immutable, system-controlled identifier for each resource */
@@ -4321,7 +4347,7 @@ export type VpcSubnetCreate = {
   /** An optional router, used to direct packets sent from hosts in this subnet to any destination address.
 
 Custom routers apply in addition to the VPC-wide *system* router, and have higher priority than the system router for an otherwise equal-prefix-length match. */
-  customRouter?: NameOrId
+  customRouter?: NameOrId | null
   description: string
   /** The IPv4 address range for this subnet.
 
@@ -4330,7 +4356,7 @@ It must be allocated from an RFC 1918 private address range, and must not overla
   /** The IPv6 address range for this subnet.
 
 It must be allocated from the RFC 4193 Unique Local Address range, with the prefix equal to the parent VPC's prefix. A random `/64` block will be assigned if one is not provided. It must not overlap with any existing subnet in the VPC. */
-  ipv6Block?: Ipv6Net
+  ipv6Block?: Ipv6Net | null
   name: Name
 }
 
@@ -4341,7 +4367,7 @@ export type VpcSubnetResultsPage = {
   /** list of items on this page of results */
   items: VpcSubnet[]
   /** token used to fetch the next page of results (if any) */
-  nextPage?: string
+  nextPage?: string | null
 }
 
 /**
@@ -4349,15 +4375,19 @@ export type VpcSubnetResultsPage = {
  */
 export type VpcSubnetUpdate = {
   /** An optional router, used to direct packets sent from hosts in this subnet to any destination address. */
-  customRouter?: NameOrId
-  description?: string
-  name?: Name
+  customRouter?: NameOrId | null
+  description?: string | null
+  name?: Name | null
 }
 
 /**
  * Updateable properties of a `Vpc`
  */
-export type VpcUpdate = { description?: string; dnsName?: Name; name?: Name }
+export type VpcUpdate = {
+  description?: string | null
+  dnsName?: Name | null
+  name?: Name | null
+}
 
 /**
  * Supported set of sort modes for scanning by name or id
@@ -4405,8 +4435,8 @@ export type SystemMetricName =
 export type NameSortMode = 'name_ascending'
 
 export interface ProbeListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   project?: NameOrId
   sortBy?: NameOrIdSortMode
 }
@@ -4432,8 +4462,8 @@ export interface ProbeDeleteQueryParams {
 }
 
 export interface SupportBundleListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   sortBy?: IdSortMode
 }
 
@@ -4473,8 +4503,8 @@ export interface LoginSamlPathParams {
 }
 
 export interface AffinityGroupListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   project?: NameOrId
   sortBy?: NameOrIdSortMode
 }
@@ -4512,8 +4542,8 @@ export interface AffinityGroupMemberListPathParams {
 }
 
 export interface AffinityGroupMemberListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   project?: NameOrId
   sortBy?: NameOrIdSortMode
 }
@@ -4546,8 +4576,8 @@ export interface AffinityGroupMemberInstanceDeleteQueryParams {
 }
 
 export interface AntiAffinityGroupListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   project?: NameOrId
   sortBy?: NameOrIdSortMode
 }
@@ -4585,8 +4615,8 @@ export interface AntiAffinityGroupMemberListPathParams {
 }
 
 export interface AntiAffinityGroupMemberListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   project?: NameOrId
   sortBy?: NameOrIdSortMode
 }
@@ -4619,8 +4649,8 @@ export interface AntiAffinityGroupMemberInstanceDeleteQueryParams {
 }
 
 export interface CertificateListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   sortBy?: NameOrIdSortMode
 }
 
@@ -4633,8 +4663,8 @@ export interface CertificateDeletePathParams {
 }
 
 export interface DiskListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   project?: NameOrId
   sortBy?: NameOrIdSortMode
 }
@@ -4698,16 +4728,16 @@ export interface DiskMetricsListPathParams {
 
 export interface DiskMetricsListQueryParams {
   endTime?: Date
-  limit?: number
+  limit?: number | null
   order?: PaginationOrder
-  pageToken?: string
+  pageToken?: string | null
   startTime?: Date
   project?: NameOrId
 }
 
 export interface FloatingIpListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   project?: NameOrId
   sortBy?: NameOrIdSortMode
 }
@@ -4757,8 +4787,8 @@ export interface FloatingIpDetachQueryParams {
 }
 
 export interface GroupListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   sortBy?: IdSortMode
 }
 
@@ -4767,8 +4797,8 @@ export interface GroupViewPathParams {
 }
 
 export interface ImageListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   project?: NameOrId
   sortBy?: NameOrIdSortMode
 }
@@ -4810,8 +4840,8 @@ export interface ImagePromoteQueryParams {
 }
 
 export interface InstanceListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   project?: NameOrId
   sortBy?: NameOrIdSortMode
 }
@@ -4849,8 +4879,8 @@ export interface InstanceAffinityGroupListPathParams {
 }
 
 export interface InstanceAffinityGroupListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   project?: NameOrId
   sortBy?: NameOrIdSortMode
 }
@@ -4860,8 +4890,8 @@ export interface InstanceAntiAffinityGroupListPathParams {
 }
 
 export interface InstanceAntiAffinityGroupListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   project?: NameOrId
   sortBy?: NameOrIdSortMode
 }
@@ -4871,8 +4901,8 @@ export interface InstanceDiskListPathParams {
 }
 
 export interface InstanceDiskListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   project?: NameOrId
   sortBy?: NameOrIdSortMode
 }
@@ -4930,9 +4960,9 @@ export interface InstanceSerialConsolePathParams {
 }
 
 export interface InstanceSerialConsoleQueryParams {
-  fromStart?: number
-  maxBytes?: number
-  mostRecent?: number
+  fromStart?: number | null
+  maxBytes?: number | null
+  mostRecent?: number | null
   project?: NameOrId
 }
 
@@ -4941,7 +4971,7 @@ export interface InstanceSerialConsoleStreamPathParams {
 }
 
 export interface InstanceSerialConsoleStreamQueryParams {
-  mostRecent?: number
+  mostRecent?: number | null
   project?: NameOrId
 }
 
@@ -4950,8 +4980,8 @@ export interface InstanceSshPublicKeyListPathParams {
 }
 
 export interface InstanceSshPublicKeyListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   project?: NameOrId
   sortBy?: NameOrIdSortMode
 }
@@ -4974,8 +5004,8 @@ export interface InstanceStopQueryParams {
 
 export interface InternetGatewayIpAddressListQueryParams {
   gateway?: NameOrId
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   project?: NameOrId
   sortBy?: NameOrIdSortMode
   vpc?: NameOrId
@@ -5000,8 +5030,8 @@ export interface InternetGatewayIpAddressDeleteQueryParams {
 
 export interface InternetGatewayIpPoolListQueryParams {
   gateway?: NameOrId
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   project?: NameOrId
   sortBy?: NameOrIdSortMode
   vpc?: NameOrId
@@ -5025,8 +5055,8 @@ export interface InternetGatewayIpPoolDeleteQueryParams {
 }
 
 export interface InternetGatewayListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   project?: NameOrId
   sortBy?: NameOrIdSortMode
   vpc?: NameOrId
@@ -5057,8 +5087,8 @@ export interface InternetGatewayDeleteQueryParams {
 }
 
 export interface ProjectIpPoolListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   sortBy?: NameOrIdSortMode
 }
 
@@ -5071,14 +5101,14 @@ export interface LoginLocalPathParams {
 }
 
 export interface CurrentUserGroupsQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   sortBy?: IdSortMode
 }
 
 export interface CurrentUserSshKeyListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   sortBy?: NameOrIdSortMode
 }
 
@@ -5096,17 +5126,17 @@ export interface SiloMetricPathParams {
 
 export interface SiloMetricQueryParams {
   endTime?: Date
-  limit?: number
+  limit?: number | null
   order?: PaginationOrder
-  pageToken?: string
+  pageToken?: string | null
   startTime?: Date
   project?: NameOrId
 }
 
 export interface InstanceNetworkInterfaceListQueryParams {
   instance?: NameOrId
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   project?: NameOrId
   sortBy?: NameOrIdSortMode
 }
@@ -5144,8 +5174,8 @@ export interface InstanceNetworkInterfaceDeleteQueryParams {
 }
 
 export interface ProjectListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   sortBy?: NameOrIdSortMode
 }
 
@@ -5170,8 +5200,8 @@ export interface ProjectPolicyUpdatePathParams {
 }
 
 export interface SnapshotListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   project?: NameOrId
   sortBy?: NameOrIdSortMode
 }
@@ -5197,8 +5227,8 @@ export interface SnapshotDeleteQueryParams {
 }
 
 export interface PhysicalDiskListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   sortBy?: IdSortMode
 }
 
@@ -5213,14 +5243,14 @@ export interface NetworkingSwitchPortLldpNeighborsPathParams {
 }
 
 export interface NetworkingSwitchPortLldpNeighborsQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   sortBy?: IdSortMode
 }
 
 export interface RackListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   sortBy?: IdSortMode
 }
 
@@ -5229,8 +5259,8 @@ export interface RackViewPathParams {
 }
 
 export interface SledListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   sortBy?: IdSortMode
 }
 
@@ -5243,8 +5273,8 @@ export interface SledPhysicalDiskListPathParams {
 }
 
 export interface SledPhysicalDiskListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   sortBy?: IdSortMode
 }
 
@@ -5253,8 +5283,8 @@ export interface SledInstanceListPathParams {
 }
 
 export interface SledInstanceListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   sortBy?: IdSortMode
 }
 
@@ -5263,15 +5293,15 @@ export interface SledSetProvisionPolicyPathParams {
 }
 
 export interface SledListUninitializedQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
 }
 
 export interface NetworkingSwitchPortListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   sortBy?: IdSortMode
-  switchPortId?: string
+  switchPortId?: string | null
 }
 
 export interface NetworkingSwitchPortLldpConfigViewPathParams {
@@ -5320,8 +5350,8 @@ export interface NetworkingSwitchPortStatusQueryParams {
 }
 
 export interface SwitchListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   sortBy?: IdSortMode
 }
 
@@ -5330,8 +5360,8 @@ export interface SwitchViewPathParams {
 }
 
 export interface SiloIdentityProviderListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   silo?: NameOrId
   sortBy?: NameOrIdSortMode
 }
@@ -5369,8 +5399,8 @@ export interface SamlIdentityProviderViewQueryParams {
 }
 
 export interface IpPoolListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   sortBy?: NameOrIdSortMode
 }
 
@@ -5391,8 +5421,8 @@ export interface IpPoolRangeListPathParams {
 }
 
 export interface IpPoolRangeListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
 }
 
 export interface IpPoolRangeAddPathParams {
@@ -5408,8 +5438,8 @@ export interface IpPoolSiloListPathParams {
 }
 
 export interface IpPoolSiloListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   sortBy?: IdSortMode
 }
 
@@ -5432,8 +5462,8 @@ export interface IpPoolUtilizationViewPathParams {
 }
 
 export interface IpPoolServiceRangeListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
 }
 
 export interface SystemMetricPathParams {
@@ -5442,16 +5472,16 @@ export interface SystemMetricPathParams {
 
 export interface SystemMetricQueryParams {
   endTime?: Date
-  limit?: number
+  limit?: number | null
   order?: PaginationOrder
-  pageToken?: string
+  pageToken?: string | null
   startTime?: Date
   silo?: NameOrId
 }
 
 export interface NetworkingAddressLotListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   sortBy?: NameOrIdSortMode
 }
 
@@ -5464,14 +5494,14 @@ export interface NetworkingAddressLotBlockListPathParams {
 }
 
 export interface NetworkingAddressLotBlockListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   sortBy?: IdSortMode
 }
 
 export interface NetworkingBgpConfigListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   sortBy?: NameOrIdSortMode
 }
 
@@ -5480,8 +5510,8 @@ export interface NetworkingBgpConfigDeleteQueryParams {
 }
 
 export interface NetworkingBgpAnnounceSetListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   sortBy?: NameOrIdSortMode
 }
 
@@ -5502,8 +5532,8 @@ export interface NetworkingBgpImportedRoutesIpv4QueryParams {
 }
 
 export interface NetworkingLoopbackAddressListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   sortBy?: IdSortMode
 }
 
@@ -5515,8 +5545,8 @@ export interface NetworkingLoopbackAddressDeletePathParams {
 }
 
 export interface NetworkingSwitchPortSettingsListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   portSettings?: NameOrId
   sortBy?: NameOrIdSortMode
 }
@@ -5530,8 +5560,8 @@ export interface NetworkingSwitchPortSettingsViewPathParams {
 }
 
 export interface RoleListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
 }
 
 export interface RoleViewPathParams {
@@ -5539,14 +5569,14 @@ export interface RoleViewPathParams {
 }
 
 export interface SystemQuotasListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   sortBy?: IdSortMode
 }
 
 export interface SiloListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   sortBy?: NameOrIdSortMode
 }
 
@@ -5563,8 +5593,8 @@ export interface SiloIpPoolListPathParams {
 }
 
 export interface SiloIpPoolListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   sortBy?: NameOrIdSortMode
 }
 
@@ -5585,13 +5615,13 @@ export interface SiloQuotasUpdatePathParams {
 }
 
 export interface SystemTimeseriesSchemaListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
 }
 
 export interface SiloUserListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   silo?: NameOrId
   sortBy?: IdSortMode
 }
@@ -5605,8 +5635,8 @@ export interface SiloUserViewQueryParams {
 }
 
 export interface UserBuiltinListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   sortBy?: NameSortMode
 }
 
@@ -5615,8 +5645,8 @@ export interface UserBuiltinViewPathParams {
 }
 
 export interface SiloUtilizationListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   sortBy?: NameOrIdSortMode
 }
 
@@ -5629,9 +5659,9 @@ export interface TimeseriesQueryQueryParams {
 }
 
 export interface UserListQueryParams {
-  group?: string
-  limit?: number
-  pageToken?: string
+  group?: string | null
+  limit?: number | null
+  pageToken?: string | null
   sortBy?: IdSortMode
 }
 
@@ -5646,8 +5676,8 @@ export interface VpcFirewallRulesUpdateQueryParams {
 }
 
 export interface VpcRouterRouteListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   project?: NameOrId
   router?: NameOrId
   sortBy?: NameOrIdSortMode
@@ -5691,8 +5721,8 @@ export interface VpcRouterRouteDeleteQueryParams {
 }
 
 export interface VpcRouterListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   project?: NameOrId
   sortBy?: NameOrIdSortMode
   vpc?: NameOrId
@@ -5731,8 +5761,8 @@ export interface VpcRouterDeleteQueryParams {
 }
 
 export interface VpcSubnetListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   project?: NameOrId
   sortBy?: NameOrIdSortMode
   vpc?: NameOrId
@@ -5775,16 +5805,16 @@ export interface VpcSubnetListNetworkInterfacesPathParams {
 }
 
 export interface VpcSubnetListNetworkInterfacesQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   project?: NameOrId
   sortBy?: NameOrIdSortMode
   vpc?: NameOrId
 }
 
 export interface VpcListQueryParams {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
   project?: NameOrId
   sortBy?: NameOrIdSortMode
 }
@@ -6069,7 +6099,10 @@ export class Api extends HttpClient {
       {
         path,
         query = {},
-      }: { path: AffinityGroupViewPathParams; query?: AffinityGroupViewQueryParams },
+      }: {
+        path: AffinityGroupViewPathParams
+        query?: AffinityGroupViewQueryParams
+      },
       params: FetchParams = {}
     ) => {
       return this.request<AffinityGroup>({
@@ -6109,7 +6142,10 @@ export class Api extends HttpClient {
       {
         path,
         query = {},
-      }: { path: AffinityGroupDeletePathParams; query?: AffinityGroupDeleteQueryParams },
+      }: {
+        path: AffinityGroupDeletePathParams
+        query?: AffinityGroupDeleteQueryParams
+      },
       params: FetchParams = {}
     ) => {
       return this.request<void>({
@@ -6220,7 +6256,10 @@ export class Api extends HttpClient {
       {
         query,
         body,
-      }: { query: AntiAffinityGroupCreateQueryParams; body: AntiAffinityGroupCreate },
+      }: {
+        query: AntiAffinityGroupCreateQueryParams
+        body: AntiAffinityGroupCreate
+      },
       params: FetchParams = {}
     ) => {
       return this.request<AntiAffinityGroup>({
@@ -6578,7 +6617,10 @@ export class Api extends HttpClient {
       {
         path,
         query = {},
-      }: { path: DiskMetricsListPathParams; query?: DiskMetricsListQueryParams },
+      }: {
+        path: DiskMetricsListPathParams
+        query?: DiskMetricsListQueryParams
+      },
       params: FetchParams = {}
     ) => {
       return this.request<MeasurementResultsPage>({
@@ -6664,7 +6706,10 @@ export class Api extends HttpClient {
       {
         path,
         query = {},
-      }: { path: FloatingIpDeletePathParams; query?: FloatingIpDeleteQueryParams },
+      }: {
+        path: FloatingIpDeletePathParams
+        query?: FloatingIpDeleteQueryParams
+      },
       params: FetchParams = {}
     ) => {
       return this.request<void>({
@@ -6704,7 +6749,10 @@ export class Api extends HttpClient {
       {
         path,
         query = {},
-      }: { path: FloatingIpDetachPathParams; query?: FloatingIpDetachQueryParams },
+      }: {
+        path: FloatingIpDetachPathParams
+        query?: FloatingIpDetachQueryParams
+      },
       params: FetchParams = {}
     ) => {
       return this.request<FloatingIp>({
@@ -6959,7 +7007,10 @@ export class Api extends HttpClient {
       {
         path,
         query = {},
-      }: { path: InstanceDiskListPathParams; query?: InstanceDiskListQueryParams },
+      }: {
+        path: InstanceDiskListPathParams
+        query?: InstanceDiskListQueryParams
+      },
       params: FetchParams = {}
     ) => {
       return this.request<DiskResultsPage>({
@@ -7300,7 +7351,10 @@ export class Api extends HttpClient {
       {
         query,
         body,
-      }: { query: InternetGatewayCreateQueryParams; body: InternetGatewayCreate },
+      }: {
+        query: InternetGatewayCreateQueryParams
+        body: InternetGatewayCreate
+      },
       params: FetchParams = {}
     ) => {
       return this.request<InternetGateway>({
@@ -7318,7 +7372,10 @@ export class Api extends HttpClient {
       {
         path,
         query = {},
-      }: { path: InternetGatewayViewPathParams; query?: InternetGatewayViewQueryParams },
+      }: {
+        path: InternetGatewayViewPathParams
+        query?: InternetGatewayViewQueryParams
+      },
       params: FetchParams = {}
     ) => {
       return this.request<InternetGateway>({
@@ -7885,7 +7942,10 @@ export class Api extends HttpClient {
       {
         path,
         query = {},
-      }: { path: SledPhysicalDiskListPathParams; query?: SledPhysicalDiskListQueryParams },
+      }: {
+        path: SledPhysicalDiskListPathParams
+        query?: SledPhysicalDiskListQueryParams
+      },
       params: FetchParams = {}
     ) => {
       return this.request<PhysicalDiskResultsPage>({
@@ -7902,7 +7962,10 @@ export class Api extends HttpClient {
       {
         path,
         query = {},
-      }: { path: SledInstanceListPathParams; query?: SledInstanceListQueryParams },
+      }: {
+        path: SledInstanceListPathParams
+        query?: SledInstanceListQueryParams
+      },
       params: FetchParams = {}
     ) => {
       return this.request<SledInstanceResultsPage>({
@@ -7919,7 +7982,10 @@ export class Api extends HttpClient {
       {
         path,
         body,
-      }: { path: SledSetProvisionPolicyPathParams; body: SledProvisionPolicyParams },
+      }: {
+        path: SledSetProvisionPolicyPathParams
+        body: SledProvisionPolicyParams
+      },
       params: FetchParams = {}
     ) => {
       return this.request<SledProvisionPolicyResponse>({
@@ -8123,7 +8189,10 @@ export class Api extends HttpClient {
       {
         path,
         query,
-      }: { path: LocalIdpUserDeletePathParams; query: LocalIdpUserDeleteQueryParams },
+      }: {
+        path: LocalIdpUserDeletePathParams
+        query: LocalIdpUserDeleteQueryParams
+      },
       params: FetchParams = {}
     ) => {
       return this.request<void>({
@@ -8163,7 +8232,10 @@ export class Api extends HttpClient {
       {
         query,
         body,
-      }: { query: SamlIdentityProviderCreateQueryParams; body: SamlIdentityProviderCreate },
+      }: {
+        query: SamlIdentityProviderCreateQueryParams
+        body: SamlIdentityProviderCreate
+      },
       params: FetchParams = {}
     ) => {
       return this.request<SamlIdentityProvider>({
@@ -8263,7 +8335,10 @@ export class Api extends HttpClient {
       {
         path,
         query = {},
-      }: { path: IpPoolRangeListPathParams; query?: IpPoolRangeListQueryParams },
+      }: {
+        path: IpPoolRangeListPathParams
+        query?: IpPoolRangeListQueryParams
+      },
       params: FetchParams = {}
     ) => {
       return this.request<IpPoolRangeResultsPage>({
@@ -9167,7 +9242,10 @@ export class Api extends HttpClient {
       {
         query,
         body,
-      }: { query: VpcFirewallRulesUpdateQueryParams; body: VpcFirewallRuleUpdateParams },
+      }: {
+        query: VpcFirewallRulesUpdateQueryParams
+        body: VpcFirewallRuleUpdateParams
+      },
       params: FetchParams = {}
     ) => {
       return this.request<VpcFirewallRules>({
@@ -9214,7 +9292,10 @@ export class Api extends HttpClient {
       {
         path,
         query,
-      }: { path: VpcRouterRouteViewPathParams; query: VpcRouterRouteViewQueryParams },
+      }: {
+        path: VpcRouterRouteViewPathParams
+        query: VpcRouterRouteViewQueryParams
+      },
       params: FetchParams = {}
     ) => {
       return this.request<RouterRoute>({
@@ -9254,7 +9335,10 @@ export class Api extends HttpClient {
       {
         path,
         query = {},
-      }: { path: VpcRouterRouteDeletePathParams; query?: VpcRouterRouteDeleteQueryParams },
+      }: {
+        path: VpcRouterRouteDeletePathParams
+        query?: VpcRouterRouteDeleteQueryParams
+      },
       params: FetchParams = {}
     ) => {
       return this.request<void>({
@@ -9340,7 +9424,10 @@ export class Api extends HttpClient {
       {
         path,
         query = {},
-      }: { path: VpcRouterDeletePathParams; query?: VpcRouterDeleteQueryParams },
+      }: {
+        path: VpcRouterDeletePathParams
+        query?: VpcRouterDeleteQueryParams
+      },
       params: FetchParams = {}
     ) => {
       return this.request<void>({
@@ -9426,7 +9513,10 @@ export class Api extends HttpClient {
       {
         path,
         query = {},
-      }: { path: VpcSubnetDeletePathParams; query?: VpcSubnetDeleteQueryParams },
+      }: {
+        path: VpcSubnetDeletePathParams
+        query?: VpcSubnetDeleteQueryParams
+      },
       params: FetchParams = {}
     ) => {
       return this.request<void>({
@@ -9504,7 +9594,11 @@ export class Api extends HttpClient {
         path,
         query = {},
         body,
-      }: { path: VpcUpdatePathParams; query?: VpcUpdateQueryParams; body: VpcUpdate },
+      }: {
+        path: VpcUpdatePathParams
+        query?: VpcUpdateQueryParams
+        body: VpcUpdate
+      },
       params: FetchParams = {}
     ) => {
       return this.request<Vpc>({

--- a/app/api/__generated__/Api.ts
+++ b/app/api/__generated__/Api.ts
@@ -270,10 +270,7 @@ export type AffinityGroupResultsPage = {
 /**
  * Updateable properties of an `AffinityGroup`
  */
-export type AffinityGroupUpdate = {
-  description?: string | null
-  name?: Name | null
-}
+export type AffinityGroupUpdate = { description?: string | null; name?: Name | null }
 
 export type BgpMessageHistory = Record<string, unknown>
 
@@ -400,10 +397,7 @@ export type AntiAffinityGroupResultsPage = {
 /**
  * Updateable properties of an `AntiAffinityGroup`
  */
-export type AntiAffinityGroupUpdate = {
-  description?: string | null
-  name?: Name | null
-}
+export type AntiAffinityGroupUpdate = { description?: string | null; name?: Name | null }
 
 /**
  * Authorization scope for a timeseries.
@@ -1774,10 +1768,7 @@ export type FloatingIpResultsPage = {
 /**
  * Updateable identity-related parameters
  */
-export type FloatingIpUpdate = {
-  description?: string | null
-  name?: Name | null
-}
+export type FloatingIpUpdate = { description?: string | null; name?: Name | null }
 
 /**
  * View of a Group
@@ -1903,10 +1894,7 @@ export type ImageResultsPage = {
 /**
  * Parameters for importing blocks with a bulk write
  */
-export type ImportBlocksBulkWrite = {
-  base64EncodedData: string
-  offset: number
-}
+export type ImportBlocksBulkWrite = { base64EncodedData: string; offset: number }
 
 /**
  * A policy determining when an instance should be automatically restarted by the control plane.
@@ -2685,11 +2673,7 @@ export type Values = {
 /**
  * Timepoints and values for one timeseries.
  */
-export type Points = {
-  startTimes?: Date[] | null
-  timestamps: Date[]
-  values: Values[]
-}
+export type Points = { startTimes?: Date[] | null; timestamps: Date[]; values: Values[] }
 
 /**
  * A timeseries contains a timestamped set of values from one source.
@@ -3996,11 +3980,7 @@ export type TimeseriesSchemaResultsPage = {
 /**
  * A sled that has not been added to an initialized rack yet
  */
-export type UninitializedSled = {
-  baseboard: Baseboard
-  cubby: number
-  rackId: string
-}
+export type UninitializedSled = { baseboard: Baseboard; cubby: number; rackId: string }
 
 /**
  * The unique hardware ID for a sled
@@ -4095,10 +4075,7 @@ export type UserResultsPage = {
 /**
  * Credentials for local user login
  */
-export type UsernamePasswordCredentials = {
-  password: Password
-  username: UserId
-}
+export type UsernamePasswordCredentials = { password: Password; username: UserId }
 
 /**
  * View of the current silo's resource utilization and capacity
@@ -4311,10 +4288,7 @@ export type VpcRouterResultsPage = {
 /**
  * Updateable properties of a `VpcRouter`
  */
-export type VpcRouterUpdate = {
-  description?: string | null
-  name?: Name | null
-}
+export type VpcRouterUpdate = { description?: string | null; name?: Name | null }
 
 /**
  * A VPC subnet represents a logical grouping for instances that allows network traffic between them, within a IPv4 subnetwork or optionally an IPv6 subnetwork.
@@ -6099,10 +6073,7 @@ export class Api extends HttpClient {
       {
         path,
         query = {},
-      }: {
-        path: AffinityGroupViewPathParams
-        query?: AffinityGroupViewQueryParams
-      },
+      }: { path: AffinityGroupViewPathParams; query?: AffinityGroupViewQueryParams },
       params: FetchParams = {}
     ) => {
       return this.request<AffinityGroup>({
@@ -6142,10 +6113,7 @@ export class Api extends HttpClient {
       {
         path,
         query = {},
-      }: {
-        path: AffinityGroupDeletePathParams
-        query?: AffinityGroupDeleteQueryParams
-      },
+      }: { path: AffinityGroupDeletePathParams; query?: AffinityGroupDeleteQueryParams },
       params: FetchParams = {}
     ) => {
       return this.request<void>({
@@ -6256,10 +6224,7 @@ export class Api extends HttpClient {
       {
         query,
         body,
-      }: {
-        query: AntiAffinityGroupCreateQueryParams
-        body: AntiAffinityGroupCreate
-      },
+      }: { query: AntiAffinityGroupCreateQueryParams; body: AntiAffinityGroupCreate },
       params: FetchParams = {}
     ) => {
       return this.request<AntiAffinityGroup>({
@@ -6617,10 +6582,7 @@ export class Api extends HttpClient {
       {
         path,
         query = {},
-      }: {
-        path: DiskMetricsListPathParams
-        query?: DiskMetricsListQueryParams
-      },
+      }: { path: DiskMetricsListPathParams; query?: DiskMetricsListQueryParams },
       params: FetchParams = {}
     ) => {
       return this.request<MeasurementResultsPage>({
@@ -6706,10 +6668,7 @@ export class Api extends HttpClient {
       {
         path,
         query = {},
-      }: {
-        path: FloatingIpDeletePathParams
-        query?: FloatingIpDeleteQueryParams
-      },
+      }: { path: FloatingIpDeletePathParams; query?: FloatingIpDeleteQueryParams },
       params: FetchParams = {}
     ) => {
       return this.request<void>({
@@ -6749,10 +6708,7 @@ export class Api extends HttpClient {
       {
         path,
         query = {},
-      }: {
-        path: FloatingIpDetachPathParams
-        query?: FloatingIpDetachQueryParams
-      },
+      }: { path: FloatingIpDetachPathParams; query?: FloatingIpDetachQueryParams },
       params: FetchParams = {}
     ) => {
       return this.request<FloatingIp>({
@@ -7007,10 +6963,7 @@ export class Api extends HttpClient {
       {
         path,
         query = {},
-      }: {
-        path: InstanceDiskListPathParams
-        query?: InstanceDiskListQueryParams
-      },
+      }: { path: InstanceDiskListPathParams; query?: InstanceDiskListQueryParams },
       params: FetchParams = {}
     ) => {
       return this.request<DiskResultsPage>({
@@ -7351,10 +7304,7 @@ export class Api extends HttpClient {
       {
         query,
         body,
-      }: {
-        query: InternetGatewayCreateQueryParams
-        body: InternetGatewayCreate
-      },
+      }: { query: InternetGatewayCreateQueryParams; body: InternetGatewayCreate },
       params: FetchParams = {}
     ) => {
       return this.request<InternetGateway>({
@@ -7372,10 +7322,7 @@ export class Api extends HttpClient {
       {
         path,
         query = {},
-      }: {
-        path: InternetGatewayViewPathParams
-        query?: InternetGatewayViewQueryParams
-      },
+      }: { path: InternetGatewayViewPathParams; query?: InternetGatewayViewQueryParams },
       params: FetchParams = {}
     ) => {
       return this.request<InternetGateway>({
@@ -7942,10 +7889,7 @@ export class Api extends HttpClient {
       {
         path,
         query = {},
-      }: {
-        path: SledPhysicalDiskListPathParams
-        query?: SledPhysicalDiskListQueryParams
-      },
+      }: { path: SledPhysicalDiskListPathParams; query?: SledPhysicalDiskListQueryParams },
       params: FetchParams = {}
     ) => {
       return this.request<PhysicalDiskResultsPage>({
@@ -7962,10 +7906,7 @@ export class Api extends HttpClient {
       {
         path,
         query = {},
-      }: {
-        path: SledInstanceListPathParams
-        query?: SledInstanceListQueryParams
-      },
+      }: { path: SledInstanceListPathParams; query?: SledInstanceListQueryParams },
       params: FetchParams = {}
     ) => {
       return this.request<SledInstanceResultsPage>({
@@ -7982,10 +7923,7 @@ export class Api extends HttpClient {
       {
         path,
         body,
-      }: {
-        path: SledSetProvisionPolicyPathParams
-        body: SledProvisionPolicyParams
-      },
+      }: { path: SledSetProvisionPolicyPathParams; body: SledProvisionPolicyParams },
       params: FetchParams = {}
     ) => {
       return this.request<SledProvisionPolicyResponse>({
@@ -8189,10 +8127,7 @@ export class Api extends HttpClient {
       {
         path,
         query,
-      }: {
-        path: LocalIdpUserDeletePathParams
-        query: LocalIdpUserDeleteQueryParams
-      },
+      }: { path: LocalIdpUserDeletePathParams; query: LocalIdpUserDeleteQueryParams },
       params: FetchParams = {}
     ) => {
       return this.request<void>({
@@ -8232,10 +8167,7 @@ export class Api extends HttpClient {
       {
         query,
         body,
-      }: {
-        query: SamlIdentityProviderCreateQueryParams
-        body: SamlIdentityProviderCreate
-      },
+      }: { query: SamlIdentityProviderCreateQueryParams; body: SamlIdentityProviderCreate },
       params: FetchParams = {}
     ) => {
       return this.request<SamlIdentityProvider>({
@@ -8335,10 +8267,7 @@ export class Api extends HttpClient {
       {
         path,
         query = {},
-      }: {
-        path: IpPoolRangeListPathParams
-        query?: IpPoolRangeListQueryParams
-      },
+      }: { path: IpPoolRangeListPathParams; query?: IpPoolRangeListQueryParams },
       params: FetchParams = {}
     ) => {
       return this.request<IpPoolRangeResultsPage>({
@@ -9242,10 +9171,7 @@ export class Api extends HttpClient {
       {
         query,
         body,
-      }: {
-        query: VpcFirewallRulesUpdateQueryParams
-        body: VpcFirewallRuleUpdateParams
-      },
+      }: { query: VpcFirewallRulesUpdateQueryParams; body: VpcFirewallRuleUpdateParams },
       params: FetchParams = {}
     ) => {
       return this.request<VpcFirewallRules>({
@@ -9292,10 +9218,7 @@ export class Api extends HttpClient {
       {
         path,
         query,
-      }: {
-        path: VpcRouterRouteViewPathParams
-        query: VpcRouterRouteViewQueryParams
-      },
+      }: { path: VpcRouterRouteViewPathParams; query: VpcRouterRouteViewQueryParams },
       params: FetchParams = {}
     ) => {
       return this.request<RouterRoute>({
@@ -9335,10 +9258,7 @@ export class Api extends HttpClient {
       {
         path,
         query = {},
-      }: {
-        path: VpcRouterRouteDeletePathParams
-        query?: VpcRouterRouteDeleteQueryParams
-      },
+      }: { path: VpcRouterRouteDeletePathParams; query?: VpcRouterRouteDeleteQueryParams },
       params: FetchParams = {}
     ) => {
       return this.request<void>({
@@ -9424,10 +9344,7 @@ export class Api extends HttpClient {
       {
         path,
         query = {},
-      }: {
-        path: VpcRouterDeletePathParams
-        query?: VpcRouterDeleteQueryParams
-      },
+      }: { path: VpcRouterDeletePathParams; query?: VpcRouterDeleteQueryParams },
       params: FetchParams = {}
     ) => {
       return this.request<void>({
@@ -9513,10 +9430,7 @@ export class Api extends HttpClient {
       {
         path,
         query = {},
-      }: {
-        path: VpcSubnetDeletePathParams
-        query?: VpcSubnetDeleteQueryParams
-      },
+      }: { path: VpcSubnetDeletePathParams; query?: VpcSubnetDeleteQueryParams },
       params: FetchParams = {}
     ) => {
       return this.request<void>({
@@ -9594,11 +9508,7 @@ export class Api extends HttpClient {
         path,
         query = {},
         body,
-      }: {
-        path: VpcUpdatePathParams
-        query?: VpcUpdateQueryParams
-        body: VpcUpdate
-      },
+      }: { path: VpcUpdatePathParams; query?: VpcUpdateQueryParams; body: VpcUpdate },
       params: FetchParams = {}
     ) => {
       return this.request<Vpc>({

--- a/app/api/__generated__/validate.ts
+++ b/app/api/__generated__/validate.ts
@@ -141,10 +141,7 @@ export const AddressLotBlockCreate = z.preprocess(
  */
 export const AddressLotBlockResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: AddressLotBlock.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: AddressLotBlock.array(), nextPage: z.string().nullable().optional() })
 )
 
 /**
@@ -173,10 +170,7 @@ export const AddressLotCreateResponse = z.preprocess(
  */
 export const AddressLotResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: AddressLot.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: AddressLot.array(), nextPage: z.string().nullable().optional() })
 )
 
 /**
@@ -255,11 +249,7 @@ export const AffinityGroupMember = z.preprocess(
   processResponseBody,
   z.object({
     type: z.enum(['instance']),
-    value: z.object({
-      id: TypedUuidForInstanceKind,
-      name: Name,
-      runState: InstanceState,
-    }),
+    value: z.object({ id: TypedUuidForInstanceKind, name: Name, runState: InstanceState }),
   })
 )
 
@@ -279,10 +269,7 @@ export const AffinityGroupMemberResultsPage = z.preprocess(
  */
 export const AffinityGroupResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: AffinityGroup.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: AffinityGroup.array(), nextPage: z.string().nullable().optional() })
 )
 
 /**
@@ -397,11 +384,7 @@ export const AntiAffinityGroupMember = z.preprocess(
   processResponseBody,
   z.object({
     type: z.enum(['instance']),
-    value: z.object({
-      id: TypedUuidForInstanceKind,
-      name: Name,
-      runState: InstanceState,
-    }),
+    value: z.object({ id: TypedUuidForInstanceKind, name: Name, runState: InstanceState }),
   })
 )
 
@@ -421,10 +404,7 @@ export const AntiAffinityGroupMemberResultsPage = z.preprocess(
  */
 export const AntiAffinityGroupResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: AntiAffinityGroup.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: AntiAffinityGroup.array(), nextPage: z.string().nullable().optional() })
 )
 
 /**
@@ -590,10 +570,7 @@ export const BgpConfigCreate = z.preprocess(
  */
 export const BgpConfigResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: BgpConfig.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: BgpConfig.array(), nextPage: z.string().nullable().optional() })
 )
 
 /**
@@ -727,19 +704,13 @@ export const BinRangefloat = z.preprocess(
 export const BinRangeint16 = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({
-      end: z.number().min(-32767).max(32767),
-      type: z.enum(['range_to']),
-    }),
+    z.object({ end: z.number().min(-32767).max(32767), type: z.enum(['range_to']) }),
     z.object({
       end: z.number().min(-32767).max(32767),
       start: z.number().min(-32767).max(32767),
       type: z.enum(['range']),
     }),
-    z.object({
-      start: z.number().min(-32767).max(32767),
-      type: z.enum(['range_from']),
-    }),
+    z.object({ start: z.number().min(-32767).max(32767), type: z.enum(['range_from']) }),
   ])
 )
 
@@ -789,19 +760,13 @@ export const BinRangeint64 = z.preprocess(
 export const BinRangeint8 = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({
-      end: z.number().min(-127).max(127),
-      type: z.enum(['range_to']),
-    }),
+    z.object({ end: z.number().min(-127).max(127), type: z.enum(['range_to']) }),
     z.object({
       end: z.number().min(-127).max(127),
       start: z.number().min(-127).max(127),
       type: z.enum(['range']),
     }),
-    z.object({
-      start: z.number().min(-127).max(127),
-      type: z.enum(['range_from']),
-    }),
+    z.object({ start: z.number().min(-127).max(127), type: z.enum(['range_from']) }),
   ])
 )
 
@@ -819,10 +784,7 @@ export const BinRangeuint16 = z.preprocess(
       start: z.number().min(0).max(65535),
       type: z.enum(['range']),
     }),
-    z.object({
-      start: z.number().min(0).max(65535),
-      type: z.enum(['range_from']),
-    }),
+    z.object({ start: z.number().min(0).max(65535), type: z.enum(['range_from']) }),
   ])
 )
 
@@ -834,19 +796,13 @@ export const BinRangeuint16 = z.preprocess(
 export const BinRangeuint32 = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({
-      end: z.number().min(0).max(4294967295),
-      type: z.enum(['range_to']),
-    }),
+    z.object({ end: z.number().min(0).max(4294967295), type: z.enum(['range_to']) }),
     z.object({
       end: z.number().min(0).max(4294967295),
       start: z.number().min(0).max(4294967295),
       type: z.enum(['range']),
     }),
-    z.object({
-      start: z.number().min(0).max(4294967295),
-      type: z.enum(['range_from']),
-    }),
+    z.object({ start: z.number().min(0).max(4294967295), type: z.enum(['range_from']) }),
   ])
 )
 
@@ -859,11 +815,7 @@ export const BinRangeuint64 = z.preprocess(
   processResponseBody,
   z.union([
     z.object({ end: z.number().min(0), type: z.enum(['range_to']) }),
-    z.object({
-      end: z.number().min(0),
-      start: z.number().min(0),
-      type: z.enum(['range']),
-    }),
+    z.object({ end: z.number().min(0), start: z.number().min(0), type: z.enum(['range']) }),
     z.object({ start: z.number().min(0), type: z.enum(['range_from']) }),
   ])
 )
@@ -882,10 +834,7 @@ export const BinRangeuint8 = z.preprocess(
       start: z.number().min(0).max(255),
       type: z.enum(['range']),
     }),
-    z.object({
-      start: z.number().min(0).max(255),
-      type: z.enum(['range_from']),
-    }),
+    z.object({ start: z.number().min(0).max(255), type: z.enum(['range_from']) }),
   ])
 )
 
@@ -1025,10 +974,7 @@ export const CertificateCreate = z.preprocess(
  */
 export const CertificateResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: Certificate.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: Certificate.array(), nextPage: z.string().nullable().optional() })
 )
 
 /**
@@ -1361,10 +1307,7 @@ export const DatumType = z.preprocess(
 
 export const MissingDatum = z.preprocess(
   processResponseBody,
-  z.object({
-    datumType: DatumType,
-    startTime: z.coerce.date().nullable().optional(),
-  })
+  z.object({ datumType: DatumType, startTime: z.coerce.date().nullable().optional() })
 )
 
 /**
@@ -1376,28 +1319,16 @@ export const Datum = z.preprocess(
     z.object({ datum: SafeBoolean, type: z.enum(['bool']) }),
     z.object({ datum: z.number().min(-127).max(127), type: z.enum(['i8']) }),
     z.object({ datum: z.number().min(0).max(255), type: z.enum(['u8']) }),
-    z.object({
-      datum: z.number().min(-32767).max(32767),
-      type: z.enum(['i16']),
-    }),
+    z.object({ datum: z.number().min(-32767).max(32767), type: z.enum(['i16']) }),
     z.object({ datum: z.number().min(0).max(65535), type: z.enum(['u16']) }),
-    z.object({
-      datum: z.number().min(-2147483647).max(2147483647),
-      type: z.enum(['i32']),
-    }),
-    z.object({
-      datum: z.number().min(0).max(4294967295),
-      type: z.enum(['u32']),
-    }),
+    z.object({ datum: z.number().min(-2147483647).max(2147483647), type: z.enum(['i32']) }),
+    z.object({ datum: z.number().min(0).max(4294967295), type: z.enum(['u32']) }),
     z.object({ datum: z.number(), type: z.enum(['i64']) }),
     z.object({ datum: z.number().min(0), type: z.enum(['u64']) }),
     z.object({ datum: z.number(), type: z.enum(['f32']) }),
     z.object({ datum: z.number(), type: z.enum(['f64']) }),
     z.object({ datum: z.string(), type: z.enum(['string']) }),
-    z.object({
-      datum: z.number().min(0).max(255).array(),
-      type: z.enum(['bytes']),
-    }),
+    z.object({ datum: z.number().min(0).max(255).array(), type: z.enum(['bytes']) }),
     z.object({ datum: Cumulativeint64, type: z.enum(['cumulative_i64']) }),
     z.object({ datum: Cumulativeuint64, type: z.enum(['cumulative_u64']) }),
     z.object({ datum: Cumulativefloat, type: z.enum(['cumulative_f32']) }),
@@ -1423,11 +1354,7 @@ export const DerEncodedKeyPair = z.preprocess(
 
 export const DeviceAccessTokenRequest = z.preprocess(
   processResponseBody,
-  z.object({
-    clientId: z.string().uuid(),
-    deviceCode: z.string(),
-    grantType: z.string(),
-  })
+  z.object({ clientId: z.string().uuid(), deviceCode: z.string(), grantType: z.string() })
 )
 
 export const DeviceAuthRequest = z.preprocess(
@@ -1505,12 +1432,7 @@ export const DiskSource = z.preprocess(
  */
 export const DiskCreate = z.preprocess(
   processResponseBody,
-  z.object({
-    description: z.string(),
-    diskSource: DiskSource,
-    name: Name,
-    size: ByteCount,
-  })
+  z.object({ description: z.string(), diskSource: DiskSource, name: Name, size: ByteCount })
 )
 
 export const DiskPath = z.preprocess(processResponseBody, z.object({ disk: NameOrId }))
@@ -1576,11 +1498,7 @@ export const EphemeralIpCreate = z.preprocess(
  */
 export const Error = z.preprocess(
   processResponseBody,
-  z.object({
-    errorCode: z.string().optional(),
-    message: z.string(),
-    requestId: z.string(),
-  })
+  z.object({ errorCode: z.string().optional(), message: z.string(), requestId: z.string() })
 )
 
 export const ExternalIp = z.preprocess(
@@ -1608,10 +1526,7 @@ export const ExternalIp = z.preprocess(
 export const ExternalIpCreate = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({
-      pool: NameOrId.nullable().optional(),
-      type: z.enum(['ephemeral']),
-    }),
+    z.object({ pool: NameOrId.nullable().optional(), type: z.enum(['ephemeral']) }),
     z.object({ floatingIp: NameOrId, type: z.enum(['floating']) }),
   ])
 )
@@ -1621,10 +1536,7 @@ export const ExternalIpCreate = z.preprocess(
  */
 export const ExternalIpResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: ExternalIp.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: ExternalIp.array(), nextPage: z.string().nullable().optional() })
 )
 
 /**
@@ -1675,19 +1587,10 @@ export const FieldValue = z.preprocess(
     z.object({ type: z.enum(['string']), value: z.string() }),
     z.object({ type: z.enum(['i8']), value: z.number().min(-127).max(127) }),
     z.object({ type: z.enum(['u8']), value: z.number().min(0).max(255) }),
-    z.object({
-      type: z.enum(['i16']),
-      value: z.number().min(-32767).max(32767),
-    }),
+    z.object({ type: z.enum(['i16']), value: z.number().min(-32767).max(32767) }),
     z.object({ type: z.enum(['u16']), value: z.number().min(0).max(65535) }),
-    z.object({
-      type: z.enum(['i32']),
-      value: z.number().min(-2147483647).max(2147483647),
-    }),
-    z.object({
-      type: z.enum(['u32']),
-      value: z.number().min(0).max(4294967295),
-    }),
+    z.object({ type: z.enum(['i32']), value: z.number().min(-2147483647).max(2147483647) }),
+    z.object({ type: z.enum(['u32']), value: z.number().min(0).max(4294967295) }),
     z.object({ type: z.enum(['i64']), value: z.number() }),
     z.object({ type: z.enum(['u64']), value: z.number().min(0) }),
     z.object({ type: z.enum(['ip_addr']), value: z.string().ip() }),
@@ -1790,10 +1693,7 @@ export const FloatingIpCreate = z.preprocess(
  */
 export const FloatingIpResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: FloatingIp.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: FloatingIp.array(), nextPage: z.string().nullable().optional() })
 )
 
 /**
@@ -1812,11 +1712,7 @@ export const FloatingIpUpdate = z.preprocess(
  */
 export const Group = z.preprocess(
   processResponseBody,
-  z.object({
-    displayName: z.string(),
-    id: z.string().uuid(),
-    siloId: z.string().uuid(),
-  })
+  z.object({ displayName: z.string(), id: z.string().uuid(), siloId: z.string().uuid() })
 )
 
 /**
@@ -1824,10 +1720,7 @@ export const Group = z.preprocess(
  */
 export const GroupResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: Group.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: Group.array(), nextPage: z.string().nullable().optional() })
 )
 
 /**
@@ -1866,10 +1759,7 @@ export const IdentityProvider = z.preprocess(
  */
 export const IdentityProviderResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: IdentityProvider.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: IdentityProvider.array(), nextPage: z.string().nullable().optional() })
 )
 
 export const IdpMetadataSource = z.preprocess(
@@ -1929,10 +1819,7 @@ export const ImageCreate = z.preprocess(
  */
 export const ImageResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: Image.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: Image.array(), nextPage: z.string().nullable().optional() })
 )
 
 /**
@@ -2021,10 +1908,7 @@ export const InstanceNetworkInterfaceCreate = z.preprocess(
 export const InstanceNetworkInterfaceAttachment = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({
-      params: InstanceNetworkInterfaceCreate.array(),
-      type: z.enum(['create']),
-    }),
+    z.object({ params: InstanceNetworkInterfaceCreate.array(), type: z.enum(['create']) }),
     z.object({ type: z.enum(['default']) }),
     z.object({ type: z.enum(['none']) }),
   ])
@@ -2121,10 +2005,7 @@ export const InstanceNetworkInterfaceUpdate = z.preprocess(
  */
 export const InstanceResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: Instance.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: Instance.array(), nextPage: z.string().nullable().optional() })
 )
 
 /**
@@ -2132,10 +2013,7 @@ export const InstanceResultsPage = z.preprocess(
  */
 export const InstanceSerialConsoleData = z.preprocess(
   processResponseBody,
-  z.object({
-    data: z.number().min(0).max(255).array(),
-    lastByteOffset: z.number().min(0),
-  })
+  z.object({ data: z.number().min(0).max(255).array(), lastByteOffset: z.number().min(0) })
 )
 
 /**
@@ -2249,10 +2127,7 @@ export const InternetGatewayIpPoolResultsPage = z.preprocess(
  */
 export const InternetGatewayResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: InternetGateway.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: InternetGateway.array(), nextPage: z.string().nullable().optional() })
 )
 
 /**
@@ -2325,10 +2200,7 @@ export const IpPoolRange = z.preprocess(
  */
 export const IpPoolRangeResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: IpPoolRange.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: IpPoolRange.array(), nextPage: z.string().nullable().optional() })
 )
 
 /**
@@ -2336,10 +2208,7 @@ export const IpPoolRangeResultsPage = z.preprocess(
  */
 export const IpPoolResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: IpPool.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: IpPool.array(), nextPage: z.string().nullable().optional() })
 )
 
 /**
@@ -2359,10 +2228,7 @@ export const IpPoolSiloLink = z.preprocess(
  */
 export const IpPoolSiloLinkResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: IpPoolSiloLink.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: IpPoolSiloLink.array(), nextPage: z.string().nullable().optional() })
 )
 
 export const IpPoolSiloUpdate = z.preprocess(
@@ -2521,10 +2387,7 @@ export const LldpNeighbor = z.preprocess(
  */
 export const LldpNeighborResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: LldpNeighbor.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: LldpNeighbor.array(), nextPage: z.string().nullable().optional() })
 )
 
 /**
@@ -2561,10 +2424,7 @@ export const LoopbackAddressCreate = z.preprocess(
  */
 export const LoopbackAddressResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: LoopbackAddress.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: LoopbackAddress.array(), nextPage: z.string().nullable().optional() })
 )
 
 /**
@@ -2580,10 +2440,7 @@ export const Measurement = z.preprocess(
  */
 export const MeasurementResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: Measurement.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: Measurement.array(), nextPage: z.string().nullable().optional() })
 )
 
 /**
@@ -2638,22 +2495,10 @@ export const NetworkInterface = z.preprocess(
 export const ValueArray = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({
-      type: z.enum(['integer']),
-      values: z.number().nullable().array(),
-    }),
-    z.object({
-      type: z.enum(['double']),
-      values: z.number().nullable().array(),
-    }),
-    z.object({
-      type: z.enum(['boolean']),
-      values: SafeBoolean.nullable().array(),
-    }),
-    z.object({
-      type: z.enum(['string']),
-      values: z.string().nullable().array(),
-    }),
+    z.object({ type: z.enum(['integer']), values: z.number().nullable().array() }),
+    z.object({ type: z.enum(['double']), values: z.number().nullable().array() }),
+    z.object({ type: z.enum(['boolean']), values: SafeBoolean.nullable().array() }),
+    z.object({ type: z.enum(['string']), values: z.string().nullable().array() }),
     z.object({
       type: z.enum(['integer_distribution']),
       values: Distributionint64.nullable().array(),
@@ -2702,10 +2547,7 @@ export const Timeseries = z.preprocess(
  */
 export const Table = z.preprocess(
   processResponseBody,
-  z.object({
-    name: z.string(),
-    timeseries: z.record(z.string().min(1), Timeseries),
-  })
+  z.object({ name: z.string(), timeseries: z.record(z.string().min(1), Timeseries) })
 )
 
 /**
@@ -2773,10 +2615,7 @@ export const PhysicalDisk = z.preprocess(
  */
 export const PhysicalDiskResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: PhysicalDisk.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: PhysicalDisk.array(), nextPage: z.string().nullable().optional() })
 )
 
 export const PingStatus = z.preprocess(processResponseBody, z.enum(['ok']))
@@ -2842,10 +2681,7 @@ export const ProbeInfo = z.preprocess(
  */
 export const ProbeInfoResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: ProbeInfo.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: ProbeInfo.array(), nextPage: z.string().nullable().optional() })
 )
 
 /**
@@ -2875,10 +2711,7 @@ export const ProjectCreate = z.preprocess(
  */
 export const ProjectResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: Project.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: Project.array(), nextPage: z.string().nullable().optional() })
 )
 
 export const ProjectRole = z.preprocess(
@@ -3067,10 +2900,7 @@ export const RouterRouteCreate = z.preprocess(
  */
 export const RouterRouteResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: RouterRoute.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: RouterRoute.array(), nextPage: z.string().nullable().optional() })
 )
 
 /**
@@ -3214,10 +3044,7 @@ export const SiloIpPool = z.preprocess(
  */
 export const SiloIpPoolResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: SiloIpPool.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: SiloIpPool.array(), nextPage: z.string().nullable().optional() })
 )
 
 /**
@@ -3238,10 +3065,7 @@ export const SiloQuotas = z.preprocess(
  */
 export const SiloQuotasResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: SiloQuotas.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: SiloQuotas.array(), nextPage: z.string().nullable().optional() })
 )
 
 /**
@@ -3319,10 +3143,7 @@ export const SiloUtilization = z.preprocess(
  */
 export const SiloUtilizationResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: SiloUtilization.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: SiloUtilization.array(), nextPage: z.string().nullable().optional() })
 )
 
 /**
@@ -3341,10 +3162,7 @@ export const SledProvisionPolicy = z.preprocess(
 export const SledPolicy = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({
-      kind: z.enum(['in_service']),
-      provisionPolicy: SledProvisionPolicy,
-    }),
+    z.object({ kind: z.enum(['in_service']), provisionPolicy: SledProvisionPolicy }),
     z.object({ kind: z.enum(['expunged']) }),
   ])
 )
@@ -3405,10 +3223,7 @@ export const SledInstance = z.preprocess(
  */
 export const SledInstanceResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: SledInstance.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: SledInstance.array(), nextPage: z.string().nullable().optional() })
 )
 
 /**
@@ -3471,10 +3286,7 @@ export const SnapshotCreate = z.preprocess(
  */
 export const SnapshotResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: Snapshot.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: Snapshot.array(), nextPage: z.string().nullable().optional() })
 )
 
 /**
@@ -3506,10 +3318,7 @@ export const SshKeyCreate = z.preprocess(
  */
 export const SshKeyResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: SshKey.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: SshKey.array(), nextPage: z.string().nullable().optional() })
 )
 
 export const TypedUuidForSupportBundleKind = z.preprocess(
@@ -3538,10 +3347,7 @@ export const SupportBundleInfo = z.preprocess(
  */
 export const SupportBundleInfoResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: SupportBundleInfo.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: SupportBundleInfo.array(), nextPage: z.string().nullable().optional() })
 )
 
 /**
@@ -3651,10 +3457,7 @@ export const SwitchPortGeometry2 = z.preprocess(
  */
 export const SwitchPortConfig = z.preprocess(
   processResponseBody,
-  z.object({
-    geometry: SwitchPortGeometry2,
-    portSettingsId: z.string().uuid(),
-  })
+  z.object({ geometry: SwitchPortGeometry2, portSettingsId: z.string().uuid() })
 )
 
 /**
@@ -3695,10 +3498,7 @@ export const SwitchPortLinkConfig = z.preprocess(
  */
 export const SwitchPortResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: SwitchPort.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: SwitchPort.array(), nextPage: z.string().nullable().optional() })
 )
 
 /**
@@ -3753,10 +3553,7 @@ export const SwitchPortSettingsCreate = z.preprocess(
  */
 export const SwitchPortSettingsGroups = z.preprocess(
   processResponseBody,
-  z.object({
-    portSettingsGroupId: z.string().uuid(),
-    portSettingsId: z.string().uuid(),
-  })
+  z.object({ portSettingsGroupId: z.string().uuid(), portSettingsId: z.string().uuid() })
 )
 
 /**
@@ -3775,10 +3572,7 @@ export const SwitchPortSettingsResultsPage = z.preprocess(
  */
 export const SwitchVlanInterfaceConfig = z.preprocess(
   processResponseBody,
-  z.object({
-    interfaceConfigId: z.string().uuid(),
-    vlanId: z.number().min(0).max(65535),
-  })
+  z.object({ interfaceConfigId: z.string().uuid(), vlanId: z.number().min(0).max(65535) })
 )
 
 /**
@@ -3806,10 +3600,7 @@ export const SwitchPortSettingsView = z.preprocess(
  */
 export const SwitchResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: Switch.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: Switch.array(), nextPage: z.string().nullable().optional() })
 )
 
 /**
@@ -3915,10 +3706,7 @@ export const TimeseriesSchema = z.preprocess(
  */
 export const TimeseriesSchemaResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: TimeseriesSchema.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: TimeseriesSchema.array(), nextPage: z.string().nullable().optional() })
 )
 
 /**
@@ -3946,10 +3734,7 @@ export const UninitializedSledId = z.preprocess(
  */
 export const UninitializedSledResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: UninitializedSled.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: UninitializedSled.array(), nextPage: z.string().nullable().optional() })
 )
 
 /**
@@ -3957,11 +3742,7 @@ export const UninitializedSledResultsPage = z.preprocess(
  */
 export const User = z.preprocess(
   processResponseBody,
-  z.object({
-    displayName: z.string(),
-    id: z.string().uuid(),
-    siloId: z.string().uuid(),
-  })
+  z.object({ displayName: z.string(), id: z.string().uuid(), siloId: z.string().uuid() })
 )
 
 /**
@@ -3985,10 +3766,7 @@ export const UserBuiltin = z.preprocess(
  */
 export const UserBuiltinResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: UserBuiltin.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: UserBuiltin.array(), nextPage: z.string().nullable().optional() })
 )
 
 /**
@@ -4047,10 +3825,7 @@ export const UsernamePasswordCredentials = z.preprocess(
  */
 export const Utilization = z.preprocess(
   processResponseBody,
-  z.object({
-    capacity: VirtualResourceCounts,
-    provisioned: VirtualResourceCounts,
-  })
+  z.object({ capacity: VirtualResourceCounts, provisioned: VirtualResourceCounts })
 )
 
 /**
@@ -4240,10 +4015,7 @@ export const VpcRouterCreate = z.preprocess(
  */
 export const VpcRouterResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: VpcRouter.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: VpcRouter.array(), nextPage: z.string().nullable().optional() })
 )
 
 /**
@@ -4294,10 +4066,7 @@ export const VpcSubnetCreate = z.preprocess(
  */
 export const VpcSubnetResultsPage = z.preprocess(
   processResponseBody,
-  z.object({
-    items: VpcSubnet.array(),
-    nextPage: z.string().nullable().optional(),
-  })
+  z.object({ items: VpcSubnet.array(), nextPage: z.string().nullable().optional() })
 )
 
 /**

--- a/app/api/__generated__/validate.ts
+++ b/app/api/__generated__/validate.ts
@@ -84,7 +84,7 @@ export const Address = z.preprocess(
   z.object({
     address: IpNet,
     addressLot: NameOrId,
-    vlanId: z.number().min(0).max(65535).optional(),
+    vlanId: z.number().min(0).max(65535).nullable().optional(),
   })
 )
 
@@ -141,7 +141,10 @@ export const AddressLotBlockCreate = z.preprocess(
  */
 export const AddressLotBlockResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: AddressLotBlock.array(), nextPage: z.string().optional() })
+  z.object({
+    items: AddressLotBlock.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -170,7 +173,10 @@ export const AddressLotCreateResponse = z.preprocess(
  */
 export const AddressLotResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: AddressLot.array(), nextPage: z.string().optional() })
+  z.object({
+    items: AddressLot.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -249,7 +255,11 @@ export const AffinityGroupMember = z.preprocess(
   processResponseBody,
   z.object({
     type: z.enum(['instance']),
-    value: z.object({ id: TypedUuidForInstanceKind, name: Name, runState: InstanceState }),
+    value: z.object({
+      id: TypedUuidForInstanceKind,
+      name: Name,
+      runState: InstanceState,
+    }),
   })
 )
 
@@ -258,7 +268,10 @@ export const AffinityGroupMember = z.preprocess(
  */
 export const AffinityGroupMemberResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: AffinityGroupMember.array(), nextPage: z.string().optional() })
+  z.object({
+    items: AffinityGroupMember.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -266,7 +279,10 @@ export const AffinityGroupMemberResultsPage = z.preprocess(
  */
 export const AffinityGroupResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: AffinityGroup.array(), nextPage: z.string().optional() })
+  z.object({
+    items: AffinityGroup.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -274,7 +290,10 @@ export const AffinityGroupResultsPage = z.preprocess(
  */
 export const AffinityGroupUpdate = z.preprocess(
   processResponseBody,
-  z.object({ description: z.string().optional(), name: Name.optional() })
+  z.object({
+    description: z.string().nullable().optional(),
+    name: Name.nullable().optional(),
+  })
 )
 
 export const BgpMessageHistory = z.preprocess(processResponseBody, z.record(z.unknown()))
@@ -378,7 +397,11 @@ export const AntiAffinityGroupMember = z.preprocess(
   processResponseBody,
   z.object({
     type: z.enum(['instance']),
-    value: z.object({ id: TypedUuidForInstanceKind, name: Name, runState: InstanceState }),
+    value: z.object({
+      id: TypedUuidForInstanceKind,
+      name: Name,
+      runState: InstanceState,
+    }),
   })
 )
 
@@ -387,7 +410,10 @@ export const AntiAffinityGroupMember = z.preprocess(
  */
 export const AntiAffinityGroupMemberResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: AntiAffinityGroupMember.array(), nextPage: z.string().optional() })
+  z.object({
+    items: AntiAffinityGroupMember.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -395,7 +421,10 @@ export const AntiAffinityGroupMemberResultsPage = z.preprocess(
  */
 export const AntiAffinityGroupResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: AntiAffinityGroup.array(), nextPage: z.string().optional() })
+  z.object({
+    items: AntiAffinityGroup.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -403,7 +432,10 @@ export const AntiAffinityGroupResultsPage = z.preprocess(
  */
 export const AntiAffinityGroupUpdate = z.preprocess(
   processResponseBody,
-  z.object({ description: z.string().optional(), name: Name.optional() })
+  z.object({
+    description: z.string().nullable().optional(),
+    name: Name.nullable().optional(),
+  })
 )
 
 /**
@@ -451,7 +483,7 @@ export const BfdSessionEnable = z.preprocess(
   processResponseBody,
   z.object({
     detectionThreshold: z.number().min(0).max(255),
-    local: z.string().ip().optional(),
+    local: z.string().ip().nullable().optional(),
     mode: BfdMode,
     remote: z.string().ip(),
     requiredRx: z.number().min(0),
@@ -468,7 +500,7 @@ export const BfdStatus = z.preprocess(
   processResponseBody,
   z.object({
     detectionThreshold: z.number().min(0).max(255),
-    local: z.string().ip().optional(),
+    local: z.string().ip().nullable().optional(),
     mode: BfdMode,
     peer: z.string().ip(),
     requiredRx: z.number().min(0),
@@ -535,7 +567,7 @@ export const BgpConfig = z.preprocess(
     name: Name,
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
-    vrf: z.string().optional(),
+    vrf: z.string().nullable().optional(),
   })
 )
 
@@ -549,7 +581,7 @@ export const BgpConfigCreate = z.preprocess(
     bgpAnnounceSetId: NameOrId,
     description: z.string(),
     name: Name,
-    vrf: Name.optional(),
+    vrf: Name.nullable().optional(),
   })
 )
 
@@ -558,7 +590,10 @@ export const BgpConfigCreate = z.preprocess(
  */
 export const BgpConfigResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: BgpConfig.array(), nextPage: z.string().optional() })
+  z.object({
+    items: BgpConfig.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -611,12 +646,12 @@ export const BgpPeer = z.preprocess(
     idleHoldTime: z.number().min(0).max(4294967295),
     interfaceName: z.string(),
     keepalive: z.number().min(0).max(4294967295),
-    localPref: z.number().min(0).max(4294967295).optional(),
-    md5AuthKey: z.string().optional(),
-    minTtl: z.number().min(0).max(255).optional(),
-    multiExitDiscriminator: z.number().min(0).max(4294967295).optional(),
-    remoteAsn: z.number().min(0).max(4294967295).optional(),
-    vlanId: z.number().min(0).max(65535).optional(),
+    localPref: z.number().min(0).max(4294967295).nullable().optional(),
+    md5AuthKey: z.string().nullable().optional(),
+    minTtl: z.number().min(0).max(255).nullable().optional(),
+    multiExitDiscriminator: z.number().min(0).max(4294967295).nullable().optional(),
+    remoteAsn: z.number().min(0).max(4294967295).nullable().optional(),
+    vlanId: z.number().min(0).max(65535).nullable().optional(),
   })
 )
 
@@ -692,13 +727,19 @@ export const BinRangefloat = z.preprocess(
 export const BinRangeint16 = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ end: z.number().min(-32767).max(32767), type: z.enum(['range_to']) }),
+    z.object({
+      end: z.number().min(-32767).max(32767),
+      type: z.enum(['range_to']),
+    }),
     z.object({
       end: z.number().min(-32767).max(32767),
       start: z.number().min(-32767).max(32767),
       type: z.enum(['range']),
     }),
-    z.object({ start: z.number().min(-32767).max(32767), type: z.enum(['range_from']) }),
+    z.object({
+      start: z.number().min(-32767).max(32767),
+      type: z.enum(['range_from']),
+    }),
   ])
 )
 
@@ -748,13 +789,19 @@ export const BinRangeint64 = z.preprocess(
 export const BinRangeint8 = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ end: z.number().min(-127).max(127), type: z.enum(['range_to']) }),
+    z.object({
+      end: z.number().min(-127).max(127),
+      type: z.enum(['range_to']),
+    }),
     z.object({
       end: z.number().min(-127).max(127),
       start: z.number().min(-127).max(127),
       type: z.enum(['range']),
     }),
-    z.object({ start: z.number().min(-127).max(127), type: z.enum(['range_from']) }),
+    z.object({
+      start: z.number().min(-127).max(127),
+      type: z.enum(['range_from']),
+    }),
   ])
 )
 
@@ -772,7 +819,10 @@ export const BinRangeuint16 = z.preprocess(
       start: z.number().min(0).max(65535),
       type: z.enum(['range']),
     }),
-    z.object({ start: z.number().min(0).max(65535), type: z.enum(['range_from']) }),
+    z.object({
+      start: z.number().min(0).max(65535),
+      type: z.enum(['range_from']),
+    }),
   ])
 )
 
@@ -784,13 +834,19 @@ export const BinRangeuint16 = z.preprocess(
 export const BinRangeuint32 = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ end: z.number().min(0).max(4294967295), type: z.enum(['range_to']) }),
+    z.object({
+      end: z.number().min(0).max(4294967295),
+      type: z.enum(['range_to']),
+    }),
     z.object({
       end: z.number().min(0).max(4294967295),
       start: z.number().min(0).max(4294967295),
       type: z.enum(['range']),
     }),
-    z.object({ start: z.number().min(0).max(4294967295), type: z.enum(['range_from']) }),
+    z.object({
+      start: z.number().min(0).max(4294967295),
+      type: z.enum(['range_from']),
+    }),
   ])
 )
 
@@ -803,7 +859,11 @@ export const BinRangeuint64 = z.preprocess(
   processResponseBody,
   z.union([
     z.object({ end: z.number().min(0), type: z.enum(['range_to']) }),
-    z.object({ end: z.number().min(0), start: z.number().min(0), type: z.enum(['range']) }),
+    z.object({
+      end: z.number().min(0),
+      start: z.number().min(0),
+      type: z.enum(['range']),
+    }),
     z.object({ start: z.number().min(0), type: z.enum(['range_from']) }),
   ])
 )
@@ -822,7 +882,10 @@ export const BinRangeuint8 = z.preprocess(
       start: z.number().min(0).max(255),
       type: z.enum(['range']),
     }),
-    z.object({ start: z.number().min(0).max(255), type: z.enum(['range_from']) }),
+    z.object({
+      start: z.number().min(0).max(255),
+      type: z.enum(['range_from']),
+    }),
   ])
 )
 
@@ -962,7 +1025,10 @@ export const CertificateCreate = z.preprocess(
  */
 export const CertificateResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: Certificate.array(), nextPage: z.string().optional() })
+  z.object({
+    items: Certificate.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -1295,7 +1361,10 @@ export const DatumType = z.preprocess(
 
 export const MissingDatum = z.preprocess(
   processResponseBody,
-  z.object({ datumType: DatumType, startTime: z.coerce.date().optional() })
+  z.object({
+    datumType: DatumType,
+    startTime: z.coerce.date().nullable().optional(),
+  })
 )
 
 /**
@@ -1307,16 +1376,28 @@ export const Datum = z.preprocess(
     z.object({ datum: SafeBoolean, type: z.enum(['bool']) }),
     z.object({ datum: z.number().min(-127).max(127), type: z.enum(['i8']) }),
     z.object({ datum: z.number().min(0).max(255), type: z.enum(['u8']) }),
-    z.object({ datum: z.number().min(-32767).max(32767), type: z.enum(['i16']) }),
+    z.object({
+      datum: z.number().min(-32767).max(32767),
+      type: z.enum(['i16']),
+    }),
     z.object({ datum: z.number().min(0).max(65535), type: z.enum(['u16']) }),
-    z.object({ datum: z.number().min(-2147483647).max(2147483647), type: z.enum(['i32']) }),
-    z.object({ datum: z.number().min(0).max(4294967295), type: z.enum(['u32']) }),
+    z.object({
+      datum: z.number().min(-2147483647).max(2147483647),
+      type: z.enum(['i32']),
+    }),
+    z.object({
+      datum: z.number().min(0).max(4294967295),
+      type: z.enum(['u32']),
+    }),
     z.object({ datum: z.number(), type: z.enum(['i64']) }),
     z.object({ datum: z.number().min(0), type: z.enum(['u64']) }),
     z.object({ datum: z.number(), type: z.enum(['f32']) }),
     z.object({ datum: z.number(), type: z.enum(['f64']) }),
     z.object({ datum: z.string(), type: z.enum(['string']) }),
-    z.object({ datum: z.number().min(0).max(255).array(), type: z.enum(['bytes']) }),
+    z.object({
+      datum: z.number().min(0).max(255).array(),
+      type: z.enum(['bytes']),
+    }),
     z.object({ datum: Cumulativeint64, type: z.enum(['cumulative_i64']) }),
     z.object({ datum: Cumulativeuint64, type: z.enum(['cumulative_u64']) }),
     z.object({ datum: Cumulativefloat, type: z.enum(['cumulative_f32']) }),
@@ -1342,7 +1423,11 @@ export const DerEncodedKeyPair = z.preprocess(
 
 export const DeviceAccessTokenRequest = z.preprocess(
   processResponseBody,
-  z.object({ clientId: z.string().uuid(), deviceCode: z.string(), grantType: z.string() })
+  z.object({
+    clientId: z.string().uuid(),
+    deviceCode: z.string(),
+    grantType: z.string(),
+  })
 )
 
 export const DeviceAuthRequest = z.preprocess(
@@ -1391,11 +1476,11 @@ export const Disk = z.preprocess(
     description: z.string(),
     devicePath: z.string(),
     id: z.string().uuid(),
-    imageId: z.string().uuid().optional(),
+    imageId: z.string().uuid().nullable().optional(),
     name: Name,
     projectId: z.string().uuid(),
     size: ByteCount,
-    snapshotId: z.string().uuid().optional(),
+    snapshotId: z.string().uuid().nullable().optional(),
     state: DiskState,
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
@@ -1420,7 +1505,12 @@ export const DiskSource = z.preprocess(
  */
 export const DiskCreate = z.preprocess(
   processResponseBody,
-  z.object({ description: z.string(), diskSource: DiskSource, name: Name, size: ByteCount })
+  z.object({
+    description: z.string(),
+    diskSource: DiskSource,
+    name: Name,
+    size: ByteCount,
+  })
 )
 
 export const DiskPath = z.preprocess(processResponseBody, z.object({ disk: NameOrId }))
@@ -1430,7 +1520,7 @@ export const DiskPath = z.preprocess(processResponseBody, z.object({ disk: NameO
  */
 export const DiskResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: Disk.array(), nextPage: z.string().optional() })
+  z.object({ items: Disk.array(), nextPage: z.string().nullable().optional() })
 )
 
 /**
@@ -1443,11 +1533,11 @@ export const Distributiondouble = z.preprocess(
   z.object({
     bins: z.number().array(),
     counts: z.number().min(0).array(),
-    max: z.number().optional(),
-    min: z.number().optional(),
-    p50: Quantile.optional(),
-    p90: Quantile.optional(),
-    p99: Quantile.optional(),
+    max: z.number().nullable().optional(),
+    min: z.number().nullable().optional(),
+    p50: Quantile.nullable().optional(),
+    p90: Quantile.nullable().optional(),
+    p99: Quantile.nullable().optional(),
     squaredMean: z.number(),
     sumOfSamples: z.number(),
   })
@@ -1463,11 +1553,11 @@ export const Distributionint64 = z.preprocess(
   z.object({
     bins: z.number().array(),
     counts: z.number().min(0).array(),
-    max: z.number().optional(),
-    min: z.number().optional(),
-    p50: Quantile.optional(),
-    p90: Quantile.optional(),
-    p99: Quantile.optional(),
+    max: z.number().nullable().optional(),
+    min: z.number().nullable().optional(),
+    p50: Quantile.nullable().optional(),
+    p90: Quantile.nullable().optional(),
+    p99: Quantile.nullable().optional(),
     squaredMean: z.number(),
     sumOfSamples: z.number(),
   })
@@ -1478,7 +1568,7 @@ export const Distributionint64 = z.preprocess(
  */
 export const EphemeralIpCreate = z.preprocess(
   processResponseBody,
-  z.object({ pool: NameOrId.optional() })
+  z.object({ pool: NameOrId.nullable().optional() })
 )
 
 /**
@@ -1486,7 +1576,11 @@ export const EphemeralIpCreate = z.preprocess(
  */
 export const Error = z.preprocess(
   processResponseBody,
-  z.object({ errorCode: z.string().optional(), message: z.string(), requestId: z.string() })
+  z.object({
+    errorCode: z.string().optional(),
+    message: z.string(),
+    requestId: z.string(),
+  })
 )
 
 export const ExternalIp = z.preprocess(
@@ -1496,7 +1590,7 @@ export const ExternalIp = z.preprocess(
     z.object({
       description: z.string(),
       id: z.string().uuid(),
-      instanceId: z.string().uuid().optional(),
+      instanceId: z.string().uuid().nullable().optional(),
       ip: z.string().ip(),
       ipPoolId: z.string().uuid(),
       kind: z.enum(['floating']),
@@ -1514,7 +1608,10 @@ export const ExternalIp = z.preprocess(
 export const ExternalIpCreate = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ pool: NameOrId.optional(), type: z.enum(['ephemeral']) }),
+    z.object({
+      pool: NameOrId.nullable().optional(),
+      type: z.enum(['ephemeral']),
+    }),
     z.object({ floatingIp: NameOrId, type: z.enum(['floating']) }),
   ])
 )
@@ -1524,7 +1621,10 @@ export const ExternalIpCreate = z.preprocess(
  */
 export const ExternalIpResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: ExternalIp.array(), nextPage: z.string().optional() })
+  z.object({
+    items: ExternalIp.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -1575,10 +1675,19 @@ export const FieldValue = z.preprocess(
     z.object({ type: z.enum(['string']), value: z.string() }),
     z.object({ type: z.enum(['i8']), value: z.number().min(-127).max(127) }),
     z.object({ type: z.enum(['u8']), value: z.number().min(0).max(255) }),
-    z.object({ type: z.enum(['i16']), value: z.number().min(-32767).max(32767) }),
+    z.object({
+      type: z.enum(['i16']),
+      value: z.number().min(-32767).max(32767),
+    }),
     z.object({ type: z.enum(['u16']), value: z.number().min(0).max(65535) }),
-    z.object({ type: z.enum(['i32']), value: z.number().min(-2147483647).max(2147483647) }),
-    z.object({ type: z.enum(['u32']), value: z.number().min(0).max(4294967295) }),
+    z.object({
+      type: z.enum(['i32']),
+      value: z.number().min(-2147483647).max(2147483647),
+    }),
+    z.object({
+      type: z.enum(['u32']),
+      value: z.number().min(0).max(4294967295),
+    }),
     z.object({ type: z.enum(['i64']), value: z.number() }),
     z.object({ type: z.enum(['u64']), value: z.number().min(0) }),
     z.object({ type: z.enum(['ip_addr']), value: z.string().ip() }),
@@ -1592,7 +1701,7 @@ export const FieldValue = z.preprocess(
  */
 export const FinalizeDisk = z.preprocess(
   processResponseBody,
-  z.object({ snapshotName: Name.optional() })
+  z.object({ snapshotName: Name.nullable().optional() })
 )
 
 export const FleetRole = z.preprocess(
@@ -1640,7 +1749,7 @@ export const FloatingIp = z.preprocess(
   z.object({
     description: z.string(),
     id: z.string().uuid(),
-    instanceId: z.string().uuid().optional(),
+    instanceId: z.string().uuid().nullable().optional(),
     ip: z.string().ip(),
     ipPoolId: z.string().uuid(),
     name: Name,
@@ -1670,9 +1779,9 @@ export const FloatingIpCreate = z.preprocess(
   processResponseBody,
   z.object({
     description: z.string(),
-    ip: z.string().ip().optional(),
+    ip: z.string().ip().nullable().optional(),
     name: Name,
-    pool: NameOrId.optional(),
+    pool: NameOrId.nullable().optional(),
   })
 )
 
@@ -1681,7 +1790,10 @@ export const FloatingIpCreate = z.preprocess(
  */
 export const FloatingIpResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: FloatingIp.array(), nextPage: z.string().optional() })
+  z.object({
+    items: FloatingIp.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -1689,7 +1801,10 @@ export const FloatingIpResultsPage = z.preprocess(
  */
 export const FloatingIpUpdate = z.preprocess(
   processResponseBody,
-  z.object({ description: z.string().optional(), name: Name.optional() })
+  z.object({
+    description: z.string().nullable().optional(),
+    name: Name.nullable().optional(),
+  })
 )
 
 /**
@@ -1697,7 +1812,11 @@ export const FloatingIpUpdate = z.preprocess(
  */
 export const Group = z.preprocess(
   processResponseBody,
-  z.object({ displayName: z.string(), id: z.string().uuid(), siloId: z.string().uuid() })
+  z.object({
+    displayName: z.string(),
+    id: z.string().uuid(),
+    siloId: z.string().uuid(),
+  })
 )
 
 /**
@@ -1705,7 +1824,10 @@ export const Group = z.preprocess(
  */
 export const GroupResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: Group.array(), nextPage: z.string().optional() })
+  z.object({
+    items: Group.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -1744,7 +1866,10 @@ export const IdentityProvider = z.preprocess(
  */
 export const IdentityProviderResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: IdentityProvider.array(), nextPage: z.string().optional() })
+  z.object({
+    items: IdentityProvider.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 export const IdpMetadataSource = z.preprocess(
@@ -1765,11 +1890,11 @@ export const Image = z.preprocess(
   z.object({
     blockSize: ByteCount,
     description: z.string(),
-    digest: Digest.optional(),
+    digest: Digest.nullable().optional(),
     id: z.string().uuid(),
     name: Name,
     os: z.string(),
-    projectId: z.string().uuid().optional(),
+    projectId: z.string().uuid().nullable().optional(),
     size: ByteCount,
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
@@ -1804,7 +1929,10 @@ export const ImageCreate = z.preprocess(
  */
 export const ImageResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: Image.array(), nextPage: z.string().optional() })
+  z.object({
+    items: Image.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -1837,10 +1965,10 @@ export const InstanceCpuCount = z.preprocess(
 export const Instance = z.preprocess(
   processResponseBody,
   z.object({
-    autoRestartCooldownExpiration: z.coerce.date().optional(),
+    autoRestartCooldownExpiration: z.coerce.date().nullable().optional(),
     autoRestartEnabled: SafeBoolean,
-    autoRestartPolicy: InstanceAutoRestartPolicy.optional(),
-    bootDiskId: z.string().uuid().optional(),
+    autoRestartPolicy: InstanceAutoRestartPolicy.nullable().optional(),
+    bootDiskId: z.string().uuid().nullable().optional(),
     description: z.string(),
     hostname: z.string(),
     id: z.string().uuid(),
@@ -1850,7 +1978,7 @@ export const Instance = z.preprocess(
     projectId: z.string().uuid(),
     runState: InstanceState,
     timeCreated: z.coerce.date(),
-    timeLastAutoRestarted: z.coerce.date().optional(),
+    timeLastAutoRestarted: z.coerce.date().nullable().optional(),
     timeModified: z.coerce.date(),
     timeRunStateUpdated: z.coerce.date(),
   })
@@ -1880,7 +2008,7 @@ export const InstanceNetworkInterfaceCreate = z.preprocess(
   processResponseBody,
   z.object({
     description: z.string(),
-    ip: z.string().ip().optional(),
+    ip: z.string().ip().nullable().optional(),
     name: Name,
     subnetName: Name,
     vpcName: Name,
@@ -1893,7 +2021,10 @@ export const InstanceNetworkInterfaceCreate = z.preprocess(
 export const InstanceNetworkInterfaceAttachment = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ params: InstanceNetworkInterfaceCreate.array(), type: z.enum(['create']) }),
+    z.object({
+      params: InstanceNetworkInterfaceCreate.array(),
+      type: z.enum(['create']),
+    }),
     z.object({ type: z.enum(['default']) }),
     z.object({ type: z.enum(['none']) }),
   ])
@@ -1906,8 +2037,8 @@ export const InstanceCreate = z.preprocess(
   processResponseBody,
   z.object({
     antiAffinityGroups: NameOrId.array().default([]).optional(),
-    autoRestartPolicy: InstanceAutoRestartPolicy.default(null).optional(),
-    bootDisk: InstanceDiskAttachment.default(null).optional(),
+    autoRestartPolicy: InstanceAutoRestartPolicy.default(null).nullable().optional(),
+    bootDisk: InstanceDiskAttachment.default(null).nullable().optional(),
     description: z.string(),
     disks: InstanceDiskAttachment.array().default([]).optional(),
     externalIps: ExternalIpCreate.array().default([]).optional(),
@@ -1964,7 +2095,10 @@ export const InstanceNetworkInterface = z.preprocess(
  */
 export const InstanceNetworkInterfaceResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: InstanceNetworkInterface.array(), nextPage: z.string().optional() })
+  z.object({
+    items: InstanceNetworkInterface.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -1975,8 +2109,8 @@ export const InstanceNetworkInterfaceResultsPage = z.preprocess(
 export const InstanceNetworkInterfaceUpdate = z.preprocess(
   processResponseBody,
   z.object({
-    description: z.string().optional(),
-    name: Name.optional(),
+    description: z.string().nullable().optional(),
+    name: Name.nullable().optional(),
     primary: SafeBoolean.default(false).optional(),
     transitIps: IpNet.array().default([]).optional(),
   })
@@ -1987,7 +2121,10 @@ export const InstanceNetworkInterfaceUpdate = z.preprocess(
  */
 export const InstanceResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: Instance.array(), nextPage: z.string().optional() })
+  z.object({
+    items: Instance.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -1995,7 +2132,10 @@ export const InstanceResultsPage = z.preprocess(
  */
 export const InstanceSerialConsoleData = z.preprocess(
   processResponseBody,
-  z.object({ data: z.number().min(0).max(255).array(), lastByteOffset: z.number().min(0) })
+  z.object({
+    data: z.number().min(0).max(255).array(),
+    lastByteOffset: z.number().min(0),
+  })
 )
 
 /**
@@ -2004,8 +2144,8 @@ export const InstanceSerialConsoleData = z.preprocess(
 export const InstanceUpdate = z.preprocess(
   processResponseBody,
   z.object({
-    autoRestartPolicy: InstanceAutoRestartPolicy.optional(),
-    bootDisk: NameOrId.optional(),
+    autoRestartPolicy: InstanceAutoRestartPolicy.nullable().optional(),
+    bootDisk: NameOrId.nullable().optional(),
     memory: ByteCount,
     ncpus: InstanceCpuCount,
   })
@@ -2063,7 +2203,10 @@ export const InternetGatewayIpAddressCreate = z.preprocess(
  */
 export const InternetGatewayIpAddressResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: InternetGatewayIpAddress.array(), nextPage: z.string().optional() })
+  z.object({
+    items: InternetGatewayIpAddress.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -2095,7 +2238,10 @@ export const InternetGatewayIpPoolCreate = z.preprocess(
  */
 export const InternetGatewayIpPoolResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: InternetGatewayIpPool.array(), nextPage: z.string().optional() })
+  z.object({
+    items: InternetGatewayIpPool.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -2103,7 +2249,10 @@ export const InternetGatewayIpPoolResultsPage = z.preprocess(
  */
 export const InternetGatewayResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: InternetGateway.array(), nextPage: z.string().optional() })
+  z.object({
+    items: InternetGateway.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -2176,7 +2325,10 @@ export const IpPoolRange = z.preprocess(
  */
 export const IpPoolRangeResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: IpPoolRange.array(), nextPage: z.string().optional() })
+  z.object({
+    items: IpPoolRange.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -2184,7 +2336,10 @@ export const IpPoolRangeResultsPage = z.preprocess(
  */
 export const IpPoolResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: IpPool.array(), nextPage: z.string().optional() })
+  z.object({
+    items: IpPool.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -2204,7 +2359,10 @@ export const IpPoolSiloLink = z.preprocess(
  */
 export const IpPoolSiloLinkResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: IpPoolSiloLink.array(), nextPage: z.string().optional() })
+  z.object({
+    items: IpPoolSiloLink.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 export const IpPoolSiloUpdate = z.preprocess(
@@ -2217,7 +2375,10 @@ export const IpPoolSiloUpdate = z.preprocess(
  */
 export const IpPoolUpdate = z.preprocess(
   processResponseBody,
-  z.object({ description: z.string().optional(), name: Name.optional() })
+  z.object({
+    description: z.string().nullable().optional(),
+    name: Name.nullable().optional(),
+  })
 )
 
 export const Ipv4Utilization = z.preprocess(
@@ -2263,13 +2424,13 @@ export const LinkFec = z.preprocess(processResponseBody, z.enum(['firecode', 'no
 export const LldpLinkConfigCreate = z.preprocess(
   processResponseBody,
   z.object({
-    chassisId: z.string().optional(),
+    chassisId: z.string().nullable().optional(),
     enabled: SafeBoolean,
-    linkDescription: z.string().optional(),
-    linkName: z.string().optional(),
-    managementIp: z.string().ip().optional(),
-    systemDescription: z.string().optional(),
-    systemName: z.string().optional(),
+    linkDescription: z.string().nullable().optional(),
+    linkName: z.string().nullable().optional(),
+    managementIp: z.string().ip().nullable().optional(),
+    systemDescription: z.string().nullable().optional(),
+    systemName: z.string().nullable().optional(),
   })
 )
 
@@ -2297,11 +2458,11 @@ export const LinkSpeed = z.preprocess(
 export const TxEqConfig = z.preprocess(
   processResponseBody,
   z.object({
-    main: z.number().min(-2147483647).max(2147483647).optional(),
-    post1: z.number().min(-2147483647).max(2147483647).optional(),
-    post2: z.number().min(-2147483647).max(2147483647).optional(),
-    pre1: z.number().min(-2147483647).max(2147483647).optional(),
-    pre2: z.number().min(-2147483647).max(2147483647).optional(),
+    main: z.number().min(-2147483647).max(2147483647).nullable().optional(),
+    post1: z.number().min(-2147483647).max(2147483647).nullable().optional(),
+    post2: z.number().min(-2147483647).max(2147483647).nullable().optional(),
+    pre1: z.number().min(-2147483647).max(2147483647).nullable().optional(),
+    pre2: z.number().min(-2147483647).max(2147483647).nullable().optional(),
   })
 )
 
@@ -2312,11 +2473,11 @@ export const LinkConfigCreate = z.preprocess(
   processResponseBody,
   z.object({
     autoneg: SafeBoolean,
-    fec: LinkFec.optional(),
+    fec: LinkFec.nullable().optional(),
     lldp: LldpLinkConfigCreate,
     mtu: z.number().min(0).max(65535),
     speed: LinkSpeed,
-    txEq: TxEqConfig.optional(),
+    txEq: TxEqConfig.nullable().optional(),
   })
 )
 
@@ -2326,14 +2487,14 @@ export const LinkConfigCreate = z.preprocess(
 export const LldpLinkConfig = z.preprocess(
   processResponseBody,
   z.object({
-    chassisId: z.string().optional(),
+    chassisId: z.string().nullable().optional(),
     enabled: SafeBoolean,
     id: z.string().uuid(),
-    linkDescription: z.string().optional(),
-    linkName: z.string().optional(),
-    managementIp: IpNet.optional(),
-    systemDescription: z.string().optional(),
-    systemName: z.string().optional(),
+    linkDescription: z.string().nullable().optional(),
+    linkName: z.string().nullable().optional(),
+    managementIp: IpNet.nullable().optional(),
+    systemDescription: z.string().nullable().optional(),
+    systemName: z.string().nullable().optional(),
   })
 )
 
@@ -2346,12 +2507,12 @@ export const LldpNeighbor = z.preprocess(
     chassisId: z.string(),
     firstSeen: z.coerce.date(),
     lastSeen: z.coerce.date(),
-    linkDescription: z.string().optional(),
+    linkDescription: z.string().nullable().optional(),
     linkName: z.string(),
     localPort: z.string(),
     managementIp: IpNet.array(),
-    systemDescription: z.string().optional(),
-    systemName: z.string().optional(),
+    systemDescription: z.string().nullable().optional(),
+    systemName: z.string().nullable().optional(),
   })
 )
 
@@ -2360,7 +2521,10 @@ export const LldpNeighbor = z.preprocess(
  */
 export const LldpNeighborResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: LldpNeighbor.array(), nextPage: z.string().optional() })
+  z.object({
+    items: LldpNeighbor.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -2397,7 +2561,10 @@ export const LoopbackAddressCreate = z.preprocess(
  */
 export const LoopbackAddressResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: LoopbackAddress.array(), nextPage: z.string().optional() })
+  z.object({
+    items: LoopbackAddress.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -2413,7 +2580,10 @@ export const Measurement = z.preprocess(
  */
 export const MeasurementResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: Measurement.array(), nextPage: z.string().optional() })
+  z.object({
+    items: Measurement.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -2468,12 +2638,30 @@ export const NetworkInterface = z.preprocess(
 export const ValueArray = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ type: z.enum(['integer']), values: z.number().array() }),
-    z.object({ type: z.enum(['double']), values: z.number().array() }),
-    z.object({ type: z.enum(['boolean']), values: SafeBoolean.array() }),
-    z.object({ type: z.enum(['string']), values: z.string().array() }),
-    z.object({ type: z.enum(['integer_distribution']), values: Distributionint64.array() }),
-    z.object({ type: z.enum(['double_distribution']), values: Distributiondouble.array() }),
+    z.object({
+      type: z.enum(['integer']),
+      values: z.number().nullable().array(),
+    }),
+    z.object({
+      type: z.enum(['double']),
+      values: z.number().nullable().array(),
+    }),
+    z.object({
+      type: z.enum(['boolean']),
+      values: SafeBoolean.nullable().array(),
+    }),
+    z.object({
+      type: z.enum(['string']),
+      values: z.string().nullable().array(),
+    }),
+    z.object({
+      type: z.enum(['integer_distribution']),
+      values: Distributionint64.nullable().array(),
+    }),
+    z.object({
+      type: z.enum(['double_distribution']),
+      values: Distributiondouble.nullable().array(),
+    }),
   ])
 )
 
@@ -2514,7 +2702,10 @@ export const Timeseries = z.preprocess(
  */
 export const Table = z.preprocess(
   processResponseBody,
-  z.object({ name: z.string(), timeseries: z.record(z.string().min(1), Timeseries) })
+  z.object({
+    name: z.string(),
+    timeseries: z.record(z.string().min(1), Timeseries),
+  })
 )
 
 /**
@@ -2569,7 +2760,7 @@ export const PhysicalDisk = z.preprocess(
     model: z.string(),
     policy: PhysicalDiskPolicy,
     serial: z.string(),
-    sledId: z.string().uuid().optional(),
+    sledId: z.string().uuid().nullable().optional(),
     state: PhysicalDiskState,
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
@@ -2582,7 +2773,10 @@ export const PhysicalDisk = z.preprocess(
  */
 export const PhysicalDiskResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: PhysicalDisk.array(), nextPage: z.string().optional() })
+  z.object({
+    items: PhysicalDisk.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 export const PingStatus = z.preprocess(processResponseBody, z.enum(['ok']))
@@ -2611,7 +2805,7 @@ export const ProbeCreate = z.preprocess(
   processResponseBody,
   z.object({
     description: z.string(),
-    ipPool: NameOrId.optional(),
+    ipPool: NameOrId.nullable().optional(),
     name: Name,
     sled: z.string().uuid(),
   })
@@ -2648,7 +2842,10 @@ export const ProbeInfo = z.preprocess(
  */
 export const ProbeInfoResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: ProbeInfo.array(), nextPage: z.string().optional() })
+  z.object({
+    items: ProbeInfo.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -2678,7 +2875,10 @@ export const ProjectCreate = z.preprocess(
  */
 export const ProjectResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: Project.array(), nextPage: z.string().optional() })
+  z.object({
+    items: Project.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 export const ProjectRole = z.preprocess(
@@ -2715,7 +2915,10 @@ export const ProjectRolePolicy = z.preprocess(
  */
 export const ProjectUpdate = z.preprocess(
   processResponseBody,
-  z.object({ description: z.string().optional(), name: Name.optional() })
+  z.object({
+    description: z.string().nullable().optional(),
+    name: Name.nullable().optional(),
+  })
 )
 
 /**
@@ -2735,7 +2938,7 @@ export const Rack = z.preprocess(
  */
 export const RackResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: Rack.array(), nextPage: z.string().optional() })
+  z.object({ items: Rack.array(), nextPage: z.string().nullable().optional() })
 )
 
 /**
@@ -2764,7 +2967,7 @@ export const Role = z.preprocess(
  */
 export const RoleResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: Role.array(), nextPage: z.string().optional() })
+  z.object({ items: Role.array(), nextPage: z.string().nullable().optional() })
 )
 
 /**
@@ -2775,8 +2978,8 @@ export const Route = z.preprocess(
   z.object({
     dst: IpNet,
     gw: z.string().ip(),
-    ribPriority: z.number().min(0).max(255).optional(),
-    vid: z.number().min(0).max(65535).optional(),
+    ribPriority: z.number().min(0).max(255).nullable().optional(),
+    vid: z.number().min(0).max(65535).nullable().optional(),
   })
 )
 
@@ -2864,7 +3067,10 @@ export const RouterRouteCreate = z.preprocess(
  */
 export const RouterRouteResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: RouterRoute.array(), nextPage: z.string().optional() })
+  z.object({
+    items: RouterRoute.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -2873,9 +3079,9 @@ export const RouterRouteResultsPage = z.preprocess(
 export const RouterRouteUpdate = z.preprocess(
   processResponseBody,
   z.object({
-    description: z.string().optional(),
+    description: z.string().nullable().optional(),
     destination: RouteDestination,
-    name: Name.optional(),
+    name: Name.nullable().optional(),
     target: RouteTarget,
   })
 )
@@ -2888,11 +3094,11 @@ export const SamlIdentityProvider = z.preprocess(
   z.object({
     acsUrl: z.string(),
     description: z.string(),
-    groupAttributeName: z.string().optional(),
+    groupAttributeName: z.string().nullable().optional(),
     id: z.string().uuid(),
     idpEntityId: z.string(),
     name: Name,
-    publicCert: z.string().optional(),
+    publicCert: z.string().nullable().optional(),
     sloUrl: z.string(),
     spClientId: z.string(),
     technicalContactEmail: z.string(),
@@ -2909,11 +3115,11 @@ export const SamlIdentityProviderCreate = z.preprocess(
   z.object({
     acsUrl: z.string(),
     description: z.string(),
-    groupAttributeName: z.string().optional(),
+    groupAttributeName: z.string().nullable().optional(),
     idpEntityId: z.string(),
     idpMetadataSource: IdpMetadataSource,
     name: Name,
-    signingKeypair: DerEncodedKeyPair.default(null).optional(),
+    signingKeypair: DerEncodedKeyPair.default(null).nullable().optional(),
     sloUrl: z.string(),
     spClientId: z.string(),
     technicalContactEmail: z.string(),
@@ -2975,7 +3181,7 @@ export const SiloQuotasCreate = z.preprocess(
 export const SiloCreate = z.preprocess(
   processResponseBody,
   z.object({
-    adminGroupName: z.string().optional(),
+    adminGroupName: z.string().nullable().optional(),
     description: z.string(),
     discoverable: SafeBoolean,
     identityMode: SiloIdentityMode,
@@ -3008,7 +3214,10 @@ export const SiloIpPool = z.preprocess(
  */
 export const SiloIpPoolResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: SiloIpPool.array(), nextPage: z.string().optional() })
+  z.object({
+    items: SiloIpPool.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -3029,7 +3238,10 @@ export const SiloQuotas = z.preprocess(
  */
 export const SiloQuotasResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: SiloQuotas.array(), nextPage: z.string().optional() })
+  z.object({
+    items: SiloQuotas.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -3038,9 +3250,9 @@ export const SiloQuotasResultsPage = z.preprocess(
 export const SiloQuotasUpdate = z.preprocess(
   processResponseBody,
   z.object({
-    cpus: z.number().optional(),
-    memory: ByteCount.optional(),
-    storage: ByteCount.optional(),
+    cpus: z.number().nullable().optional(),
+    memory: ByteCount.nullable().optional(),
+    storage: ByteCount.nullable().optional(),
   })
 )
 
@@ -3049,7 +3261,7 @@ export const SiloQuotasUpdate = z.preprocess(
  */
 export const SiloResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: Silo.array(), nextPage: z.string().optional() })
+  z.object({ items: Silo.array(), nextPage: z.string().nullable().optional() })
 )
 
 export const SiloRole = z.preprocess(
@@ -3107,7 +3319,10 @@ export const SiloUtilization = z.preprocess(
  */
 export const SiloUtilizationResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: SiloUtilization.array(), nextPage: z.string().optional() })
+  z.object({
+    items: SiloUtilization.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -3126,7 +3341,10 @@ export const SledProvisionPolicy = z.preprocess(
 export const SledPolicy = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ kind: z.enum(['in_service']), provisionPolicy: SledProvisionPolicy }),
+    z.object({
+      kind: z.enum(['in_service']),
+      provisionPolicy: SledProvisionPolicy,
+    }),
     z.object({ kind: z.enum(['expunged']) }),
   ])
 )
@@ -3171,7 +3389,7 @@ export const SledInstance = z.preprocess(
     activeSledId: z.string().uuid(),
     id: z.string().uuid(),
     memory: z.number(),
-    migrationId: z.string().uuid().optional(),
+    migrationId: z.string().uuid().nullable().optional(),
     name: Name,
     ncpus: z.number(),
     projectName: Name,
@@ -3187,7 +3405,10 @@ export const SledInstance = z.preprocess(
  */
 export const SledInstanceResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: SledInstance.array(), nextPage: z.string().optional() })
+  z.object({
+    items: SledInstance.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -3211,7 +3432,7 @@ export const SledProvisionPolicyResponse = z.preprocess(
  */
 export const SledResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: Sled.array(), nextPage: z.string().optional() })
+  z.object({ items: Sled.array(), nextPage: z.string().nullable().optional() })
 )
 
 export const SnapshotState = z.preprocess(
@@ -3250,7 +3471,10 @@ export const SnapshotCreate = z.preprocess(
  */
 export const SnapshotResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: Snapshot.array(), nextPage: z.string().optional() })
+  z.object({
+    items: Snapshot.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -3282,7 +3506,10 @@ export const SshKeyCreate = z.preprocess(
  */
 export const SshKeyResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: SshKey.array(), nextPage: z.string().optional() })
+  z.object({
+    items: SshKey.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 export const TypedUuidForSupportBundleKind = z.preprocess(
@@ -3300,7 +3527,7 @@ export const SupportBundleInfo = z.preprocess(
   z.object({
     id: TypedUuidForSupportBundleKind,
     reasonForCreation: z.string(),
-    reasonForFailure: z.string().optional(),
+    reasonForFailure: z.string().nullable().optional(),
     state: SupportBundleState,
     timeCreated: z.coerce.date(),
   })
@@ -3311,7 +3538,10 @@ export const SupportBundleInfo = z.preprocess(
  */
 export const SupportBundleInfoResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: SupportBundleInfo.array(), nextPage: z.string().optional() })
+  z.object({
+    items: SupportBundleInfo.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -3380,7 +3610,7 @@ export const SwitchPort = z.preprocess(
   z.object({
     id: z.string().uuid(),
     portName: z.string(),
-    portSettingsId: z.string().uuid().optional(),
+    portSettingsId: z.string().uuid().nullable().optional(),
     rackId: z.string().uuid(),
     switchLocation: z.string(),
   })
@@ -3396,7 +3626,7 @@ export const SwitchPortAddressConfig = z.preprocess(
     addressLotBlockId: z.string().uuid(),
     interfaceName: z.string(),
     portSettingsId: z.string().uuid(),
-    vlanId: z.number().min(0).max(65535).optional(),
+    vlanId: z.number().min(0).max(65535).nullable().optional(),
   })
 )
 
@@ -3421,7 +3651,10 @@ export const SwitchPortGeometry2 = z.preprocess(
  */
 export const SwitchPortConfig = z.preprocess(
   processResponseBody,
-  z.object({ geometry: SwitchPortGeometry2, portSettingsId: z.string().uuid() })
+  z.object({
+    geometry: SwitchPortGeometry2,
+    portSettingsId: z.string().uuid(),
+  })
 )
 
 /**
@@ -3447,13 +3680,13 @@ export const SwitchPortLinkConfig = z.preprocess(
   processResponseBody,
   z.object({
     autoneg: SafeBoolean,
-    fec: LinkFec.optional(),
+    fec: LinkFec.nullable().optional(),
     linkName: z.string(),
-    lldpLinkConfigId: z.string().uuid().optional(),
+    lldpLinkConfigId: z.string().uuid().nullable().optional(),
     mtu: z.number().min(0).max(65535),
     portSettingsId: z.string().uuid(),
     speed: LinkSpeed,
-    txEqConfigId: z.string().uuid().optional(),
+    txEqConfigId: z.string().uuid().nullable().optional(),
   })
 )
 
@@ -3462,7 +3695,10 @@ export const SwitchPortLinkConfig = z.preprocess(
  */
 export const SwitchPortResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: SwitchPort.array(), nextPage: z.string().optional() })
+  z.object({
+    items: SwitchPort.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -3475,8 +3711,8 @@ export const SwitchPortRouteConfig = z.preprocess(
     gw: IpNet,
     interfaceName: z.string(),
     portSettingsId: z.string().uuid(),
-    ribPriority: z.number().min(0).max(255).optional(),
-    vlanId: z.number().min(0).max(65535).optional(),
+    ribPriority: z.number().min(0).max(255).nullable().optional(),
+    vlanId: z.number().min(0).max(65535).nullable().optional(),
   })
 )
 
@@ -3517,7 +3753,10 @@ export const SwitchPortSettingsCreate = z.preprocess(
  */
 export const SwitchPortSettingsGroups = z.preprocess(
   processResponseBody,
-  z.object({ portSettingsGroupId: z.string().uuid(), portSettingsId: z.string().uuid() })
+  z.object({
+    portSettingsGroupId: z.string().uuid(),
+    portSettingsId: z.string().uuid(),
+  })
 )
 
 /**
@@ -3525,7 +3764,10 @@ export const SwitchPortSettingsGroups = z.preprocess(
  */
 export const SwitchPortSettingsResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: SwitchPortSettings.array(), nextPage: z.string().optional() })
+  z.object({
+    items: SwitchPortSettings.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -3533,7 +3775,10 @@ export const SwitchPortSettingsResultsPage = z.preprocess(
  */
 export const SwitchVlanInterfaceConfig = z.preprocess(
   processResponseBody,
-  z.object({ interfaceConfigId: z.string().uuid(), vlanId: z.number().min(0).max(65535) })
+  z.object({
+    interfaceConfigId: z.string().uuid(),
+    vlanId: z.number().min(0).max(65535),
+  })
 )
 
 /**
@@ -3551,7 +3796,7 @@ export const SwitchPortSettingsView = z.preprocess(
     port: SwitchPortConfig,
     routes: SwitchPortRouteConfig.array(),
     settings: SwitchPortSettings,
-    txEq: TxEqConfig.array(),
+    txEq: TxEqConfig.nullable().array(),
     vlanInterfaces: SwitchVlanInterfaceConfig.array(),
   })
 )
@@ -3561,7 +3806,10 @@ export const SwitchPortSettingsView = z.preprocess(
  */
 export const SwitchResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: Switch.array(), nextPage: z.string().optional() })
+  z.object({
+    items: Switch.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -3667,7 +3915,10 @@ export const TimeseriesSchema = z.preprocess(
  */
 export const TimeseriesSchemaResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: TimeseriesSchema.array(), nextPage: z.string().optional() })
+  z.object({
+    items: TimeseriesSchema.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -3695,7 +3946,10 @@ export const UninitializedSledId = z.preprocess(
  */
 export const UninitializedSledResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: UninitializedSled.array(), nextPage: z.string().optional() })
+  z.object({
+    items: UninitializedSled.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -3703,7 +3957,11 @@ export const UninitializedSledResultsPage = z.preprocess(
  */
 export const User = z.preprocess(
   processResponseBody,
-  z.object({ displayName: z.string(), id: z.string().uuid(), siloId: z.string().uuid() })
+  z.object({
+    displayName: z.string(),
+    id: z.string().uuid(),
+    siloId: z.string().uuid(),
+  })
 )
 
 /**
@@ -3727,7 +3985,10 @@ export const UserBuiltin = z.preprocess(
  */
 export const UserBuiltinResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: UserBuiltin.array(), nextPage: z.string().optional() })
+  z.object({
+    items: UserBuiltin.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -3770,7 +4031,7 @@ export const UserCreate = z.preprocess(
  */
 export const UserResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: User.array(), nextPage: z.string().optional() })
+  z.object({ items: User.array(), nextPage: z.string().nullable().optional() })
 )
 
 /**
@@ -3786,7 +4047,10 @@ export const UsernamePasswordCredentials = z.preprocess(
  */
 export const Utilization = z.preprocess(
   processResponseBody,
-  z.object({ capacity: VirtualResourceCounts, provisioned: VirtualResourceCounts })
+  z.object({
+    capacity: VirtualResourceCounts,
+    provisioned: VirtualResourceCounts,
+  })
 )
 
 /**
@@ -3815,7 +4079,7 @@ export const VpcCreate = z.preprocess(
   z.object({
     description: z.string(),
     dnsName: Name,
-    ipv6Prefix: Ipv6Net.optional(),
+    ipv6Prefix: Ipv6Net.nullable().optional(),
     name: Name,
   })
 )
@@ -3942,7 +4206,7 @@ export const VpcFirewallRules = z.preprocess(
  */
 export const VpcResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: Vpc.array(), nextPage: z.string().optional() })
+  z.object({ items: Vpc.array(), nextPage: z.string().nullable().optional() })
 )
 
 export const VpcRouterKind = z.preprocess(processResponseBody, z.enum(['system', 'custom']))
@@ -3976,7 +4240,10 @@ export const VpcRouterCreate = z.preprocess(
  */
 export const VpcRouterResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: VpcRouter.array(), nextPage: z.string().optional() })
+  z.object({
+    items: VpcRouter.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -3984,7 +4251,10 @@ export const VpcRouterResultsPage = z.preprocess(
  */
 export const VpcRouterUpdate = z.preprocess(
   processResponseBody,
-  z.object({ description: z.string().optional(), name: Name.optional() })
+  z.object({
+    description: z.string().nullable().optional(),
+    name: Name.nullable().optional(),
+  })
 )
 
 /**
@@ -3993,7 +4263,7 @@ export const VpcRouterUpdate = z.preprocess(
 export const VpcSubnet = z.preprocess(
   processResponseBody,
   z.object({
-    customRouterId: z.string().uuid().optional(),
+    customRouterId: z.string().uuid().nullable().optional(),
     description: z.string(),
     id: z.string().uuid(),
     ipv4Block: Ipv4Net,
@@ -4011,10 +4281,10 @@ export const VpcSubnet = z.preprocess(
 export const VpcSubnetCreate = z.preprocess(
   processResponseBody,
   z.object({
-    customRouter: NameOrId.optional(),
+    customRouter: NameOrId.nullable().optional(),
     description: z.string(),
     ipv4Block: Ipv4Net,
-    ipv6Block: Ipv6Net.optional(),
+    ipv6Block: Ipv6Net.nullable().optional(),
     name: Name,
   })
 )
@@ -4024,7 +4294,10 @@ export const VpcSubnetCreate = z.preprocess(
  */
 export const VpcSubnetResultsPage = z.preprocess(
   processResponseBody,
-  z.object({ items: VpcSubnet.array(), nextPage: z.string().optional() })
+  z.object({
+    items: VpcSubnet.array(),
+    nextPage: z.string().nullable().optional(),
+  })
 )
 
 /**
@@ -4033,9 +4306,9 @@ export const VpcSubnetResultsPage = z.preprocess(
 export const VpcSubnetUpdate = z.preprocess(
   processResponseBody,
   z.object({
-    customRouter: NameOrId.optional(),
-    description: z.string().optional(),
-    name: Name.optional(),
+    customRouter: NameOrId.nullable().optional(),
+    description: z.string().nullable().optional(),
+    name: Name.nullable().optional(),
   })
 )
 
@@ -4045,9 +4318,9 @@ export const VpcSubnetUpdate = z.preprocess(
 export const VpcUpdate = z.preprocess(
   processResponseBody,
   z.object({
-    description: z.string().optional(),
-    dnsName: Name.optional(),
-    name: Name.optional(),
+    description: z.string().nullable().optional(),
+    dnsName: Name.nullable().optional(),
+    name: Name.nullable().optional(),
   })
 )
 
@@ -4120,8 +4393,8 @@ export const ProbeListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       project: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
@@ -4167,8 +4440,8 @@ export const SupportBundleListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       sortBy: IdSortMode.optional(),
     }),
   })
@@ -4270,8 +4543,8 @@ export const AffinityGroupListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       project: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
@@ -4331,8 +4604,8 @@ export const AffinityGroupMemberListParams = z.preprocess(
       affinityGroup: NameOrId,
     }),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       project: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
@@ -4383,8 +4656,8 @@ export const AntiAffinityGroupListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       project: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
@@ -4444,8 +4717,8 @@ export const AntiAffinityGroupMemberListParams = z.preprocess(
       antiAffinityGroup: NameOrId,
     }),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       project: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
@@ -4496,8 +4769,8 @@ export const CertificateListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
   })
@@ -4536,8 +4809,8 @@ export const DiskListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       project: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
@@ -4635,9 +4908,9 @@ export const DiskMetricsListParams = z.preprocess(
     }),
     query: z.object({
       endTime: z.coerce.date().optional(),
-      limit: z.number().min(1).max(4294967295).optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
       order: PaginationOrder.optional(),
-      pageToken: z.string().optional(),
+      pageToken: z.string().nullable().optional(),
       startTime: z.coerce.date().optional(),
       project: NameOrId.optional(),
     }),
@@ -4649,8 +4922,8 @@ export const FloatingIpListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       project: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
@@ -4732,8 +5005,8 @@ export const GroupListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       sortBy: IdSortMode.optional(),
     }),
   })
@@ -4754,8 +5027,8 @@ export const ImageListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       project: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
@@ -4825,8 +5098,8 @@ export const InstanceListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       project: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
@@ -4886,8 +5159,8 @@ export const InstanceAffinityGroupListParams = z.preprocess(
       instance: NameOrId,
     }),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       project: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
@@ -4901,8 +5174,8 @@ export const InstanceAntiAffinityGroupListParams = z.preprocess(
       instance: NameOrId,
     }),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       project: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
@@ -4916,8 +5189,8 @@ export const InstanceDiskListParams = z.preprocess(
       instance: NameOrId,
     }),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       project: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
@@ -5003,9 +5276,9 @@ export const InstanceSerialConsoleParams = z.preprocess(
       instance: NameOrId,
     }),
     query: z.object({
-      fromStart: z.number().min(0).optional(),
-      maxBytes: z.number().min(0).optional(),
-      mostRecent: z.number().min(0).optional(),
+      fromStart: z.number().min(0).nullable().optional(),
+      maxBytes: z.number().min(0).nullable().optional(),
+      mostRecent: z.number().min(0).nullable().optional(),
       project: NameOrId.optional(),
     }),
   })
@@ -5018,7 +5291,7 @@ export const InstanceSerialConsoleStreamParams = z.preprocess(
       instance: NameOrId,
     }),
     query: z.object({
-      mostRecent: z.number().min(0).optional(),
+      mostRecent: z.number().min(0).nullable().optional(),
       project: NameOrId.optional(),
     }),
   })
@@ -5031,8 +5304,8 @@ export const InstanceSshPublicKeyListParams = z.preprocess(
       instance: NameOrId,
     }),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       project: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
@@ -5069,8 +5342,8 @@ export const InternetGatewayIpAddressListParams = z.preprocess(
     path: z.object({}),
     query: z.object({
       gateway: NameOrId.optional(),
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       project: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
       vpc: NameOrId.optional(),
@@ -5111,8 +5384,8 @@ export const InternetGatewayIpPoolListParams = z.preprocess(
     path: z.object({}),
     query: z.object({
       gateway: NameOrId.optional(),
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       project: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
       vpc: NameOrId.optional(),
@@ -5152,8 +5425,8 @@ export const InternetGatewayListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       project: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
       vpc: NameOrId.optional(),
@@ -5204,8 +5477,8 @@ export const ProjectIpPoolListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
   })
@@ -5252,8 +5525,8 @@ export const CurrentUserGroupsParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       sortBy: IdSortMode.optional(),
     }),
   })
@@ -5264,8 +5537,8 @@ export const CurrentUserSshKeyListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
   })
@@ -5307,9 +5580,9 @@ export const SiloMetricParams = z.preprocess(
     }),
     query: z.object({
       endTime: z.coerce.date().optional(),
-      limit: z.number().min(1).max(4294967295).optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
       order: PaginationOrder.optional(),
-      pageToken: z.string().optional(),
+      pageToken: z.string().nullable().optional(),
       startTime: z.coerce.date().optional(),
       project: NameOrId.optional(),
     }),
@@ -5322,8 +5595,8 @@ export const InstanceNetworkInterfaceListParams = z.preprocess(
     path: z.object({}),
     query: z.object({
       instance: NameOrId.optional(),
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       project: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
@@ -5409,8 +5682,8 @@ export const ProjectListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
   })
@@ -5479,8 +5752,8 @@ export const SnapshotListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       project: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
@@ -5526,8 +5799,8 @@ export const PhysicalDiskListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       sortBy: IdSortMode.optional(),
     }),
   })
@@ -5552,8 +5825,8 @@ export const NetworkingSwitchPortLldpNeighborsParams = z.preprocess(
       switchLocation: Name,
     }),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       sortBy: IdSortMode.optional(),
     }),
   })
@@ -5564,8 +5837,8 @@ export const RackListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       sortBy: IdSortMode.optional(),
     }),
   })
@@ -5586,8 +5859,8 @@ export const SledListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       sortBy: IdSortMode.optional(),
     }),
   })
@@ -5618,8 +5891,8 @@ export const SledPhysicalDiskListParams = z.preprocess(
       sledId: z.string().uuid(),
     }),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       sortBy: IdSortMode.optional(),
     }),
   })
@@ -5632,8 +5905,8 @@ export const SledInstanceListParams = z.preprocess(
       sledId: z.string().uuid(),
     }),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       sortBy: IdSortMode.optional(),
     }),
   })
@@ -5654,8 +5927,8 @@ export const SledListUninitializedParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
     }),
   })
 )
@@ -5665,10 +5938,10 @@ export const NetworkingSwitchPortListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       sortBy: IdSortMode.optional(),
-      switchPortId: z.string().uuid().optional(),
+      switchPortId: z.string().uuid().nullable().optional(),
     }),
   })
 )
@@ -5743,8 +6016,8 @@ export const SwitchListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       sortBy: IdSortMode.optional(),
     }),
   })
@@ -5765,8 +6038,8 @@ export const SiloIdentityProviderListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       silo: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
@@ -5834,8 +6107,8 @@ export const IpPoolListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
   })
@@ -5886,8 +6159,8 @@ export const IpPoolRangeListParams = z.preprocess(
       pool: NameOrId,
     }),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
     }),
   })
 )
@@ -5919,8 +6192,8 @@ export const IpPoolSiloListParams = z.preprocess(
       pool: NameOrId,
     }),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       sortBy: IdSortMode.optional(),
     }),
   })
@@ -5981,8 +6254,8 @@ export const IpPoolServiceRangeListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
     }),
   })
 )
@@ -6011,9 +6284,9 @@ export const SystemMetricParams = z.preprocess(
     }),
     query: z.object({
       endTime: z.coerce.date().optional(),
-      limit: z.number().min(1).max(4294967295).optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
       order: PaginationOrder.optional(),
-      pageToken: z.string().optional(),
+      pageToken: z.string().nullable().optional(),
       startTime: z.coerce.date().optional(),
       silo: NameOrId.optional(),
     }),
@@ -6025,8 +6298,8 @@ export const NetworkingAddressLotListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
   })
@@ -6057,8 +6330,8 @@ export const NetworkingAddressLotBlockListParams = z.preprocess(
       addressLot: NameOrId,
     }),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       sortBy: IdSortMode.optional(),
     }),
   })
@@ -6109,8 +6382,8 @@ export const NetworkingBgpConfigListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
   })
@@ -6139,8 +6412,8 @@ export const NetworkingBgpAnnounceSetListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
   })
@@ -6215,8 +6488,8 @@ export const NetworkingLoopbackAddressListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       sortBy: IdSortMode.optional(),
     }),
   })
@@ -6248,8 +6521,8 @@ export const NetworkingSwitchPortSettingsListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       portSettings: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
@@ -6305,8 +6578,8 @@ export const RoleListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
     }),
   })
 )
@@ -6326,8 +6599,8 @@ export const SystemQuotasListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       sortBy: IdSortMode.optional(),
     }),
   })
@@ -6338,8 +6611,8 @@ export const SiloListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
   })
@@ -6380,8 +6653,8 @@ export const SiloIpPoolListParams = z.preprocess(
       silo: NameOrId,
     }),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
   })
@@ -6440,8 +6713,8 @@ export const SystemTimeseriesSchemaListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
     }),
   })
 )
@@ -6467,8 +6740,8 @@ export const SiloUserListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       silo: NameOrId.optional(),
       sortBy: IdSortMode.optional(),
     }),
@@ -6492,8 +6765,8 @@ export const UserBuiltinListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       sortBy: NameSortMode.optional(),
     }),
   })
@@ -6514,8 +6787,8 @@ export const SiloUtilizationListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),
   })
@@ -6546,9 +6819,9 @@ export const UserListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      group: z.string().uuid().optional(),
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      group: z.string().uuid().nullable().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       sortBy: IdSortMode.optional(),
     }),
   })
@@ -6589,8 +6862,8 @@ export const VpcRouterRouteListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       project: NameOrId.optional(),
       router: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
@@ -6658,8 +6931,8 @@ export const VpcRouterListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       project: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
       vpc: NameOrId.optional(),
@@ -6722,8 +6995,8 @@ export const VpcSubnetListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       project: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
       vpc: NameOrId.optional(),
@@ -6788,8 +7061,8 @@ export const VpcSubnetListNetworkInterfacesParams = z.preprocess(
       subnet: NameOrId,
     }),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       project: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
       vpc: NameOrId.optional(),
@@ -6802,8 +7075,8 @@ export const VpcListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      limit: z.number().min(1).max(4294967295).optional(),
-      pageToken: z.string().optional(),
+      limit: z.number().min(1).max(4294967295).nullable().optional(),
+      pageToken: z.string().nullable().optional(),
       project: NameOrId.optional(),
       sortBy: NameOrIdSortMode.optional(),
     }),

--- a/app/api/hooks.ts
+++ b/app/api/hooks.ts
@@ -31,7 +31,7 @@ import { navToLogin } from './nav-to-login'
 type Params<F> = F extends (p: infer P) => any ? P : never
 type Result<F> = F extends (p: any) => Promise<ApiResult<infer R>> ? R : never
 
-export type ResultsPage<TItem> = { items: TItem[]; nextPage?: string }
+export type ResultsPage<TItem> = { items: TItem[]; nextPage?: string | null }
 
 type ApiClient = Record<string, (...args: any) => Promise<ApiResult<any>>>
 /* eslint-enable @typescript-eslint/no-explicit-any */

--- a/app/components/InstanceAutoRestartPopover.tsx
+++ b/app/components/InstanceAutoRestartPopover.tsx
@@ -9,7 +9,7 @@ import { CloseButton, Popover, PopoverButton, PopoverPanel } from '@headlessui/r
 import { formatDistanceToNow } from 'date-fns'
 import { type ReactNode } from 'react'
 import { Link } from 'react-router'
-import { match } from 'ts-pattern'
+import { match, P } from 'ts-pattern'
 
 import {
   AutoRestart12Icon,
@@ -69,7 +69,7 @@ export const InstanceAutoRestartPopover = ({ instance }: { instance: Instance })
                 </Badge>
               ))
               .with('best_effort', () => <Badge>best effort</Badge>)
-              .with(undefined, () => <Badge color="neutral">Default</Badge>)
+              .with(P.nullish, () => <Badge color="neutral">Default</Badge>)
               .exhaustive()}
             <div className="transition-transform group-hover:translate-x-1">
               <NextArrow12Icon />

--- a/app/components/form/fields/useItemsList.ts
+++ b/app/components/form/fields/useItemsList.ts
@@ -24,7 +24,7 @@ export function customRouterFormToData(value: string): string | undefined {
 }
 
 /** Convert value from response body to form value */
-export function customRouterDataToForm(value: string | undefined): string {
+export function customRouterDataToForm(value: string | undefined | null): string {
   return value || NO_ROUTER
 }
 

--- a/app/components/oxql-metrics/util.spec.ts
+++ b/app/components/oxql-metrics/util.spec.ts
@@ -150,9 +150,6 @@ const utilizationQueryResult1: OxqlQueryResult = {
               {
                 values: {
                   type: 'double',
-                  // there is a bug in the client generator that makes this not allow nulls,
-                  // but we can in fact get them from the API for these values
-                  // @ts-expect-error
                   values: [4991154550.953981, 5002306111.529594, 5005747970.58788, null],
                 },
                 metricType: 'gauge',

--- a/app/forms/network-interface-create.tsx
+++ b/app/forms/network-interface-create.tsx
@@ -7,7 +7,7 @@
  */
 import { useMemo } from 'react'
 import { useForm } from 'react-hook-form'
-import type { SetRequired } from 'type-fest'
+import type { SetNonNullable, SetRequired } from 'type-fest'
 
 import { useApiQuery, type ApiError, type InstanceNetworkInterfaceCreate } from '@oxide/api'
 
@@ -20,7 +20,7 @@ import { SideModalForm } from '~/components/form/SideModalForm'
 import { useProjectSelector } from '~/hooks/use-params'
 import { FormDivider } from '~/ui/lib/Divider'
 
-const defaultValues: SetRequired<InstanceNetworkInterfaceCreate, 'ip'> = {
+const defaultValues: SetRequired<SetNonNullable<InstanceNetworkInterfaceCreate>, 'ip'> = {
   name: '',
   description: '',
   ip: '',

--- a/app/forms/subnet-create.tsx
+++ b/app/forms/subnet-create.tsx
@@ -7,6 +7,7 @@
  */
 import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router'
+import type { SetNonNullable } from 'type-fest'
 
 import { useApiMutation, useApiQueryClient, type VpcSubnetCreate } from '@oxide/api'
 
@@ -27,7 +28,7 @@ import { addToast } from '~/stores/toast'
 import { FormDivider } from '~/ui/lib/Divider'
 import { pb } from '~/util/path-builder'
 
-const defaultValues: Required<VpcSubnetCreate> = {
+const defaultValues: SetNonNullable<Required<VpcSubnetCreate>> = {
   name: '',
   description: '',
   ipv4Block: '',

--- a/app/forms/subnet-edit.tsx
+++ b/app/forms/subnet-edit.tsx
@@ -7,6 +7,7 @@
  */
 import { useForm } from 'react-hook-form'
 import { useNavigate, type LoaderFunctionArgs } from 'react-router'
+import type { SetNonNullable } from 'type-fest'
 
 import {
   apiq,
@@ -61,7 +62,7 @@ export default function EditSubnetForm() {
     },
   })
 
-  const defaultValues: Required<VpcSubnetUpdate> = {
+  const defaultValues: SetNonNullable<Required<VpcSubnetUpdate>> = {
     name: subnet.name,
     description: subnet.description,
     customRouter: customRouterDataToForm(subnet.customRouterId),

--- a/app/forms/vpc-router-route-common.tsx
+++ b/app/forms/vpc-router-route-common.tsx
@@ -7,6 +7,7 @@
  */
 
 import type { UseFormReturn } from 'react-hook-form'
+import type { SetNonNullable } from 'type-fest'
 
 import {
   usePrefetchedApiQuery,
@@ -26,7 +27,9 @@ import { Message } from '~/ui/lib/Message'
 import { ALL_ISH } from '~/util/consts'
 import { validateIp, validateIpNet } from '~/util/ip'
 
-export type RouteFormValues = RouterRouteCreate | Required<RouterRouteUpdate>
+export type RouteFormValues =
+  | RouterRouteCreate
+  | SetNonNullable<Required<RouterRouteUpdate>>
 
 export const routeFormMessage = {
   vpcSubnetNotModifiable:

--- a/app/pages/system/silos/SiloQuotasTab.tsx
+++ b/app/pages/system/silos/SiloQuotasTab.tsx
@@ -8,6 +8,7 @@
 
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
+import type { SetNonNullable } from 'type-fest'
 
 import {
   apiQueryClient,
@@ -96,7 +97,7 @@ function EditQuotasForm({ onDismiss }: { onDismiss: () => void }) {
   const quotas = utilization.allocated
 
   // required because we need to rule out undefined because NumberField hates that
-  const defaultValues: Required<SiloQuotasUpdate> = {
+  const defaultValues: SetNonNullable<Required<SiloQuotasUpdate>> = {
     cpus: quotas.cpus,
     memory: bytesToGiB(quotas.memory),
     storage: bytesToGiB(quotas.storage),

--- a/app/table/cells/InstanceLinkCell.tsx
+++ b/app/table/cells/InstanceLinkCell.tsx
@@ -14,7 +14,7 @@ import { pb } from '~/util/path-builder'
 import { EmptyCell, SkeletonCell } from './EmptyCell'
 import { LinkCell } from './LinkCell'
 
-export const InstanceLinkCell = ({ instanceId }: { instanceId?: string }) => {
+export const InstanceLinkCell = ({ instanceId }: { instanceId?: string | null }) => {
   const { project } = useProjectSelector()
   const { data: instance } = useApiQuery(
     'instanceView',

--- a/app/table/cells/RouterLinkCell.tsx
+++ b/app/table/cells/RouterLinkCell.tsx
@@ -14,7 +14,7 @@ import { pb } from '~/util/path-builder'
 import { EmptyCell, SkeletonCell } from './EmptyCell'
 import { LinkCell } from './LinkCell'
 
-export const RouterLinkCell = ({ routerId }: { routerId?: string }) => {
+export const RouterLinkCell = ({ routerId }: { routerId?: string | null }) => {
   const { project, vpc } = useVpcSelector()
   const { data: router, isError } = useApiQuery(
     'vpcRouterView',

--- a/app/ui/lib/Pagination.tsx
+++ b/app/ui/lib/Pagination.tsx
@@ -32,7 +32,7 @@ export interface PaginationProps {
   pageSize: number
   hasNext: boolean
   hasPrev: boolean
-  nextPage: string | undefined
+  nextPage: string | undefined | null
   onNext: (nextPage: string) => void
   onPrev: () => void
   className?: string

--- a/mock-api/instance.ts
+++ b/mock-api/instance.ts
@@ -44,6 +44,7 @@ const failedInstance: Json<Instance> = {
   hostname: 'oxide.com',
   project_id: project.id,
   run_state: 'failed',
+  auto_restart_policy: null,
   auto_restart_cooldown_expiration: addMinutes(new Date(), 5).toISOString(), // 5 minutes from now
   time_last_auto_restarted: addMinutes(new Date(), -55).toISOString(), // 55 minutes ago
 }

--- a/mock-api/msw/db.ts
+++ b/mock-api/msw/db.ts
@@ -54,8 +54,8 @@ function ensureNoParentSelectors(
   }
 }
 
-export const getIpFromPool = (poolName: string | undefined) => {
-  const pool = lookup.ipPool({ pool: poolName })
+export const getIpFromPool = (poolName: string | undefined | null) => {
+  const pool = lookup.ipPool({ pool: poolName || undefined })
   const ipPoolRange = db.ipPoolRanges.find((range) => range.ip_pool_id === pool.id)
   if (!ipPoolRange) throw notFoundErr(`IP range for pool '${poolName}'`)
 

--- a/mock-api/msw/handlers.ts
+++ b/mock-api/msw/handlers.ts
@@ -270,9 +270,14 @@ export const handlers = makeHandlers({
       id: uuid(),
       project_id: project.id,
       // TODO: use ip-num to actually get the next available IP in the pool
-      ip: [...Array(4)].map(() => Math.floor(Math.random() * 256)).join('.'),
+      ip:
+        body.ip ||
+        Array.from({ length: 4 })
+          .map(() => Math.floor(Math.random() * 256))
+          .join('.'),
       ip_pool_id: pool.id,
-      ...body,
+      description: body.description,
+      name: body.name,
       ...getTimestamps(),
     }
     db.floatingIps.push(newFloatingIp)
@@ -661,6 +666,7 @@ export const handlers = makeHandlers({
     // https://github.com/oxidecomputer/omicron/blob/0c6ab099e/nexus/db-queries/src/db/datastore/instance.rs#L228-L239
     instance.auto_restart_enabled = match(instance.auto_restart_policy)
       .with(undefined, () => true)
+      .with(null, () => true)
       .with('best_effort', () => true)
       .with('never', () => false)
       .exhaustive()
@@ -1518,9 +1524,9 @@ export const handlers = makeHandlers({
     requireFleetCollab(cookies)
     const quotas = lookup.siloQuotas(path)
 
-    if (body.cpus !== undefined) quotas.cpus = body.cpus
-    if (body.memory !== undefined) quotas.memory = body.memory
-    if (body.storage !== undefined) quotas.storage = body.storage
+    if (body.cpus != null) quotas.cpus = body.cpus
+    if (body.memory != null) quotas.memory = body.memory
+    if (body.storage != null) quotas.storage = body.storage
 
     return quotas
   },

--- a/mock-api/msw/util.ts
+++ b/mock-api/msw/util.ts
@@ -37,8 +37,8 @@ import { genI64Data } from '../metrics'
 import { db } from './db'
 
 interface PaginateOptions {
-  limit?: number
-  pageToken?: string
+  limit?: number | null
+  pageToken?: string | null
 }
 export interface ResultsPage<I extends { id: string }> {
   items: I[]
@@ -49,7 +49,9 @@ export const paginated = <P extends PaginateOptions, I extends { id: string }>(
   params: P,
   items: I[]
 ) => {
-  const { limit = 100, pageToken } = params || {}
+  const limit = params.limit || 100
+  const pageToken = params.pageToken
+
   let startIndex = pageToken ? items.findIndex((i) => i.id === pageToken) : 0
   startIndex = startIndex < 0 ? 0 : startIndex
 
@@ -410,10 +412,10 @@ export const ipInAnyRange = (ip: string, ranges: IpRange[]) =>
 
 export function updateDesc(
   resource: { description: string },
-  update: { description?: string }
+  update: { description?: string | null }
 ) {
   // Can't be `if (update.description)` because you could never set it to ''
-  if (update.description !== undefined) {
+  if (update.description != null) {
     resource.description = update.description
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
       "devDependencies": {
         "@ianvs/prettier-plugin-sort-imports": "^4.4.1",
         "@mswjs/http-middleware": "^0.10.3",
-        "@oxide/openapi-gen-ts": "~0.6.2",
+        "@oxide/openapi-gen-ts": "~0.7.0",
         "@playwright/test": "^1.52.0",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -1573,9 +1573,9 @@
       }
     },
     "node_modules/@oxide/openapi-gen-ts": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@oxide/openapi-gen-ts/-/openapi-gen-ts-0.6.2.tgz",
-      "integrity": "sha512-3KMHnXmfpttBWnlgvYe3sPVQKxcwCfb/Z9T0nvR1ok4diwPuG33Na/qNjnCWCEv2PDhEJU6KU/QvXruLCpKMcg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@oxide/openapi-gen-ts/-/openapi-gen-ts-0.7.0.tgz",
+      "integrity": "sha512-5pFEUC+BCmVbQsAUIhWIPFhWwdteBNaH8nGYGf0ufap/6HpRLpqyqAMNOD2THUw64wMDYKDrAjpMNUuY0u4LFg==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^4.4.1",
     "@mswjs/http-middleware": "^0.10.3",
-    "@oxide/openapi-gen-ts": "~0.6.2",
+    "@oxide/openapi-gen-ts": "~0.7.0",
     "@playwright/test": "^1.52.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",


### PR DESCRIPTION
Closes #2820 

Note that while there are many lines of changes to the generated types and zod validators (the latter only used in the mock API), the only runtime app change is the change from `undefined` to `P.nullish` in the offending `match` in the auto restart popover.