### PR TITLE
remove underlines in Firewall Rule messages

### DIFF
--- a/app/forms/firewall-rules-common.tsx
+++ b/app/forms/firewall-rules-common.tsx
@@ -626,8 +626,8 @@ export const CommonFields = ({ control, nameTaken, error }: CommonFieldsProps) =
               apply the rule to traffic going to all matching instances.
             </p>
             <p className="mt-2">
-              Targets are additive: the rule applies to instances matching{' '}
-              <span className="underline">any</span> target.
+              Targets are additive: the rule applies to instances matching <em>any</em>{' '}
+              target.
             </p>
           </>
         }
@@ -643,7 +643,7 @@ export const CommonFields = ({ control, nameTaken, error }: CommonFieldsProps) =
             Filters reduce the scope of this rule. Without filters, the rule applies to all
             traffic to the targets (or from the targets, if it&rsquo;s an outbound rule).
             With multiple filter types, the rule applies to traffic matching at least one
-            filter of <span className="underline">every</span> type.
+            filter of <em>every</em> type.
           </>
         }
       />


### PR DESCRIPTION
Small tweak to move from underlines to italics so they don't look like links.
<img width="462" height="160" alt="Screenshot 2025-10-28 at 2 02 11 PM" src="https://github.com/user-attachments/assets/3bea5e26-c5cd-4e59-9a1a-e292e6dff77b" />
<img width="457" height="133" alt="Screenshot 2025-10-28 at 2 02 28 PM" src="https://github.com/user-attachments/assets/85ff5b6c-03ba-43b0-9ad8-4457dae2415d" />

Closes #2944 