### PR TITLE
minor: fix hydration warning due to whitespace in minitable

### DIFF
--- a/app/ui/lib/MiniTable.tsx
+++ b/app/ui/lib/MiniTable.tsx
@@ -144,7 +144,8 @@ export function MiniTable<T>({
         {columns.map((column, index) => (
           <HeadCell key={index}>{column.header}</HeadCell>
         ))}
-        <HeadCell /> {/* For remove button */}
+        {/* For remove button */}
+        <HeadCell />
       </Header>
 
       <Body>


### PR DESCRIPTION
Got this on the instance create form. A fun one, never seen this before. And for such a silly reason: an inline comment in JSX that caused prettier to put whitespace after a closing tab.

<img width="808" height="581" alt="image" src="https://github.com/user-attachments/assets/d2e82293-9d42-4742-95b0-4366e485c8f8" />
