### PR TITLE
Bump max instance RAM to 1536 GiB

### DIFF
--- a/app/api/util.ts
+++ b/app/api/util.ts
@@ -23,17 +23,17 @@ import type {
   VpcFirewallRuleUpdate,
 } from './__generated__/Api'
 
-// API limits encoded in https://github.com/oxidecomputer/omicron/blob/b7af5f8e/nexus/src/app/mod.rs
+// API limits encoded in https://github.com/oxidecomputer/omicron/blob/aec3cd8d/nexus/src/app/mod.rs
 
 export const MAX_NICS_PER_INSTANCE = 8
 
 export const INSTANCE_MAX_CPU = 64
 export const INSTANCE_MIN_RAM_GiB = 1
-export const INSTANCE_MAX_RAM_GiB = 1024
+export const INSTANCE_MAX_RAM_GiB = 1536
 
 export const MIN_DISK_SIZE_GiB = 1
 /**
- * Disk size limited to 1023  as that's the maximum we can safely allocate right now
+ * Disk size limited to 1023 as that's the maximum we can safely allocate right now
  * @see https://github.com/oxidecomputer/omicron/issues/3212#issuecomment-1634497344
  */
 export const MAX_DISK_SIZE_GiB = 1023

--- a/test/e2e/instance-create.e2e.ts
+++ b/test/e2e/instance-create.e2e.ts
@@ -634,12 +634,12 @@ test('Validate CPU and RAM', async ({ page }) => {
   // make sure it's not clamping the value
   await expect(cpu).toHaveValue('999')
 
-  await memory.fill('1025')
+  await memory.fill('1537')
 
   const submitButton = page.getByRole('button', { name: 'Create instance' })
 
   const cpuMsg = page.getByText('Can be at most 64').first()
-  const memMsg = page.getByText('Can be at most 1024 GiB').first()
+  const memMsg = page.getByText('Can be at most 1536 GiB').first()
 
   await expect(cpuMsg).toBeHidden()
   await expect(memMsg).toBeHidden()


### PR DESCRIPTION
Since https://github.com/oxidecomputer/omicron/pull/8527 the control plane has been happy to accept such sizes.