### PR TITLE
Only show message to stop instance when instance has been selected

### DIFF
--- a/app/forms/anti-affinity-group-member-add.tsx
+++ b/app/forms/anti-affinity-group-member-add.tsx
@@ -80,7 +80,7 @@ export default function AddAntiAffinityGroupMemberForm({ instances, onDismiss }:
           {selectedInstance && !canAddInstance && (
             <Message
               variant="notice"
-              content="An instance must be stopped to add it to a group"
+              content="This instance must be stopped to add it to a group"
             />
           )}
         </Modal.Section>


### PR DESCRIPTION
A small logic update to check for the presence of a selected instance before showing the "plz stop instance" message box. Also updates the copy from "An instance" to "This instance"

Closes #2943 

No selected instance:
<img width="455" height="287" alt="Screenshot 2025-11-03 at 9 17 09 PM" src="https://github.com/user-attachments/assets/efbf03ed-129a-4645-9ed7-831497467617" />

A not-stopped instance has been selected:
<img width="456" height="349" alt="Screenshot 2025-11-03 at 9 21 15 PM" src="https://github.com/user-attachments/assets/fe7938b0-5fc6-459e-bfad-91cf8cf8e1e0" />

O ho! A stopped instance has been selected:
<img width="460" height="289" alt="Screenshot 2025-11-03 at 9 17 26 PM" src="https://github.com/user-attachments/assets/aa89576f-e872-4c2c-a8d4-88466fcaa010" />