### PR TITLE
minor: fix HL color inside `Message`

### DIFF
--- a/app/components/HL.tsx
+++ b/app/components/HL.tsx
@@ -14,4 +14,5 @@ export const HL = classed.span`
   group-[.text-accent-secondary]:text-accent
   group-[.text-error-secondary]:text-error
   group-[.text-info-secondary]:text-info
+  group-[.text-notice-secondary]:text-notice
 `

--- a/app/ui/lib/Message.tsx
+++ b/app/ui/lib/Message.tsx
@@ -86,7 +86,7 @@ export const Message = ({
       {showIcon && (
         <div
           className={cn(
-            'mt-[2px] flex [&>svg]:h-3 [&>svg]:w-3',
+            'mt-0.5 flex [&>svg]:h-3 [&>svg]:w-3',
             `[&>svg]:${textColor[variant]}`
           )}
         >
@@ -96,7 +96,11 @@ export const Message = ({
       <div className="flex-1">
         {title && <div className="text-sans-semi-md">{title}</div>}
         <div
-          className={cn('text-sans-md [&>a]:tint-underline', secondaryTextColor[variant])}
+          className={cn(
+            // group gives HL the right color
+            'text-sans-md [&>a]:tint-underline group',
+            secondaryTextColor[variant]
+          )}
         >
           {content}
         </div>


### PR DESCRIPTION
Closes #2956 

<img width="441" height="89" alt="Screenshot 2025-10-30 at 5 07 55 PM" src="https://github.com/user-attachments/assets/e4dea2a7-45a4-45b2-940f-30887f8b352c" />

<img width="443" height="93" alt="Screenshot 2025-10-30 at 5 08 04 PM" src="https://github.com/user-attachments/assets/0caed5eb-578c-428d-875e-6360850365be" />

<img width="437" height="87" alt="Screenshot 2025-10-30 at 5 08 16 PM" src="https://github.com/user-attachments/assets/afaf6d02-c0fa-4d23-bec9-fab293c5a4f0" />

<img width="438" height="93" alt="Screenshot 2025-10-30 at 5 08 45 PM" src="https://github.com/user-attachments/assets/0cc8416b-a0e8-46e7-9423-95af7e8fdb61" />
