### PR TITLE
metrics: handle varying ncpu within a query.

### DIFF
--- a/app/components/oxql-metrics/OxqlMetric.tsx
+++ b/app/components/oxql-metrics/OxqlMetric.tsx
@@ -72,17 +72,16 @@ export function OxqlMetric({ title, description, unit, ...queryObj }: OxqlMetric
   const hasError = !!error && !errorMeansEmpty
 
   const { startTime, endTime } = queryObj
-  const { chartData, timeseriesCount } = useMemo(
-    () =>
-      errorMeansEmpty ? { chartData: [], timeseriesCount: 0 } : composeOxqlData(metrics),
+  const { chartData, valueCounts } = useMemo(
+    () => (errorMeansEmpty ? { chartData: [], valueCounts: [] } : composeOxqlData(metrics)),
     [metrics, errorMeansEmpty]
   )
 
   const { data, label, unitForSet, yAxisTickFormatter } = useMemo(() => {
     if (unit === 'Bytes') return getBytesChartProps(chartData)
     if (unit === 'Count') return getCountChartProps(chartData)
-    return getUtilizationChartProps(chartData, timeseriesCount)
-  }, [unit, chartData, timeseriesCount])
+    return getUtilizationChartProps(chartData, valueCounts)
+  }, [unit, chartData, valueCounts])
 
   const [modalOpen, setModalOpen] = useState(false)
 


### PR DESCRIPTION
The metrics dashboards assume that queries return a consistent number of series
over time. For example, if a query for cpu utilization gets four timeseries at
one timepoint, it shouldhave four timeseries at all timepoints. However, this
assumption isn't met when the cardinality of the given resource changes over
time, such as when the user scales the number of vcpus for an instance. This
assumption leads to two bugs:

* If the number of vcpus changes within a query, we normalize by the largest
  observed vcpu count. In other words, increasing the number vcpus makes
  utilization appear lower at timepoints prior to the scaling event.
* If a user scales up the number of vcpus such that the 0th vcpu timeseries has
  fewer timepoints than subsequent timeseries, we truncate series after the
  0th.

This patch attempts to fix both bugs. First, we count the number of non-null
values per timeseries to normalize cpu use. Second, we consider all timestamps
from all returned series so that we don't accidentally truncate the results.