### PR TITLE
Upgrade to client generator 0.8.1 to test changes

### DIFF
--- a/app/api/__generated__/Api.ts
+++ b/app/api/__generated__/Api.ts
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 /**
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -7,6 +5,8 @@
  *
  * Copyright Oxide Computer Company
  */
+
+/* eslint-disable */
 
 import { HttpClient, toQueryString, type FetchParams } from './http-client'
 

--- a/app/api/__generated__/validate.ts
+++ b/app/api/__generated__/validate.ts
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 /**
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -7,6 +5,8 @@
  *
  * Copyright Oxide Computer Company
  */
+
+/* eslint-disable */
 
 import { z, ZodType } from 'zod'
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
       "devDependencies": {
         "@ianvs/prettier-plugin-sort-imports": "^4.4.1",
         "@mswjs/http-middleware": "^0.10.3",
-        "@oxide/openapi-gen-ts": "~0.7.0",
+        "@oxide/openapi-gen-ts": "~0.8.1",
         "@playwright/test": "^1.54.1",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -1573,9 +1573,9 @@
       }
     },
     "node_modules/@oxide/openapi-gen-ts": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@oxide/openapi-gen-ts/-/openapi-gen-ts-0.7.0.tgz",
-      "integrity": "sha512-5pFEUC+BCmVbQsAUIhWIPFhWwdteBNaH8nGYGf0ufap/6HpRLpqyqAMNOD2THUw64wMDYKDrAjpMNUuY0u4LFg==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@oxide/openapi-gen-ts/-/openapi-gen-ts-0.8.1.tgz",
+      "integrity": "sha512-2U9n2qFOemfVm8mAxkgmCLvQL43OXggyvZybjSN9q54WxLgXz3Wl3pG73+mHgXVpfNsBOvrCEscZf/gy4iS1cQ==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^4.4.1",
     "@mswjs/http-middleware": "^0.10.3",
-    "@oxide/openapi-gen-ts": "~0.7.0",
+    "@oxide/openapi-gen-ts": "~0.8.1",
     "@playwright/test": "^1.54.1",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",

--- a/tools/generate_api_client.sh
+++ b/tools/generate_api_client.sh
@@ -14,8 +14,25 @@ GEN_DIR="$PWD/app/api/__generated__"
 
 SPEC_URL="https://raw.githubusercontent.com/oxidecomputer/omicron/$OMICRON_SHA/openapi/nexus.json"
 
+HEADER=$(cat <<'EOF'
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
+ */
+
+EOF)
+
 # use versions of these packages specified in dev deps
 npm run openapi-gen-ts -- $SPEC_URL $GEN_DIR --features msw
+
+for f in Api.ts msw-handlers.ts validate.ts; do
+  (printf '%s\n\n' "$HEADER"; cat "$GEN_DIR/$f") > "$GEN_DIR/$f.tmp"
+  mv "$GEN_DIR/$f.tmp" "$GEN_DIR/$f"
+done
+
 npm run prettier -- --write --log-level error "$GEN_DIR"
 
 cat > $GEN_DIR/OMICRON_VERSION <<EOF


### PR DESCRIPTION
Confirming changes to license headers in https://github.com/oxidecomputer/oxide.ts/pull/297 are solid. We now have to prepend our own headers on the generated files.