### PR TITLE
Zod v4

### DIFF
--- a/app/api/__generated__/msw-handlers.ts
+++ b/app/api/__generated__/msw-handlers.ts
@@ -14,7 +14,7 @@ import {
   type StrictResponse,
 } from 'msw'
 import type { Promisable, SnakeCasedPropertiesDeep as Snakify } from 'type-fest'
-import { type ZodSchema } from 'zod'
+import { type ZodType } from 'zod/v4'
 
 import type * as Api from './Api'
 import { snakeify } from './util'
@@ -1717,7 +1717,7 @@ export interface MSWHandlers {
   }) => Promisable<StatusCode>
 }
 
-function validateParams<S extends ZodSchema>(
+function validateParams<S extends ZodType>(
   schema: S,
   req: Request,
   pathParams: PathParams
@@ -1750,8 +1750,9 @@ function validateParams<S extends ZodSchema>(
 const handler =
   (
     handler: MSWHandlers[keyof MSWHandlers],
-    paramSchema: ZodSchema | null,
-    bodySchema: ZodSchema | null
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    paramSchema: ZodType<any> | null,
+    bodySchema: ZodType | null
   ) =>
   async ({
     request: req,

--- a/app/api/__generated__/validate.ts
+++ b/app/api/__generated__/validate.ts
@@ -8,7 +8,7 @@
  * Copyright Oxide Computer Company
  */
 
-import { z, ZodType } from 'zod'
+import { z, ZodType } from 'zod/v4'
 
 import { processResponseBody, uniqueItems } from './util'
 
@@ -71,10 +71,7 @@ export const Name = z.preprocess(
     )
 )
 
-export const NameOrId = z.preprocess(
-  processResponseBody,
-  z.union([z.string().uuid(), Name])
-)
+export const NameOrId = z.preprocess(processResponseBody, z.union([z.uuid(), Name]))
 
 /**
  * An address tied to an address lot.
@@ -108,7 +105,7 @@ export const AddressLot = z.preprocess(
   processResponseBody,
   z.object({
     description: z.string(),
-    id: z.string().uuid(),
+    id: z.uuid(),
     kind: AddressLotKind,
     name: Name,
     timeCreated: z.coerce.date(),
@@ -122,9 +119,9 @@ export const AddressLot = z.preprocess(
 export const AddressLotBlock = z.preprocess(
   processResponseBody,
   z.object({
-    firstAddress: z.string().ip(),
-    id: z.string().uuid(),
-    lastAddress: z.string().ip(),
+    firstAddress: z.ipv4(),
+    id: z.uuid(),
+    lastAddress: z.ipv4(),
   })
 )
 
@@ -133,7 +130,7 @@ export const AddressLotBlock = z.preprocess(
  */
 export const AddressLotBlockCreate = z.preprocess(
   processResponseBody,
-  z.object({ firstAddress: z.string().ip(), lastAddress: z.string().ip() })
+  z.object({ firstAddress: z.ipv4(), lastAddress: z.ipv4() })
 )
 
 /**
@@ -193,10 +190,10 @@ export const AffinityGroup = z.preprocess(
   z.object({
     description: z.string(),
     failureDomain: FailureDomain,
-    id: z.string().uuid(),
+    id: z.uuid(),
     name: Name,
     policy: AffinityPolicy,
-    projectId: z.string().uuid(),
+    projectId: z.uuid(),
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
   })
@@ -215,7 +212,7 @@ export const AffinityGroupCreate = z.preprocess(
   })
 )
 
-export const TypedUuidForInstanceKind = z.preprocess(processResponseBody, z.string().uuid())
+export const TypedUuidForInstanceKind = z.preprocess(processResponseBody, z.uuid())
 
 /**
  * Running state of an Instance (primarily: booted or stopped)
@@ -283,7 +280,10 @@ export const AffinityGroupUpdate = z.preprocess(
   })
 )
 
-export const BgpMessageHistory = z.preprocess(processResponseBody, z.record(z.unknown()))
+export const BgpMessageHistory = z.preprocess(
+  processResponseBody,
+  z.record(z.string(), z.unknown())
+)
 
 /**
  * Identifies switch physical location
@@ -351,10 +351,10 @@ export const AntiAffinityGroup = z.preprocess(
   z.object({
     description: z.string(),
     failureDomain: FailureDomain,
-    id: z.string().uuid(),
+    id: z.uuid(),
     name: Name,
     policy: AffinityPolicy,
-    projectId: z.string().uuid(),
+    projectId: z.uuid(),
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
   })
@@ -453,7 +453,7 @@ export const BfdMode = z.preprocess(
  */
 export const BfdSessionDisable = z.preprocess(
   processResponseBody,
-  z.object({ remote: z.string().ip(), switch: Name })
+  z.object({ remote: z.ipv4(), switch: Name })
 )
 
 /**
@@ -463,9 +463,9 @@ export const BfdSessionEnable = z.preprocess(
   processResponseBody,
   z.object({
     detectionThreshold: z.number().min(0).max(255),
-    local: z.string().ip().nullable().optional(),
+    local: z.ipv4().nullable().optional(),
     mode: BfdMode,
-    remote: z.string().ip(),
+    remote: z.ipv4(),
     requiredRx: z.number().min(0),
     switch: Name,
   })
@@ -480,9 +480,9 @@ export const BfdStatus = z.preprocess(
   processResponseBody,
   z.object({
     detectionThreshold: z.number().min(0).max(255),
-    local: z.string().ip().nullable().optional(),
+    local: z.ipv4().nullable().optional(),
     mode: BfdMode,
-    peer: z.string().ip(),
+    peer: z.ipv4(),
     requiredRx: z.number().min(0),
     state: BfdState,
     switch: Name,
@@ -496,7 +496,7 @@ export const BgpAnnounceSet = z.preprocess(
   processResponseBody,
   z.object({
     description: z.string(),
-    id: z.string().uuid(),
+    id: z.uuid(),
     name: Name,
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
@@ -529,8 +529,8 @@ export const BgpAnnounceSetCreate = z.preprocess(
 export const BgpAnnouncement = z.preprocess(
   processResponseBody,
   z.object({
-    addressLotBlockId: z.string().uuid(),
-    announceSetId: z.string().uuid(),
+    addressLotBlockId: z.uuid(),
+    announceSetId: z.uuid(),
     network: IpNet,
   })
 )
@@ -543,7 +543,7 @@ export const BgpConfig = z.preprocess(
   z.object({
     asn: z.number().min(0).max(4294967295),
     description: z.string(),
-    id: z.string().uuid(),
+    id: z.uuid(),
     name: Name,
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
@@ -588,7 +588,7 @@ export const BgpImportedRouteIpv4 = z.preprocess(
   processResponseBody,
   z.object({
     id: z.number().min(0).max(4294967295),
-    nexthop: z.string().ip({ version: 'v4' }),
+    nexthop: z.ipv4(),
     prefix: Ipv4Net,
     switch: SwitchLocation,
   })
@@ -611,7 +611,7 @@ export const ImportExportPolicy = z.preprocess(
 export const BgpPeer = z.preprocess(
   processResponseBody,
   z.object({
-    addr: z.string().ip(),
+    addr: z.ipv4(),
     allowedExport: ImportExportPolicy,
     allowedImport: ImportExportPolicy,
     bgpConfig: NameOrId,
@@ -659,7 +659,7 @@ export const BgpPeerState = z.preprocess(
 export const BgpPeerStatus = z.preprocess(
   processResponseBody,
   z.object({
-    addr: z.string().ip(),
+    addr: z.ipv4(),
     localAsn: z.number().min(0).max(4294967295),
     remoteAsn: z.number().min(0).max(4294967295),
     state: BgpPeerState,
@@ -947,7 +947,7 @@ export const Certificate = z.preprocess(
   z.object({
     cert: z.string(),
     description: z.string(),
-    id: z.string().uuid(),
+    id: z.uuid(),
     name: Name,
     service: ServiceUsingCertificate,
     timeCreated: z.coerce.date(),
@@ -1016,8 +1016,8 @@ export const CurrentUser = z.preprocess(
   processResponseBody,
   z.object({
     displayName: z.string(),
-    id: z.string().uuid(),
-    siloId: z.string().uuid(),
+    id: z.uuid(),
+    siloId: z.uuid(),
     siloName: Name,
   })
 )
@@ -1354,12 +1354,12 @@ export const DerEncodedKeyPair = z.preprocess(
 
 export const DeviceAccessTokenRequest = z.preprocess(
   processResponseBody,
-  z.object({ clientId: z.string().uuid(), deviceCode: z.string(), grantType: z.string() })
+  z.object({ clientId: z.uuid(), deviceCode: z.string(), grantType: z.string() })
 )
 
 export const DeviceAuthRequest = z.preprocess(
   processResponseBody,
-  z.object({ clientId: z.string().uuid() })
+  z.object({ clientId: z.uuid() })
 )
 
 export const DeviceAuthVerify = z.preprocess(
@@ -1385,9 +1385,9 @@ export const DiskState = z.preprocess(
     z.object({ state: z.enum(['importing_from_bulk_writes']) }),
     z.object({ state: z.enum(['finalizing']) }),
     z.object({ state: z.enum(['maintenance']) }),
-    z.object({ instance: z.string().uuid(), state: z.enum(['attaching']) }),
-    z.object({ instance: z.string().uuid(), state: z.enum(['attached']) }),
-    z.object({ instance: z.string().uuid(), state: z.enum(['detaching']) }),
+    z.object({ instance: z.uuid(), state: z.enum(['attaching']) }),
+    z.object({ instance: z.uuid(), state: z.enum(['attached']) }),
+    z.object({ instance: z.uuid(), state: z.enum(['detaching']) }),
     z.object({ state: z.enum(['destroyed']) }),
     z.object({ state: z.enum(['faulted']) }),
   ])
@@ -1402,12 +1402,12 @@ export const Disk = z.preprocess(
     blockSize: ByteCount,
     description: z.string(),
     devicePath: z.string(),
-    id: z.string().uuid(),
-    imageId: z.string().uuid().nullable().optional(),
+    id: z.uuid(),
+    imageId: z.uuid().nullable().optional(),
     name: Name,
-    projectId: z.string().uuid(),
+    projectId: z.uuid(),
     size: ByteCount,
-    snapshotId: z.string().uuid().nullable().optional(),
+    snapshotId: z.uuid().nullable().optional(),
     state: DiskState,
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
@@ -1421,8 +1421,8 @@ export const DiskSource = z.preprocess(
   processResponseBody,
   z.union([
     z.object({ blockSize: BlockSize, type: z.enum(['blank']) }),
-    z.object({ snapshotId: z.string().uuid(), type: z.enum(['snapshot']) }),
-    z.object({ imageId: z.string().uuid(), type: z.enum(['image']) }),
+    z.object({ snapshotId: z.uuid(), type: z.enum(['snapshot']) }),
+    z.object({ imageId: z.uuid(), type: z.enum(['image']) }),
     z.object({ blockSize: BlockSize, type: z.enum(['importing_blocks']) }),
   ])
 )
@@ -1520,16 +1520,16 @@ export const EventClassResultsPage = z.preprocess(
 export const ExternalIp = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ ip: z.string().ip(), kind: z.enum(['ephemeral']) }),
+    z.object({ ip: z.ipv4(), kind: z.enum(['ephemeral']) }),
     z.object({
       description: z.string(),
-      id: z.string().uuid(),
-      instanceId: z.string().uuid().nullable().optional(),
-      ip: z.string().ip(),
-      ipPoolId: z.string().uuid(),
+      id: z.uuid(),
+      instanceId: z.uuid().nullable().optional(),
+      ip: z.ipv4(),
+      ipPoolId: z.uuid(),
       kind: z.enum(['floating']),
       name: Name,
-      projectId: z.string().uuid(),
+      projectId: z.uuid(),
       timeCreated: z.coerce.date(),
       timeModified: z.coerce.date(),
     }),
@@ -1609,8 +1609,8 @@ export const FieldValue = z.preprocess(
     z.object({ type: z.enum(['u32']), value: z.number().min(0).max(4294967295) }),
     z.object({ type: z.enum(['i64']), value: z.number() }),
     z.object({ type: z.enum(['u64']), value: z.number().min(0) }),
-    z.object({ type: z.enum(['ip_addr']), value: z.string().ip() }),
-    z.object({ type: z.enum(['uuid']), value: z.string().uuid() }),
+    z.object({ type: z.enum(['ip_addr']), value: z.ipv4() }),
+    z.object({ type: z.enum(['uuid']), value: z.uuid() }),
     z.object({ type: z.enum(['bool']), value: SafeBoolean }),
   ])
 )
@@ -1644,7 +1644,7 @@ export const IdentityType = z.preprocess(
 export const FleetRoleRoleAssignment = z.preprocess(
   processResponseBody,
   z.object({
-    identityId: z.string().uuid(),
+    identityId: z.uuid(),
     identityType: IdentityType,
     roleName: FleetRole,
   })
@@ -1667,12 +1667,12 @@ export const FloatingIp = z.preprocess(
   processResponseBody,
   z.object({
     description: z.string(),
-    id: z.string().uuid(),
-    instanceId: z.string().uuid().nullable().optional(),
-    ip: z.string().ip(),
-    ipPoolId: z.string().uuid(),
+    id: z.uuid(),
+    instanceId: z.uuid().nullable().optional(),
+    ip: z.ipv4(),
+    ipPoolId: z.uuid(),
     name: Name,
-    projectId: z.string().uuid(),
+    projectId: z.uuid(),
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
   })
@@ -1698,7 +1698,7 @@ export const FloatingIpCreate = z.preprocess(
   processResponseBody,
   z.object({
     description: z.string(),
-    ip: z.string().ip().nullable().optional(),
+    ip: z.ipv4().nullable().optional(),
     name: Name,
     pool: NameOrId.nullable().optional(),
   })
@@ -1728,7 +1728,7 @@ export const FloatingIpUpdate = z.preprocess(
  */
 export const Group = z.preprocess(
   processResponseBody,
-  z.object({ displayName: z.string(), id: z.string().uuid(), siloId: z.string().uuid() })
+  z.object({ displayName: z.string(), id: z.uuid(), siloId: z.uuid() })
 )
 
 /**
@@ -1762,7 +1762,7 @@ export const IdentityProvider = z.preprocess(
   processResponseBody,
   z.object({
     description: z.string(),
-    id: z.string().uuid(),
+    id: z.uuid(),
     name: Name,
     providerType: IdentityProviderType,
     timeCreated: z.coerce.date(),
@@ -1797,10 +1797,10 @@ export const Image = z.preprocess(
     blockSize: ByteCount,
     description: z.string(),
     digest: Digest.nullable().optional(),
-    id: z.string().uuid(),
+    id: z.uuid(),
     name: Name,
     os: z.string(),
-    projectId: z.string().uuid().nullable().optional(),
+    projectId: z.uuid().nullable().optional(),
     size: ByteCount,
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
@@ -1813,7 +1813,7 @@ export const Image = z.preprocess(
  */
 export const ImageSource = z.preprocess(
   processResponseBody,
-  z.object({ id: z.string().uuid(), type: z.enum(['snapshot']) })
+  z.object({ id: z.uuid(), type: z.enum(['snapshot']) })
 )
 
 /**
@@ -1871,14 +1871,14 @@ export const Instance = z.preprocess(
     autoRestartCooldownExpiration: z.coerce.date().nullable().optional(),
     autoRestartEnabled: SafeBoolean,
     autoRestartPolicy: InstanceAutoRestartPolicy.nullable().optional(),
-    bootDiskId: z.string().uuid().nullable().optional(),
+    bootDiskId: z.uuid().nullable().optional(),
     description: z.string(),
     hostname: z.string(),
-    id: z.string().uuid(),
+    id: z.uuid(),
     memory: ByteCount,
     name: Name,
     ncpus: InstanceCpuCount,
-    projectId: z.string().uuid(),
+    projectId: z.uuid(),
     runState: InstanceState,
     timeCreated: z.coerce.date(),
     timeLastAutoRestarted: z.coerce.date().nullable().optional(),
@@ -1911,7 +1911,7 @@ export const InstanceNetworkInterfaceCreate = z.preprocess(
   processResponseBody,
   z.object({
     description: z.string(),
-    ip: z.string().ip().nullable().optional(),
+    ip: z.ipv4().nullable().optional(),
     name: Name,
     subnetName: Name,
     vpcName: Name,
@@ -1937,8 +1937,8 @@ export const InstanceCreate = z.preprocess(
   processResponseBody,
   z.object({
     antiAffinityGroups: NameOrId.array().default([]).optional(),
-    autoRestartPolicy: InstanceAutoRestartPolicy.default(null).nullable().optional(),
-    bootDisk: InstanceDiskAttachment.default(null).nullable().optional(),
+    autoRestartPolicy: InstanceAutoRestartPolicy.nullable().default(null).optional(),
+    bootDisk: InstanceDiskAttachment.nullable().default(null).optional(),
     description: z.string(),
     disks: InstanceDiskAttachment.array().default([]).optional(),
     externalIps: ExternalIpCreate.array().default([]).optional(),
@@ -1976,17 +1976,17 @@ export const InstanceNetworkInterface = z.preprocess(
   processResponseBody,
   z.object({
     description: z.string(),
-    id: z.string().uuid(),
-    instanceId: z.string().uuid(),
-    ip: z.string().ip(),
+    id: z.uuid(),
+    instanceId: z.uuid(),
+    ip: z.ipv4(),
     mac: MacAddr,
     name: Name,
     primary: SafeBoolean,
-    subnetId: z.string().uuid(),
+    subnetId: z.uuid(),
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
     transitIps: IpNet.array().default([]).optional(),
-    vpcId: z.string().uuid(),
+    vpcId: z.uuid(),
   })
 )
 
@@ -2061,11 +2061,11 @@ export const InternetGateway = z.preprocess(
   processResponseBody,
   z.object({
     description: z.string(),
-    id: z.string().uuid(),
+    id: z.uuid(),
     name: Name,
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
-    vpcId: z.string().uuid(),
+    vpcId: z.uuid(),
   })
 )
 
@@ -2083,10 +2083,10 @@ export const InternetGatewayCreate = z.preprocess(
 export const InternetGatewayIpAddress = z.preprocess(
   processResponseBody,
   z.object({
-    address: z.string().ip(),
+    address: z.ipv4(),
     description: z.string(),
-    id: z.string().uuid(),
-    internetGatewayId: z.string().uuid(),
+    id: z.uuid(),
+    internetGatewayId: z.uuid(),
     name: Name,
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
@@ -2098,7 +2098,7 @@ export const InternetGatewayIpAddress = z.preprocess(
  */
 export const InternetGatewayIpAddressCreate = z.preprocess(
   processResponseBody,
-  z.object({ address: z.string().ip(), description: z.string(), name: Name })
+  z.object({ address: z.ipv4(), description: z.string(), name: Name })
 )
 
 /**
@@ -2119,9 +2119,9 @@ export const InternetGatewayIpPool = z.preprocess(
   processResponseBody,
   z.object({
     description: z.string(),
-    id: z.string().uuid(),
-    internetGatewayId: z.string().uuid(),
-    ipPoolId: z.string().uuid(),
+    id: z.uuid(),
+    internetGatewayId: z.uuid(),
+    ipPoolId: z.uuid(),
     name: Name,
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
@@ -2162,7 +2162,7 @@ export const IpPool = z.preprocess(
   processResponseBody,
   z.object({
     description: z.string(),
-    id: z.string().uuid(),
+    id: z.uuid(),
     name: Name,
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
@@ -2190,8 +2190,8 @@ export const IpPoolLinkSilo = z.preprocess(
 export const Ipv4Range = z.preprocess(
   processResponseBody,
   z.object({
-    first: z.string().ip({ version: 'v4' }),
-    last: z.string().ip({ version: 'v4' }),
+    first: z.ipv4(),
+    last: z.ipv4(),
   })
 )
 
@@ -2203,8 +2203,8 @@ export const Ipv4Range = z.preprocess(
 export const Ipv6Range = z.preprocess(
   processResponseBody,
   z.object({
-    first: z.string().ip({ version: 'v6' }),
-    last: z.string().ip({ version: 'v6' }),
+    first: z.ipv6(),
+    last: z.ipv6(),
   })
 )
 
@@ -2213,8 +2213,8 @@ export const IpRange = z.preprocess(processResponseBody, z.union([Ipv4Range, Ipv
 export const IpPoolRange = z.preprocess(
   processResponseBody,
   z.object({
-    id: z.string().uuid(),
-    ipPoolId: z.string().uuid(),
+    id: z.uuid(),
+    ipPoolId: z.uuid(),
     range: IpRange,
     timeCreated: z.coerce.date(),
   })
@@ -2242,9 +2242,9 @@ export const IpPoolResultsPage = z.preprocess(
 export const IpPoolSiloLink = z.preprocess(
   processResponseBody,
   z.object({
-    ipPoolId: z.string().uuid(),
+    ipPoolId: z.uuid(),
     isDefault: SafeBoolean,
-    siloId: z.string().uuid(),
+    siloId: z.uuid(),
   })
 )
 
@@ -2319,7 +2319,7 @@ export const LldpLinkConfigCreate = z.preprocess(
     enabled: SafeBoolean,
     linkDescription: z.string().nullable().optional(),
     linkName: z.string().nullable().optional(),
-    managementIp: z.string().ip().nullable().optional(),
+    managementIp: z.ipv4().nullable().optional(),
     systemDescription: z.string().nullable().optional(),
     systemName: z.string().nullable().optional(),
   })
@@ -2380,7 +2380,7 @@ export const LldpLinkConfig = z.preprocess(
   z.object({
     chassisId: z.string().nullable().optional(),
     enabled: SafeBoolean,
-    id: z.string().uuid(),
+    id: z.uuid(),
     linkDescription: z.string().nullable().optional(),
     linkName: z.string().nullable().optional(),
     managementIp: IpNet.nullable().optional(),
@@ -2392,7 +2392,7 @@ export const LldpLinkConfig = z.preprocess(
 export const NetworkAddress = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ ipAddr: z.string().ip() }),
+    z.object({ ipAddr: z.ipv4() }),
     z.object({ iEEE802: z.number().min(0).max(255).array() }),
   ])
 )
@@ -2439,9 +2439,9 @@ export const LoopbackAddress = z.preprocess(
   processResponseBody,
   z.object({
     address: IpNet,
-    addressLotBlockId: z.string().uuid(),
-    id: z.string().uuid(),
-    rackId: z.string().uuid(),
+    addressLotBlockId: z.uuid(),
+    id: z.uuid(),
+    rackId: z.uuid(),
     switchLocation: z.string(),
   })
 )
@@ -2452,11 +2452,11 @@ export const LoopbackAddress = z.preprocess(
 export const LoopbackAddressCreate = z.preprocess(
   processResponseBody,
   z.object({
-    address: z.string().ip(),
+    address: z.ipv4(),
     addressLot: NameOrId,
     anycast: SafeBoolean,
     mask: z.number().min(0).max(255),
-    rackId: z.string().uuid(),
+    rackId: z.uuid(),
     switchLocation: Name,
   })
 )
@@ -2499,9 +2499,9 @@ export const MetricType = z.preprocess(
 export const NetworkInterfaceKind = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ id: z.string().uuid(), type: z.enum(['instance']) }),
-    z.object({ id: z.string().uuid(), type: z.enum(['service']) }),
-    z.object({ id: z.string().uuid(), type: z.enum(['probe']) }),
+    z.object({ id: z.uuid(), type: z.enum(['instance']) }),
+    z.object({ id: z.uuid(), type: z.enum(['service']) }),
+    z.object({ id: z.uuid(), type: z.enum(['probe']) }),
   ])
 )
 
@@ -2516,8 +2516,8 @@ export const Vni = z.preprocess(processResponseBody, z.number().min(0).max(42949
 export const NetworkInterface = z.preprocess(
   processResponseBody,
   z.object({
-    id: z.string().uuid(),
-    ip: z.string().ip(),
+    id: z.uuid(),
+    ip: z.ipv4(),
     kind: NetworkInterfaceKind,
     mac: MacAddr,
     name: Name,
@@ -2640,11 +2640,11 @@ export const PhysicalDisk = z.preprocess(
   processResponseBody,
   z.object({
     formFactor: PhysicalDiskKind,
-    id: z.string().uuid(),
+    id: z.uuid(),
     model: z.string(),
     policy: PhysicalDiskPolicy,
     serial: z.string(),
-    sledId: z.string().uuid().nullable().optional(),
+    sledId: z.uuid().nullable().optional(),
     state: PhysicalDiskState,
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
@@ -2671,9 +2671,9 @@ export const Probe = z.preprocess(
   processResponseBody,
   z.object({
     description: z.string(),
-    id: z.string().uuid(),
+    id: z.uuid(),
     name: Name,
-    sled: z.string().uuid(),
+    sled: z.uuid(),
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
   })
@@ -2688,7 +2688,7 @@ export const ProbeCreate = z.preprocess(
     description: z.string(),
     ipPool: NameOrId.nullable().optional(),
     name: Name,
-    sled: z.string().uuid(),
+    sled: z.uuid(),
   })
 )
 
@@ -2701,7 +2701,7 @@ export const ProbeExternalIp = z.preprocess(
   processResponseBody,
   z.object({
     firstPort: z.number().min(0).max(65535),
-    ip: z.string().ip(),
+    ip: z.ipv4(),
     kind: ProbeExternalIpKind,
     lastPort: z.number().min(0).max(65535),
   })
@@ -2711,10 +2711,10 @@ export const ProbeInfo = z.preprocess(
   processResponseBody,
   z.object({
     externalIps: ProbeExternalIp.array(),
-    id: z.string().uuid(),
+    id: z.uuid(),
     interface: NetworkInterface,
     name: Name,
-    sled: z.string().uuid(),
+    sled: z.uuid(),
   })
 )
 
@@ -2733,7 +2733,7 @@ export const Project = z.preprocess(
   processResponseBody,
   z.object({
     description: z.string(),
-    id: z.string().uuid(),
+    id: z.uuid(),
     name: Name,
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
@@ -2769,7 +2769,7 @@ export const ProjectRole = z.preprocess(
 export const ProjectRoleRoleAssignment = z.preprocess(
   processResponseBody,
   z.object({
-    identityId: z.string().uuid(),
+    identityId: z.uuid(),
     identityType: IdentityType,
     roleName: ProjectRole,
   })
@@ -2802,7 +2802,7 @@ export const ProjectUpdate = z.preprocess(
 export const Rack = z.preprocess(
   processResponseBody,
   z.object({
-    id: z.string().uuid(),
+    id: z.uuid(),
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
   })
@@ -2852,7 +2852,7 @@ export const Route = z.preprocess(
   processResponseBody,
   z.object({
     dst: IpNet,
-    gw: z.string().ip(),
+    gw: z.ipv4(),
     ribPriority: z.number().min(0).max(255).nullable().optional(),
     vid: z.number().min(0).max(65535).nullable().optional(),
   })
@@ -2874,7 +2874,7 @@ export const RouteConfig = z.preprocess(
 export const RouteDestination = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ type: z.enum(['ip']), value: z.string().ip() }),
+    z.object({ type: z.enum(['ip']), value: z.ipv4() }),
     z.object({ type: z.enum(['ip_net']), value: IpNet }),
     z.object({ type: z.enum(['vpc']), value: Name }),
     z.object({ type: z.enum(['subnet']), value: Name }),
@@ -2887,7 +2887,7 @@ export const RouteDestination = z.preprocess(
 export const RouteTarget = z.preprocess(
   processResponseBody,
   z.union([
-    z.object({ type: z.enum(['ip']), value: z.string().ip() }),
+    z.object({ type: z.enum(['ip']), value: z.ipv4() }),
     z.object({ type: z.enum(['vpc']), value: Name }),
     z.object({ type: z.enum(['subnet']), value: Name }),
     z.object({ type: z.enum(['instance']), value: Name }),
@@ -2914,13 +2914,13 @@ export const RouterRoute = z.preprocess(
   z.object({
     description: z.string(),
     destination: RouteDestination,
-    id: z.string().uuid(),
+    id: z.uuid(),
     kind: RouterRouteKind,
     name: Name,
     target: RouteTarget,
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
-    vpcRouterId: z.string().uuid(),
+    vpcRouterId: z.uuid(),
   })
 )
 
@@ -2967,7 +2967,7 @@ export const SamlIdentityProvider = z.preprocess(
     acsUrl: z.string(),
     description: z.string(),
     groupAttributeName: z.string().nullable().optional(),
-    id: z.string().uuid(),
+    id: z.uuid(),
     idpEntityId: z.string(),
     name: Name,
     publicCert: z.string().nullable().optional(),
@@ -2991,7 +2991,7 @@ export const SamlIdentityProviderCreate = z.preprocess(
     idpEntityId: z.string(),
     idpMetadataSource: IdpMetadataSource,
     name: Name,
-    signingKeypair: DerEncodedKeyPair.default(null).nullable().optional(),
+    signingKeypair: DerEncodedKeyPair.nullable().default(null).optional(),
     sloUrl: z.string(),
     spClientId: z.string(),
     technicalContactEmail: z.string(),
@@ -3030,7 +3030,7 @@ export const Silo = z.preprocess(
   z.object({
     description: z.string(),
     discoverable: SafeBoolean,
-    id: z.string().uuid(),
+    id: z.uuid(),
     identityMode: SiloIdentityMode,
     mappedFleetRoles: z.record(z.string().min(1), FleetRole.array().refine(...uniqueItems)),
     name: Name,
@@ -3073,7 +3073,7 @@ export const SiloIpPool = z.preprocess(
   processResponseBody,
   z.object({
     description: z.string(),
-    id: z.string().uuid(),
+    id: z.uuid(),
     isDefault: SafeBoolean,
     name: Name,
     timeCreated: z.coerce.date(),
@@ -3097,7 +3097,7 @@ export const SiloQuotas = z.preprocess(
   z.object({
     cpus: z.number(),
     memory: ByteCount,
-    siloId: z.string().uuid(),
+    siloId: z.uuid(),
     storage: ByteCount,
   })
 )
@@ -3143,7 +3143,7 @@ export const SiloRole = z.preprocess(
 export const SiloRoleRoleAssignment = z.preprocess(
   processResponseBody,
   z.object({
-    identityId: z.string().uuid(),
+    identityId: z.uuid(),
     identityType: IdentityType,
     roleName: SiloRole,
   })
@@ -3175,7 +3175,7 @@ export const SiloUtilization = z.preprocess(
   z.object({
     allocated: VirtualResourceCounts,
     provisioned: VirtualResourceCounts,
-    siloId: z.string().uuid(),
+    siloId: z.uuid(),
     siloName: Name,
   })
 )
@@ -3224,9 +3224,9 @@ export const Sled = z.preprocess(
   processResponseBody,
   z.object({
     baseboard: Baseboard,
-    id: z.string().uuid(),
+    id: z.uuid(),
     policy: SledPolicy,
-    rackId: z.string().uuid(),
+    rackId: z.uuid(),
     state: SledState,
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
@@ -3238,7 +3238,7 @@ export const Sled = z.preprocess(
 /**
  * The unique ID of a sled.
  */
-export const SledId = z.preprocess(processResponseBody, z.object({ id: z.string().uuid() }))
+export const SledId = z.preprocess(processResponseBody, z.object({ id: z.uuid() }))
 
 /**
  * An operator's view of an instance running on a given sled
@@ -3246,10 +3246,10 @@ export const SledId = z.preprocess(processResponseBody, z.object({ id: z.string(
 export const SledInstance = z.preprocess(
   processResponseBody,
   z.object({
-    activeSledId: z.string().uuid(),
-    id: z.string().uuid(),
+    activeSledId: z.uuid(),
+    id: z.uuid(),
     memory: z.number(),
-    migrationId: z.string().uuid().nullable().optional(),
+    migrationId: z.uuid().nullable().optional(),
     name: Name,
     ncpus: z.number(),
     projectName: Name,
@@ -3304,10 +3304,10 @@ export const Snapshot = z.preprocess(
   processResponseBody,
   z.object({
     description: z.string(),
-    diskId: z.string().uuid(),
-    id: z.string().uuid(),
+    diskId: z.uuid(),
+    id: z.uuid(),
     name: Name,
-    projectId: z.string().uuid(),
+    projectId: z.uuid(),
     size: ByteCount,
     state: SnapshotState,
     timeCreated: z.coerce.date(),
@@ -3338,10 +3338,10 @@ export const SshKey = z.preprocess(
   processResponseBody,
   z.object({
     description: z.string(),
-    id: z.string().uuid(),
+    id: z.uuid(),
     name: Name,
     publicKey: z.string(),
-    siloUserId: z.string().uuid(),
+    siloUserId: z.uuid(),
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
   })
@@ -3363,10 +3363,7 @@ export const SshKeyResultsPage = z.preprocess(
   z.object({ items: SshKey.array(), nextPage: z.string().nullable().optional() })
 )
 
-export const TypedUuidForSupportBundleKind = z.preprocess(
-  processResponseBody,
-  z.string().uuid()
-)
+export const TypedUuidForSupportBundleKind = z.preprocess(processResponseBody, z.uuid())
 
 export const SupportBundleState = z.preprocess(
   processResponseBody,
@@ -3399,8 +3396,8 @@ export const Switch = z.preprocess(
   processResponseBody,
   z.object({
     baseboard: Baseboard,
-    id: z.string().uuid(),
-    rackId: z.string().uuid(),
+    id: z.uuid(),
+    rackId: z.uuid(),
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
   })
@@ -3420,10 +3417,10 @@ export const SwitchInterfaceKind2 = z.preprocess(
 export const SwitchInterfaceConfig = z.preprocess(
   processResponseBody,
   z.object({
-    id: z.string().uuid(),
+    id: z.uuid(),
     interfaceName: z.string(),
     kind: SwitchInterfaceKind2,
-    portSettingsId: z.string().uuid(),
+    portSettingsId: z.uuid(),
     v6Enabled: SafeBoolean,
   })
 )
@@ -3448,7 +3445,10 @@ export const SwitchInterfaceConfigCreate = z.preprocess(
   z.object({ kind: SwitchInterfaceKind, v6Enabled: SafeBoolean })
 )
 
-export const SwitchLinkState = z.preprocess(processResponseBody, z.record(z.unknown()))
+export const SwitchLinkState = z.preprocess(
+  processResponseBody,
+  z.record(z.string(), z.unknown())
+)
 
 /**
  * A switch port represents a physical external port on a rack switch.
@@ -3456,10 +3456,10 @@ export const SwitchLinkState = z.preprocess(processResponseBody, z.record(z.unkn
 export const SwitchPort = z.preprocess(
   processResponseBody,
   z.object({
-    id: z.string().uuid(),
+    id: z.uuid(),
     portName: z.string(),
-    portSettingsId: z.string().uuid().nullable().optional(),
-    rackId: z.string().uuid(),
+    portSettingsId: z.uuid().nullable().optional(),
+    rackId: z.uuid(),
     switchLocation: z.string(),
   })
 )
@@ -3471,9 +3471,9 @@ export const SwitchPortAddressConfig = z.preprocess(
   processResponseBody,
   z.object({
     address: IpNet,
-    addressLotBlockId: z.string().uuid(),
+    addressLotBlockId: z.uuid(),
     interfaceName: z.string(),
-    portSettingsId: z.string().uuid(),
+    portSettingsId: z.uuid(),
     vlanId: z.number().min(0).max(65535).nullable().optional(),
   })
 )
@@ -3499,7 +3499,7 @@ export const SwitchPortGeometry2 = z.preprocess(
  */
 export const SwitchPortConfig = z.preprocess(
   processResponseBody,
-  z.object({ geometry: SwitchPortGeometry2, portSettingsId: z.string().uuid() })
+  z.object({ geometry: SwitchPortGeometry2, portSettingsId: z.uuid() })
 )
 
 /**
@@ -3527,11 +3527,11 @@ export const SwitchPortLinkConfig = z.preprocess(
     autoneg: SafeBoolean,
     fec: LinkFec.nullable().optional(),
     linkName: z.string(),
-    lldpLinkConfigId: z.string().uuid().nullable().optional(),
+    lldpLinkConfigId: z.uuid().nullable().optional(),
     mtu: z.number().min(0).max(65535),
-    portSettingsId: z.string().uuid(),
+    portSettingsId: z.uuid(),
     speed: LinkSpeed,
-    txEqConfigId: z.string().uuid().nullable().optional(),
+    txEqConfigId: z.uuid().nullable().optional(),
   })
 )
 
@@ -3552,7 +3552,7 @@ export const SwitchPortRouteConfig = z.preprocess(
     dst: IpNet,
     gw: IpNet,
     interfaceName: z.string(),
-    portSettingsId: z.string().uuid(),
+    portSettingsId: z.uuid(),
     ribPriority: z.number().min(0).max(255).nullable().optional(),
     vlanId: z.number().min(0).max(65535).nullable().optional(),
   })
@@ -3565,7 +3565,7 @@ export const SwitchPortSettings = z.preprocess(
   processResponseBody,
   z.object({
     description: z.string(),
-    id: z.string().uuid(),
+    id: z.uuid(),
     name: Name,
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
@@ -3595,7 +3595,7 @@ export const SwitchPortSettingsCreate = z.preprocess(
  */
 export const SwitchPortSettingsGroups = z.preprocess(
   processResponseBody,
-  z.object({ portSettingsGroupId: z.string().uuid(), portSettingsId: z.string().uuid() })
+  z.object({ portSettingsGroupId: z.uuid(), portSettingsId: z.uuid() })
 )
 
 /**
@@ -3614,7 +3614,7 @@ export const SwitchPortSettingsResultsPage = z.preprocess(
  */
 export const SwitchVlanInterfaceConfig = z.preprocess(
   processResponseBody,
-  z.object({ interfaceConfigId: z.string().uuid(), vlanId: z.number().min(0).max(65535) })
+  z.object({ interfaceConfigId: z.uuid(), vlanId: z.number().min(0).max(65535) })
 )
 
 /**
@@ -3751,15 +3751,9 @@ export const TimeseriesSchemaResultsPage = z.preprocess(
   z.object({ items: TimeseriesSchema.array(), nextPage: z.string().nullable().optional() })
 )
 
-export const TypedUuidForWebhookEventKind = z.preprocess(
-  processResponseBody,
-  z.string().uuid()
-)
+export const TypedUuidForWebhookEventKind = z.preprocess(processResponseBody, z.uuid())
 
-export const TypedUuidForWebhookReceiverKind = z.preprocess(
-  processResponseBody,
-  z.string().uuid()
-)
+export const TypedUuidForWebhookReceiverKind = z.preprocess(processResponseBody, z.uuid())
 
 /**
  * A sled that has not been added to an initialized rack yet
@@ -3769,7 +3763,7 @@ export const UninitializedSled = z.preprocess(
   z.object({
     baseboard: Baseboard,
     cubby: z.number().min(0).max(65535),
-    rackId: z.string().uuid(),
+    rackId: z.uuid(),
   })
 )
 
@@ -3794,7 +3788,7 @@ export const UninitializedSledResultsPage = z.preprocess(
  */
 export const User = z.preprocess(
   processResponseBody,
-  z.object({ displayName: z.string(), id: z.string().uuid(), siloId: z.string().uuid() })
+  z.object({ displayName: z.string(), id: z.uuid(), siloId: z.uuid() })
 )
 
 /**
@@ -3806,7 +3800,7 @@ export const UserBuiltin = z.preprocess(
   processResponseBody,
   z.object({
     description: z.string(),
-    id: z.string().uuid(),
+    id: z.uuid(),
     name: Name,
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
@@ -3888,11 +3882,11 @@ export const Vpc = z.preprocess(
   z.object({
     description: z.string(),
     dnsName: Name,
-    id: z.string().uuid(),
+    id: z.uuid(),
     ipv6Prefix: Ipv6Net,
     name: Name,
-    projectId: z.string().uuid(),
-    systemRouterId: z.string().uuid(),
+    projectId: z.uuid(),
+    systemRouterId: z.uuid(),
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
   })
@@ -3930,7 +3924,7 @@ export const VpcFirewallRuleHostFilter = z.preprocess(
     z.object({ type: z.enum(['vpc']), value: Name }),
     z.object({ type: z.enum(['subnet']), value: Name }),
     z.object({ type: z.enum(['instance']), value: Name }),
-    z.object({ type: z.enum(['ip']), value: z.string().ip() }),
+    z.object({ type: z.enum(['ip']), value: z.ipv4() }),
     z.object({ type: z.enum(['ip_net']), value: IpNet }),
   ])
 )
@@ -3969,7 +3963,7 @@ export const VpcFirewallRuleTarget = z.preprocess(
     z.object({ type: z.enum(['vpc']), value: Name }),
     z.object({ type: z.enum(['subnet']), value: Name }),
     z.object({ type: z.enum(['instance']), value: Name }),
-    z.object({ type: z.enum(['ip']), value: z.string().ip() }),
+    z.object({ type: z.enum(['ip']), value: z.ipv4() }),
     z.object({ type: z.enum(['ip_net']), value: IpNet }),
   ])
 )
@@ -3984,14 +3978,14 @@ export const VpcFirewallRule = z.preprocess(
     description: z.string(),
     direction: VpcFirewallRuleDirection,
     filters: VpcFirewallRuleFilter,
-    id: z.string().uuid(),
+    id: z.uuid(),
     name: Name,
     priority: z.number().min(0).max(65535),
     status: VpcFirewallRuleStatus,
     targets: VpcFirewallRuleTarget.array(),
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
-    vpcId: z.string().uuid(),
+    vpcId: z.uuid(),
   })
 )
 
@@ -4045,12 +4039,12 @@ export const VpcRouter = z.preprocess(
   processResponseBody,
   z.object({
     description: z.string(),
-    id: z.string().uuid(),
+    id: z.uuid(),
     kind: VpcRouterKind,
     name: Name,
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
-    vpcId: z.string().uuid(),
+    vpcId: z.uuid(),
   })
 )
 
@@ -4087,15 +4081,15 @@ export const VpcRouterUpdate = z.preprocess(
 export const VpcSubnet = z.preprocess(
   processResponseBody,
   z.object({
-    customRouterId: z.string().uuid().nullable().optional(),
+    customRouterId: z.uuid().nullable().optional(),
     description: z.string(),
-    id: z.string().uuid(),
+    id: z.uuid(),
     ipv4Block: Ipv4Net,
     ipv6Block: Ipv6Net,
     name: Name,
     timeCreated: z.coerce.date(),
     timeModified: z.coerce.date(),
-    vpcId: z.string().uuid(),
+    vpcId: z.uuid(),
   })
 )
 
@@ -4222,7 +4216,7 @@ export const WebhookDelivery = z.preprocess(
     attempts: WebhookDeliveryAttempt.array(),
     eventClass: z.string(),
     eventId: TypedUuidForWebhookEventKind,
-    id: z.string().uuid(),
+    id: z.uuid(),
     state: WebhookDeliveryState,
     timeStarted: z.coerce.date(),
     trigger: WebhookDeliveryTrigger,
@@ -4232,7 +4226,7 @@ export const WebhookDelivery = z.preprocess(
 
 export const WebhookDeliveryId = z.preprocess(
   processResponseBody,
-  z.object({ deliveryId: z.string().uuid() })
+  z.object({ deliveryId: z.uuid() })
 )
 
 /**
@@ -4261,7 +4255,7 @@ export const WebhookProbeResult = z.preprocess(
  */
 export const WebhookSecret = z.preprocess(
   processResponseBody,
-  z.object({ id: z.string().uuid(), timeCreated: z.coerce.date() })
+  z.object({ id: z.uuid(), timeCreated: z.coerce.date() })
 )
 
 /**
@@ -4272,7 +4266,7 @@ export const WebhookReceiver = z.preprocess(
   z.object({
     description: z.string(),
     endpoint: z.string(),
-    id: z.string().uuid(),
+    id: z.uuid(),
     name: Name,
     secrets: WebhookSecret.array(),
     subscriptions: WebhookSubscription.array(),
@@ -4467,7 +4461,7 @@ export const SupportBundleViewParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({
-      supportBundle: z.string().uuid(),
+      supportBundle: z.uuid(),
     }),
     query: z.object({}),
   })
@@ -4477,7 +4471,7 @@ export const SupportBundleDeleteParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({
-      supportBundle: z.string().uuid(),
+      supportBundle: z.uuid(),
     }),
     query: z.object({}),
   })
@@ -4487,7 +4481,7 @@ export const SupportBundleDownloadParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({
-      supportBundle: z.string().uuid(),
+      supportBundle: z.uuid(),
     }),
     query: z.object({}),
   })
@@ -4497,7 +4491,7 @@ export const SupportBundleHeadParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({
-      supportBundle: z.string().uuid(),
+      supportBundle: z.uuid(),
     }),
     query: z.object({}),
   })
@@ -4508,7 +4502,7 @@ export const SupportBundleDownloadFileParams = z.preprocess(
   z.object({
     path: z.object({
       file: z.string(),
-      supportBundle: z.string().uuid(),
+      supportBundle: z.uuid(),
     }),
     query: z.object({}),
   })
@@ -4519,7 +4513,7 @@ export const SupportBundleHeadFileParams = z.preprocess(
   z.object({
     path: z.object({
       file: z.string(),
-      supportBundle: z.string().uuid(),
+      supportBundle: z.uuid(),
     }),
     query: z.object({}),
   })
@@ -4529,7 +4523,7 @@ export const SupportBundleIndexParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({
-      supportBundle: z.string().uuid(),
+      supportBundle: z.uuid(),
     }),
     query: z.object({}),
   })
@@ -5024,7 +5018,7 @@ export const GroupViewParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({
-      groupId: z.string().uuid(),
+      groupId: z.uuid(),
     }),
     query: z.object({}),
   })
@@ -5818,7 +5812,7 @@ export const PhysicalDiskViewParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({
-      diskId: z.string().uuid(),
+      diskId: z.uuid(),
     }),
     query: z.object({}),
   })
@@ -5829,7 +5823,7 @@ export const NetworkingSwitchPortLldpNeighborsParams = z.preprocess(
   z.object({
     path: z.object({
       port: Name,
-      rackId: z.string().uuid(),
+      rackId: z.uuid(),
       switchLocation: Name,
     }),
     query: z.object({
@@ -5856,7 +5850,7 @@ export const RackViewParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({
-      rackId: z.string().uuid(),
+      rackId: z.uuid(),
     }),
     query: z.object({}),
   })
@@ -5886,7 +5880,7 @@ export const SledViewParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({
-      sledId: z.string().uuid(),
+      sledId: z.uuid(),
     }),
     query: z.object({}),
   })
@@ -5896,7 +5890,7 @@ export const SledPhysicalDiskListParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({
-      sledId: z.string().uuid(),
+      sledId: z.uuid(),
     }),
     query: z.object({
       limit: z.number().min(1).max(4294967295).nullable().optional(),
@@ -5910,7 +5904,7 @@ export const SledInstanceListParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({
-      sledId: z.string().uuid(),
+      sledId: z.uuid(),
     }),
     query: z.object({
       limit: z.number().min(1).max(4294967295).nullable().optional(),
@@ -5924,7 +5918,7 @@ export const SledSetProvisionPolicyParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({
-      sledId: z.string().uuid(),
+      sledId: z.uuid(),
     }),
     query: z.object({}),
   })
@@ -5949,7 +5943,7 @@ export const NetworkingSwitchPortListParams = z.preprocess(
       limit: z.number().min(1).max(4294967295).nullable().optional(),
       pageToken: z.string().nullable().optional(),
       sortBy: IdSortMode.optional(),
-      switchPortId: z.string().uuid().nullable().optional(),
+      switchPortId: z.uuid().nullable().optional(),
     }),
   })
 )
@@ -5961,7 +5955,7 @@ export const NetworkingSwitchPortLldpConfigViewParams = z.preprocess(
       port: Name,
     }),
     query: z.object({
-      rackId: z.string().uuid(),
+      rackId: z.uuid(),
       switchLocation: Name,
     }),
   })
@@ -5974,7 +5968,7 @@ export const NetworkingSwitchPortLldpConfigUpdateParams = z.preprocess(
       port: Name,
     }),
     query: z.object({
-      rackId: z.string().uuid(),
+      rackId: z.uuid(),
       switchLocation: Name,
     }),
   })
@@ -5987,7 +5981,7 @@ export const NetworkingSwitchPortApplySettingsParams = z.preprocess(
       port: Name,
     }),
     query: z.object({
-      rackId: z.string().uuid(),
+      rackId: z.uuid(),
       switchLocation: Name,
     }),
   })
@@ -6000,7 +5994,7 @@ export const NetworkingSwitchPortClearSettingsParams = z.preprocess(
       port: Name,
     }),
     query: z.object({
-      rackId: z.string().uuid(),
+      rackId: z.uuid(),
       switchLocation: Name,
     }),
   })
@@ -6013,7 +6007,7 @@ export const NetworkingSwitchPortStatusParams = z.preprocess(
       port: Name,
     }),
     query: z.object({
-      rackId: z.string().uuid(),
+      rackId: z.uuid(),
       switchLocation: Name,
     }),
   })
@@ -6035,7 +6029,7 @@ export const SwitchViewParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({
-      switchId: z.string().uuid(),
+      switchId: z.uuid(),
     }),
     query: z.object({}),
   })
@@ -6068,7 +6062,7 @@ export const LocalIdpUserDeleteParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({
-      userId: z.string().uuid(),
+      userId: z.uuid(),
     }),
     query: z.object({
       silo: NameOrId,
@@ -6080,7 +6074,7 @@ export const LocalIdpUserSetPasswordParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({
-      userId: z.string().uuid(),
+      userId: z.uuid(),
     }),
     query: z.object({
       silo: NameOrId,
@@ -6515,8 +6509,8 @@ export const NetworkingLoopbackAddressDeleteParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({
-      address: z.string().ip(),
-      rackId: z.string().uuid(),
+      address: z.ipv4(),
+      rackId: z.uuid(),
       subnetMask: z.number().min(0).max(255),
       switchLocation: Name,
     }),
@@ -6760,7 +6754,7 @@ export const SiloUserViewParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({
-      userId: z.string().uuid(),
+      userId: z.uuid(),
     }),
     query: z.object({
       silo: NameOrId,
@@ -6827,7 +6821,7 @@ export const UserListParams = z.preprocess(
   z.object({
     path: z.object({}),
     query: z.object({
-      group: z.string().uuid().nullable().optional(),
+      group: z.uuid().nullable().optional(),
       limit: z.number().min(1).max(4294967295).nullable().optional(),
       pageToken: z.string().nullable().optional(),
       sortBy: IdSortMode.optional(),
@@ -7157,7 +7151,7 @@ export const WebhookDeliveryResendParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({
-      eventId: z.string().uuid(),
+      eventId: z.uuid(),
     }),
     query: z.object({
       receiver: NameOrId,
@@ -7284,7 +7278,7 @@ export const WebhookSecretsDeleteParams = z.preprocess(
   processResponseBody,
   z.object({
     path: z.object({
-      secretId: z.string().uuid(),
+      secretId: z.uuid(),
     }),
     query: z.object({}),
   })

--- a/mock-api/snapshot.ts
+++ b/mock-api/snapshot.ts
@@ -77,7 +77,7 @@ export const snapshots: Json<Snapshot>[] = [
     state: 'ready',
   },
   {
-    id: '7fc6ca11-452e-d3e4-9e1c-752ff615abea',
+    id: '75832119-7d9b-4e91-a7c6-76b996b69aaa',
     name: 'snapshot-heavy',
     description: '',
     project_id: project.id,

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "tunnel-rat": "^0.1.2",
         "use-debounce": "^10.0.4",
         "uuid": "^10.0.0",
-        "zod": "^3.24.3",
+        "zod": "^3.25.3",
         "zustand": "^5.0.3"
       },
       "devDependencies": {
@@ -15142,9 +15142,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.3.tgz",
-      "integrity": "sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==",
+      "version": "3.25.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.3.tgz",
+      "integrity": "sha512-VGZqnyYNrl8JpEJRZaFPqeVNIuqgXNu4cXZ5cOb6zEUO1OxKbRnWB4UdDIXMmiERWncs0yDQukssHov8JUxykQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "tunnel-rat": "^0.1.2",
     "use-debounce": "^10.0.4",
     "uuid": "^10.0.0",
-    "zod": "^3.24.3",
+    "zod": "^3.25.3",
     "zustand": "^5.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
https://zod.dev/v4

Was curious how the Zod v4 migration would look, so I tried it and it turned out to be easy enough that I finished it. This will remain a draft for now because we need to upgrade [oxide.ts](https://github.com/oxidecomputer/oxide.ts) to do automatically what I've done here by hand in the generated code:

- `z.string().uuid()` -> `z.uuid()`
- `z.string().ip()` -> `z.ipv4()` or a union of v4 and v6
- `z.record(X)` -> `z.record(z.string(), X)` (they got rid of the single-arg shorthand)
- Put `.nullable()` before `.default(null)` so `default` knows it can take `null`