### PR TITLE
Use v4.0.2 design system

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@floating-ui/react": "^0.26.23",
         "@headlessui/react": "^2.2.9",
-        "@oxide/design-system": "^4.0.0--canary.151.18511380774.0",
+        "@oxide/design-system": "^4.0.2",
         "@radix-ui/react-accordion": "^1.2.0",
         "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-tabs": "^1.1.0",
@@ -1487,9 +1487,9 @@
       "license": "MIT"
     },
     "node_modules/@oxide/design-system": {
-      "version": "4.0.0--canary.151.18511380774.0",
-      "resolved": "https://registry.npmjs.org/@oxide/design-system/-/design-system-4.0.0--canary.151.18511380774.0.tgz",
-      "integrity": "sha512-Qr/2xWI9oNx7yA3xGX+4GnF7eK34kV6fYCj7Ptyi6y0JNBc6EaSycW/EeYMELB38vFyMBcK1LuiHC6u+y4IY0A==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@oxide/design-system/-/design-system-4.0.2.tgz",
+      "integrity": "sha512-DQd/nhUj1vMnPMeEWA5Vp4wec7mdXvud+OdxxP0apknOpifnJRZoE8XdUdO0iVWpCefnnL4xceiRMPwQRdYpEA==",
       "license": "MPL 2.0",
       "dependencies": {
         "@floating-ui/react": "^0.27.16",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@floating-ui/react": "^0.26.23",
     "@headlessui/react": "^2.2.9",
-    "@oxide/design-system": "^4.0.0--canary.151.18511380774.0",
+    "@oxide/design-system": "^4.0.2",
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-tabs": "^1.1.0",


### PR DESCRIPTION
After some NPM shenanigans, finally got a non-canary design system release.