### PR TITLE
Show size of attached disks in mini table

### DIFF
--- a/app/components/form/fields/DisksTableField.tsx
+++ b/app/components/form/fields/DisksTableField.tsx
@@ -8,12 +8,11 @@
 import { useState } from 'react'
 import { useController, type Control } from 'react-hook-form'
 
-import type { Disk, DiskCreate } from '@oxide/api'
+import type { DiskCreate } from '@oxide/api'
 
 import { AttachDiskModalForm } from '~/forms/disk-attach'
 import { CreateDiskSideModalForm } from '~/forms/disk-create'
 import type { InstanceCreateInput } from '~/forms/instance-create'
-import { EmptyCell } from '~/table/cells/EmptyCell'
 import { sizeCellInner } from '~/table/columns/common'
 import { Badge } from '~/ui/lib/Badge'
 import { Button } from '~/ui/lib/Button'
@@ -32,12 +31,10 @@ export function DisksTableField({
   control,
   disabled,
   unavailableDiskNames,
-  allDisks,
 }: {
   control: Control<InstanceCreateInput>
   disabled: boolean
   unavailableDiskNames: string[]
-  allDisks: Disk[]
 }) {
   const [showDiskCreate, setShowDiskCreate] = useState(false)
   const [showDiskAttach, setShowDiskAttach] = useState(false)
@@ -63,7 +60,7 @@ export function DisksTableField({
             },
             {
               header: 'Size',
-              cell: (item) => (item.size ? sizeCellInner(item.size) : <EmptyCell />),
+              cell: (item) => sizeCellInner(item.size),
             },
           ]}
           rowKey={(item) => item.name}
@@ -100,11 +97,8 @@ export function DisksTableField({
       {showDiskAttach && (
         <AttachDiskModalForm
           onDismiss={() => setShowDiskAttach(false)}
-          onSubmit={({ name }: { name: string }) => {
-            onChange([
-              ...items,
-              { name, type: 'attach', size: allDisks.find((d) => d.name === name)?.size },
-            ])
+          onSubmit={({ name, size }: { name: string; size: number }) => {
+            onChange([...items, { type: 'attach', name, size } satisfies DiskTableItem])
             setShowDiskAttach(false)
           }}
           diskNamesToExclude={items.filter((i) => i.type === 'attach').map((i) => i.name)}

--- a/app/forms/disk-attach.tsx
+++ b/app/forms/disk-attach.tsx
@@ -20,7 +20,7 @@ const defaultValues = { name: '' }
 
 type AttachDiskProps = {
   /** If defined, this overrides the usual mutation */
-  onSubmit: (diskAttach: { name: string }) => void
+  onSubmit: (diskAttach: { name: string; size: number }) => void
   onDismiss: () => void
   diskNamesToExclude?: string[]
   loading?: boolean
@@ -64,7 +64,13 @@ export function AttachDiskModalForm({
       submitError={submitError}
       loading={loading}
       title="Attach disk"
-      onSubmit={onSubmit}
+      onSubmit={({ name }) => {
+        // because the ComboboxField is required and does not allow arbitrary
+        // values (values not in the list of disks), we can only get here if the
+        // disk is defined and in the list
+        const disk = data!.items.find((d) => d.name === name)!
+        onSubmit({ name, size: disk.size })
+      }}
     >
       <ComboboxField
         label="Disk name"

--- a/app/forms/instance-create.tsx
+++ b/app/forms/instance-create.tsx
@@ -586,7 +586,6 @@ export default function CreateInstanceForm() {
           // Don't allow the user to create a new disk with a name that matches other disk names (either the boot disk,
           // the names of disks that will be created and attached to this instance, or disks that already exist).
           unavailableDiskNames={[bootDiskName, ...unavailableDiskNames]}
-          allDisks={allDisks}
         />
         <FormDivider />
         <Form.Heading id="authentication">Authentication</Form.Heading>

--- a/app/forms/instance-create.tsx
+++ b/app/forms/instance-create.tsx
@@ -586,6 +586,7 @@ export default function CreateInstanceForm() {
           // Don't allow the user to create a new disk with a name that matches other disk names (either the boot disk,
           // the names of disks that will be created and attached to this instance, or disks that already exist).
           unavailableDiskNames={[bootDiskName, ...unavailableDiskNames]}
+          allDisks={allDisks}
         />
         <FormDivider />
         <Form.Heading id="authentication">Authentication</Form.Heading>

--- a/test/e2e/instance-create.e2e.ts
+++ b/test/e2e/instance-create.e2e.ts
@@ -597,7 +597,7 @@ test('create instance with additional disks', async ({ page }) => {
   await selectOption(page, 'Disk name', 'disk-3')
   await page.getByRole('button', { name: 'Attach disk' }).click()
 
-  await expectRowVisible(disksTable, { Name: 'disk-3', Type: 'attach', Size: '—' })
+  await expectRowVisible(disksTable, { Name: 'disk-3', Type: 'attach', Size: '6 GiB' })
 
   // Create the instance
   await page.getByRole('button', { name: 'Create instance' }).click()


### PR DESCRIPTION
This adds in a fix for #1662, where we aren't showing the size of the _attached_ disks in the disks minitable.

As this isn't necessary for the `data-minitable` branch, I'm happy to wait until that branch is merged and I can merge this to main, but if you want to include it in the branch, it's available.

<img width="527" alt="Screenshot 2025-06-29 at 9 11 24 AM" src="https://github.com/user-attachments/assets/62337ca5-a78a-4324-b2b9-4cfc57bb478d" />

Closes #1662.