### PR TITLE
Move IP Address column in Internet Gateways table

### DIFF
--- a/app/pages/project/vpcs/VpcGatewaysTab.tsx
+++ b/app/pages/project/vpcs/VpcGatewaysTab.tsx
@@ -69,17 +69,15 @@ export async function clientLoader({ params }: LoaderFunctionArgs) {
 
   await Promise.all([
     ...gateways.items.flatMap((gateway: InternetGateway) => [
-      queryClient.prefetchQuery(
+      queryClient.fetchQuery(
         gatewayIpAddressList({ project, vpc, gateway: gateway.name }).optionsFn()
       ),
-      queryClient.prefetchQuery(
+      queryClient.fetchQuery(
         gatewayIpPoolList({ project, vpc, gateway: gateway.name }).optionsFn()
       ),
     ]),
     ...routers.items.map((router) =>
-      queryClient.prefetchQuery(
-        routeList({ project, vpc, router: router.name }).optionsFn()
-      )
+      queryClient.fetchQuery(routeList({ project, vpc, router: router.name }).optionsFn())
     ),
     queryClient.fetchQuery(projectIpPoolList.optionsFn()).then((pools) => {
       for (const pool of pools.items) {
@@ -94,7 +92,7 @@ export async function clientLoader({ params }: LoaderFunctionArgs) {
 
 export const AttachedIpAddressHeader = () => (
   <>
-    attached IP address
+    Attached IP Address
     <TipIcon className="ml-1.5">
       Internet gateways without an IP address attached will use an address from the attached
       IP pool


### PR DESCRIPTION
This moves the `Attached IP Address` column to come after the `Attached IP Pool` column, and adds a header with explanatory text.
<img width="1272" alt="Screenshot 2025-06-16 at 2 47 55 PM" src="https://github.com/user-attachments/assets/a25980b2-db87-42a7-8a2b-a3b9dae1a53e" />

Relates to #2831, but, per Crespo's comments below, does not fully address the root issue.