### PR TITLE
Update arbitrary combobox value automatically without requiring confirmation

### DIFF
--- a/app/ui/lib/Combobox.tsx
+++ b/app/ui/lib/Combobox.tsx
@@ -151,8 +151,6 @@ export const Combobox = ({
       value={selectedItemValue}
       // fallback to '' allows clearing field to work
       onChange={(val) => onChange(val || '')}
-      // we only want to keep the query on close when arbitrary values are allowed
-      onClose={allowArbitraryValues ? undefined : () => setQuery('')}
       disabled={disabled || isLoading}
       immediate
       {...props}


### PR DESCRIPTION
Currently you are required to hit enter or click on the custom option to apply the arbitrary value with a combobox. This is confusing and the better behaviour is just to assume the user wants the custom value regardless.

Just a patch for now, the bigger rework as per #2857 will help make this even clearer. Only affects firewall rule forms for now, since that's the only place that allows arbitrary combobox values.