### PR TITLE
Try to reduce serial console test flake

### DIFF
--- a/mock-api/msw/handlers.ts
+++ b/mock-api/msw/handlers.ts
@@ -585,13 +585,15 @@ export const handlers = makeHandlers({
       auto_restart_enabled: true,
     }
 
-    setTimeout(() => {
-      newInstance.run_state = 'starting'
-    }, 1000)
+    if (body.start) {
+      setTimeout(() => {
+        newInstance.run_state = 'starting'
+      }, 1500)
 
-    setTimeout(() => {
-      newInstance.run_state = 'running'
-    }, 4000)
+      setTimeout(() => {
+        newInstance.run_state = 'running'
+      }, 4000)
+    }
 
     db.instances.push(newInstance)
 


### PR DESCRIPTION
Increase time instance sits in `creating` before starting from 1 to 1.5 seconds. Aimed at #2781, which we are still seeing too often: https://github.com/oxidecomputer/console/actions/runs/15978180728/job/45066018854

I also noticed that we are not conditioning mock instance start on whether `start` is true in the request body, so I fixed that here.