### PR TITLE
Prevent event bubbling on copy-to-clipboard clicks

### DIFF
--- a/app/ui/lib/CopyToClipboard.tsx
+++ b/app/ui/lib/CopyToClipboard.tsx
@@ -36,7 +36,6 @@ export const CopyToClipboard = ({
   useTimeout(() => setHasCopied(false), hasCopied ? 2000 : null)
 
   const handleCopy = (event: React.MouseEvent) => {
-    event.preventDefault()
     event.stopPropagation()
     window.navigator.clipboard.writeText(text).then(() => {
       setHasCopied(true)


### PR DESCRIPTION
On #2860, I noticed that clicking the copy buttons was opening the JSON viewer for each row, because the CopyToClipboard component isn't capturing the event bubbling. This fixes that.