### PR TITLE
chore: Get rid of `useApiQuery`

### DIFF
--- a/app/api/client.ts
+++ b/app/api/client.ts
@@ -19,7 +19,6 @@ import {
   getApiQueryOptionsErrorsAllowed,
   getListQueryOptionsFn,
   getUseApiMutation,
-  getUseApiQuery,
   getUsePrefetchedApiQuery,
   wrapQueryClient,
 } from './hooks'
@@ -56,7 +55,6 @@ export const apiqErrorsAllowed = getApiQueryOptionsErrorsAllowed(api.methods)
  * `useQueryTable`.
  */
 export const getListQFn = getListQueryOptionsFn(api.methods)
-export const useApiQuery = getUseApiQuery(api.methods)
 /**
  * Same as `useApiQuery`, except we use `invariant(data)` to ensure the data is
  * already there in the cache at request time, which means it has been

--- a/app/api/hooks.ts
+++ b/app/api/hooks.ts
@@ -177,15 +177,6 @@ export const getListQueryOptionsFn =
     }
   }
 
-export const getUseApiQuery =
-  <A extends ApiClient>(api: A) =>
-  <M extends string & keyof A>(
-    method: M,
-    params: Params<A[M]>,
-    options: UseQueryOtherOptions<Result<A[M]>> = {}
-  ) =>
-    useQuery(getApiQueryOptions(api)(method, params, options))
-
 export const getUsePrefetchedApiQuery =
   <A extends ApiClient>(api: A) =>
   <M extends string & keyof A>(

--- a/app/components/ExternalIps.tsx
+++ b/app/components/ExternalIps.tsx
@@ -6,10 +6,11 @@
  * Copyright Oxide Computer Company
  */
 
+import { useQuery } from '@tanstack/react-query'
 import { Link } from 'react-router'
 import * as R from 'remeda'
 
-import { useApiQuery, type ExternalIp } from '@oxide/api'
+import { apiq, type ExternalIp } from '@oxide/api'
 
 import { EmptyCell, SkeletonCell } from '~/table/cells/EmptyCell'
 import { CopyableIp } from '~/ui/lib/CopyableIp'
@@ -23,10 +24,9 @@ const IP_ORDER = { floating: 0, ephemeral: 1, snat: 2 } as const
 export const orderIps = (ips: ExternalIp[]) => R.sortBy(ips, (a) => IP_ORDER[a.kind])
 
 export function ExternalIps({ project, instance }: PP.Instance) {
-  const { data, isPending } = useApiQuery('instanceExternalIpList', {
-    path: { instance },
-    query: { project },
-  })
+  const { data, isPending } = useQuery(
+    apiq('instanceExternalIpList', { path: { instance }, query: { project } })
+  )
   if (isPending) return <SkeletonCell />
 
   // Exclude SNAT IPs from the properties table because they are rarely going

--- a/app/components/SystemMetric.tsx
+++ b/app/components/SystemMetric.tsx
@@ -5,14 +5,10 @@
  *
  * Copyright Oxide Computer Company
  */
+import { useQuery } from '@tanstack/react-query'
 import { useMemo, useRef } from 'react'
 
-import {
-  synthesizeData,
-  useApiQuery,
-  type ChartDatum,
-  type SystemMetricName,
-} from '@oxide/api'
+import { apiq, synthesizeData, type ChartDatum, type SystemMetricName } from '@oxide/api'
 
 import { ChartContainer, ChartHeader, TimeSeriesChart } from './TimeSeriesChart'
 
@@ -53,23 +49,21 @@ export function SiloMetric({
 }: SiloMetricProps) {
   // TODO: we're only pulling the first page. Should we bump the cap to 10k?
   // Fetch multiple pages if 10k is not enough? That's a bit much.
-  const inRange = useApiQuery(
-    'siloMetric',
-    {
-      path: { metricName },
-      query: { project, startTime, endTime, limit: 3000 },
-    },
-    { placeholderData: (x) => x }
+  const inRange = useQuery(
+    apiq(
+      'siloMetric',
+      { path: { metricName }, query: { project, startTime, endTime, limit: 3000 } },
+      { placeholderData: (x) => x }
+    )
   )
 
   // get last point before startTime to use as first point in graph
-  const beforeStart = useApiQuery(
-    'siloMetric',
-    {
-      path: { metricName },
-      query: { project, endTime: startTime, ...staticParams },
-    },
-    { placeholderData: (x) => x }
+  const beforeStart = useQuery(
+    apiq(
+      'siloMetric',
+      { path: { metricName }, query: { project, endTime: startTime, ...staticParams } },
+      { placeholderData: (x) => x }
+    )
   )
 
   const ref = useRef<ChartDatum[] | undefined>(undefined)
@@ -124,23 +118,21 @@ export function SystemMetric({
 }: SystemMetricProps) {
   // TODO: we're only pulling the first page. Should we bump the cap to 10k?
   // Fetch multiple pages if 10k is not enough? That's a bit much.
-  const inRange = useApiQuery(
-    'systemMetric',
-    {
-      path: { metricName },
-      query: { silo, startTime, endTime, limit: 3000 },
-    },
-    { placeholderData: (x) => x }
+  const inRange = useQuery(
+    apiq(
+      'systemMetric',
+      { path: { metricName }, query: { silo, startTime, endTime, limit: 3000 } },
+      { placeholderData: (x) => x }
+    )
   )
 
   // get last point before startTime to use as first point in graph
-  const beforeStart = useApiQuery(
-    'systemMetric',
-    {
-      path: { metricName },
-      query: { silo, endTime: startTime, ...staticParams },
-    },
-    { placeholderData: (x) => x }
+  const beforeStart = useQuery(
+    apiq(
+      'systemMetric',
+      { path: { metricName }, query: { silo, endTime: startTime, ...staticParams } },
+      { placeholderData: (x) => x }
+    )
   )
 
   const ref = useRef<ChartDatum[] | undefined>(undefined)

--- a/app/components/form/fields/SubnetListbox.tsx
+++ b/app/components/form/fields/SubnetListbox.tsx
@@ -5,9 +5,10 @@
  *
  * Copyright Oxide Computer Company
  */
+import { useQuery } from '@tanstack/react-query'
 import { useWatch, type FieldPath, type FieldValues } from 'react-hook-form'
 
-import { useApiQuery } from '@oxide/api'
+import { apiq } from '@oxide/api'
 
 import { useProjectSelector } from '~/hooks/use-params'
 
@@ -40,10 +41,12 @@ export function SubnetListbox<
 
   // TODO: error handling other than fallback to empty list?
   const subnets =
-    useApiQuery(
-      'vpcSubnetList',
-      { query: { ...projectSelector, vpc: vpcName } },
-      { enabled: vpcExists, throwOnError: false }
+    useQuery(
+      apiq(
+        'vpcSubnetList',
+        { query: { ...projectSelector, vpc: vpcName } },
+        { enabled: vpcExists, throwOnError: false }
+      )
     ).data?.items || []
 
   return (

--- a/app/components/form/fields/useItemsList.ts
+++ b/app/components/form/fields/useItemsList.ts
@@ -6,9 +6,11 @@
  * Copyright Oxide Computer Company
  */
 
+import { useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
 
-import { useApiQuery } from '~/api'
+import { apiq } from '@oxide/api'
+
 import { useVpcSelector } from '~/hooks/use-params'
 
 /**
@@ -30,7 +32,7 @@ export function customRouterDataToForm(value: string | undefined | null): string
 
 export const useCustomRouterItems = () => {
   const vpcSelector = useVpcSelector()
-  const { data, isLoading } = useApiQuery('vpcRouterList', { query: vpcSelector })
+  const { data, isLoading } = useQuery(apiq('vpcRouterList', { query: vpcSelector }))
 
   const routerItems = useMemo(() => {
     const items = (data?.items || [])

--- a/app/forms/disk-attach.tsx
+++ b/app/forms/disk-attach.tsx
@@ -5,10 +5,11 @@
  *
  * Copyright Oxide Computer Company
  */
+import { useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
 import { useForm } from 'react-hook-form'
 
-import { useApiQuery, type ApiError } from '@oxide/api'
+import { apiq, type ApiError } from '@oxide/api'
 
 import { ComboboxField } from '~/components/form/fields/ComboboxField'
 import { ModalForm } from '~/components/form/ModalForm'
@@ -40,9 +41,9 @@ export function AttachDiskModalForm({
 }: AttachDiskProps) {
   const { project } = useProjectSelector()
 
-  const { data, isPending } = useApiQuery('diskList', {
-    query: { project, limit: ALL_ISH },
-  })
+  const { data, isPending } = useQuery(
+    apiq('diskList', { query: { project, limit: ALL_ISH } })
+  )
   const detachedDisks = useMemo(
     () =>
       toComboboxItems(

--- a/app/forms/disk-create.tsx
+++ b/app/forms/disk-create.tsx
@@ -5,13 +5,14 @@
  *
  * Copyright Oxide Computer Company
  */
+import { useQuery } from '@tanstack/react-query'
 import { filesize } from 'filesize'
 import { useMemo } from 'react'
 import { useController, useForm, type Control } from 'react-hook-form'
 
 import {
+  apiq,
   useApiMutation,
-  useApiQuery,
   useApiQueryClient,
   type BlockSize,
   type Disk,
@@ -82,8 +83,8 @@ export function CreateDiskSideModalForm({
 
   const form = useForm({ defaultValues })
   const { project } = useProjectSelector()
-  const projectImages = useApiQuery('imageList', { query: { project } })
-  const siloImages = useApiQuery('imageList', {})
+  const projectImages = useQuery(apiq('imageList', { query: { project } }))
+  const siloImages = useQuery(apiq('imageList', {}))
 
   // put project images first because if there are any, there probably aren't
   // very many and they're probably relevant
@@ -93,7 +94,7 @@ export function CreateDiskSideModalForm({
   )
   const areImagesLoading = projectImages.isPending || siloImages.isPending
 
-  const snapshotsQuery = useApiQuery('snapshotList', { query: { project } })
+  const snapshotsQuery = useQuery(apiq('snapshotList', { query: { project } }))
   const snapshots = snapshotsQuery.data?.items || []
 
   // validate disk source size
@@ -235,11 +236,8 @@ const DiskSourceField = ({
 }
 
 const DiskNameFromId = ({ disk }: { disk: string }) => {
-  const { data, isPending, isError } = useApiQuery(
-    'diskView',
-    { path: { disk } },
-    // this can 404 if the source disk has been deleted, and that's fine
-    { throwOnError: false }
+  const { data, isPending, isError } = useQuery(
+    apiq('diskView', { path: { disk } }, { throwOnError: false })
   )
 
   if (isPending || isError) return null
@@ -248,7 +246,7 @@ const DiskNameFromId = ({ disk }: { disk: string }) => {
 
 const SnapshotSelectField = ({ control }: { control: Control<DiskCreate> }) => {
   const { project } = useProjectSelector()
-  const snapshotsQuery = useApiQuery('snapshotList', { query: { project } })
+  const snapshotsQuery = useQuery(apiq('snapshotList', { query: { project } }))
 
   const snapshots = snapshotsQuery.data?.items || []
   const diskSizeField = useController({ control, name: 'size' }).field

--- a/app/forms/floating-ip-create.tsx
+++ b/app/forms/floating-ip-create.tsx
@@ -6,16 +6,12 @@
  * Copyright Oxide Computer Company
  */
 import * as Accordion from '@radix-ui/react-accordion'
+import { useQuery } from '@tanstack/react-query'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router'
 
-import {
-  useApiMutation,
-  useApiQuery,
-  useApiQueryClient,
-  type FloatingIpCreate,
-} from '@oxide/api'
+import { apiq, useApiMutation, useApiQueryClient, type FloatingIpCreate } from '@oxide/api'
 
 import { AccordionItem } from '~/components/AccordionItem'
 import { DescriptionField } from '~/components/form/fields/DescriptionField'
@@ -42,7 +38,9 @@ export const handle = titleCrumb('New Floating IP')
 export default function CreateFloatingIpSideModalForm() {
   // Fetch 1000 to we can be sure to get them all. Don't bother prefetching
   // because the list is hidden under the Advanced accordion.
-  const { data: allPools } = useApiQuery('projectIpPoolList', { query: { limit: ALL_ISH } })
+  const { data: allPools } = useQuery(
+    apiq('projectIpPoolList', { query: { limit: ALL_ISH } })
+  )
 
   const queryClient = useApiQueryClient()
   const projectSelector = useProjectSelector()

--- a/app/forms/network-interface-create.tsx
+++ b/app/forms/network-interface-create.tsx
@@ -5,11 +5,12 @@
  *
  * Copyright Oxide Computer Company
  */
+import { useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
 import { useForm } from 'react-hook-form'
 import type { SetNonNullable, SetRequired } from 'type-fest'
 
-import { useApiQuery, type ApiError, type InstanceNetworkInterfaceCreate } from '@oxide/api'
+import { apiq, type ApiError, type InstanceNetworkInterfaceCreate } from '@oxide/api'
 
 import { DescriptionField } from '~/components/form/fields/DescriptionField'
 import { ListboxField } from '~/components/form/fields/ListboxField'
@@ -47,7 +48,7 @@ export function CreateNetworkInterfaceForm({
 }: CreateNetworkInterfaceFormProps) {
   const projectSelector = useProjectSelector()
 
-  const { data: vpcsData } = useApiQuery('vpcList', { query: projectSelector })
+  const { data: vpcsData } = useQuery(apiq('vpcList', { query: projectSelector }))
   const vpcs = useMemo(() => vpcsData?.items || [], [vpcsData])
 
   const form = useForm({ defaultValues })

--- a/app/forms/snapshot-create.tsx
+++ b/app/forms/snapshot-create.tsx
@@ -5,14 +5,15 @@
  *
  * Copyright Oxide Computer Company
  */
+import { useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
 import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router'
 
 import {
+  apiq,
   diskCan,
   useApiMutation,
-  useApiQuery,
   useApiQueryClient,
   type SnapshotCreate,
 } from '@oxide/api'
@@ -31,9 +32,7 @@ import { pb } from '~/util/path-builder'
 import type * as PP from '~/util/path-params'
 
 const useSnapshotDiskItems = ({ project }: PP.Project) => {
-  const { data: disks } = useApiQuery('diskList', {
-    query: { project, limit: ALL_ISH },
-  })
+  const { data: disks } = useQuery(apiq('diskList', { query: { project, limit: ALL_ISH } }))
   return disks?.items.filter(diskCan.snapshot)
 }
 

--- a/app/pages/SiloImagesPage.tsx
+++ b/app/pages/SiloImagesPage.tsx
@@ -5,16 +5,17 @@
  *
  * Copyright Oxide Computer Company
  */
+import { useQuery } from '@tanstack/react-query'
 import { createColumnHelper } from '@tanstack/react-table'
 import { useCallback, useMemo, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { Outlet } from 'react-router'
 
 import {
+  apiq,
   getListQFn,
   queryClient,
   useApiMutation,
-  useApiQuery,
   useApiQueryClient,
   type Image,
 } from '@oxide/api'
@@ -144,15 +145,17 @@ const PromoteImageModal = ({ onDismiss }: { onDismiss: () => void }) => {
     onSettled: onDismiss,
   })
 
-  const projects = useApiQuery('projectList', {})
+  const projects = useQuery(apiq('projectList', {}))
   const projectItems = useMemo(() => toComboboxItems(projects.data?.items), [projects.data])
   const selectedProject = form.watch('project')
 
   // can only fetch images if a project is selected
-  const images = useApiQuery(
-    'imageList',
-    { query: { project: selectedProject! } },
-    { enabled: !!selectedProject }
+  const images = useQuery(
+    apiq(
+      'imageList',
+      { query: { project: selectedProject! } },
+      { enabled: !!selectedProject }
+    )
   )
   const imageItems = useMemo(
     () => (images.data?.items || []).map((i) => toImageComboboxItem(i)),
@@ -239,7 +242,7 @@ const DemoteImageModal = ({
     onSettled: onDismiss,
   })
 
-  const projects = useApiQuery('projectList', {})
+  const projects = useQuery(apiq('projectList', {}))
   const projectItems = useMemo(() => toComboboxItems(projects.data?.items), [projects.data])
 
   return (

--- a/app/pages/project/instances/InstancePage.tsx
+++ b/app/pages/project/instances/InstancePage.tsx
@@ -5,15 +5,16 @@
  *
  * Copyright Oxide Computer Company
  */
+import { useQuery } from '@tanstack/react-query'
 import { filesize } from 'filesize'
 import { useId, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { Link, useNavigate, type LoaderFunctionArgs } from 'react-router'
 
 import {
+  apiq,
   apiQueryClient,
   useApiMutation,
-  useApiQuery,
   usePrefetchedApiQuery,
   type Instance,
   type InstanceNetworkInterface,
@@ -168,10 +169,8 @@ export default function InstancePage() {
   // a little funny, as noted in the loader -- this should always be prefetched
   // when primaryVpcId is defined, but primaryVpcId might not be defined, so
   // we can't use usePrefetchedApiQuery
-  const { data: vpc } = useApiQuery(
-    'vpcView',
-    { path: { vpc: primaryVpcId! } },
-    { enabled: !!primaryVpcId }
+  const { data: vpc } = useQuery(
+    apiq('vpcView', { path: { vpc: primaryVpcId! } }, { enabled: !!primaryVpcId })
   )
 
   const memory = filesize(instance.memory, { output: 'object', base: 2 })

--- a/app/pages/project/instances/NetworkingTab.tsx
+++ b/app/pages/project/instances/NetworkingTab.tsx
@@ -5,18 +5,19 @@
  *
  * Copyright Oxide Computer Company
  */
+import { useQuery } from '@tanstack/react-query'
 import { createColumnHelper, getCoreRowModel, useReactTable } from '@tanstack/react-table'
 import { useCallback, useMemo, useState } from 'react'
 import { type LoaderFunctionArgs } from 'react-router'
 import { match } from 'ts-pattern'
 
 import {
+  apiq,
   apiqErrorsAllowed,
   apiQueryClient,
   instanceCan,
   queryClient,
   useApiMutation,
-  useApiQuery,
   useApiQueryClient,
   usePrefetchedApiQuery,
   type ExternalIp,
@@ -62,10 +63,8 @@ import { fancifyStates } from './common'
 
 const VpcNameFromId = ({ value }: { value: string }) => {
   const { project } = useProjectSelector()
-  const { data: vpc, isError } = useApiQuery(
-    'vpcView',
-    { path: { vpc: value } },
-    { throwOnError: false }
+  const { data: vpc, isError } = useQuery(
+    apiq('vpcView', { path: { vpc: value } }, { throwOnError: false })
   )
 
   // If we can't find it, it must have been deleted. This is probably not
@@ -77,10 +76,8 @@ const VpcNameFromId = ({ value }: { value: string }) => {
 }
 
 const SubnetNameFromId = ({ value }: { value: string }) => {
-  const { data: subnet, isError } = useApiQuery(
-    'vpcSubnetView',
-    { path: { subnet: value } },
-    { throwOnError: false }
+  const { data: subnet, isError } = useQuery(
+    apiq('vpcSubnetView', { path: { subnet: value } }, { throwOnError: false })
   )
 
   // same deal as VPC: probably not possible but let's be safe

--- a/app/pages/system/networking/IpPoolPage.tsx
+++ b/app/pages/system/networking/IpPoolPage.tsx
@@ -6,6 +6,7 @@
  * Copyright Oxide Computer Company
  */
 
+import { useQuery } from '@tanstack/react-query'
 import { createColumnHelper } from '@tanstack/react-table'
 import { useCallback, useMemo, useState } from 'react'
 import { useForm } from 'react-hook-form'
@@ -17,7 +18,6 @@ import {
   getListQFn,
   queryClient,
   useApiMutation,
-  useApiQuery,
   useApiQueryClient,
   usePrefetchedApiQuery,
   usePrefetchedQuery,
@@ -244,7 +244,7 @@ function IpRangesTable() {
 }
 
 function SiloNameFromId({ value: siloId }: { value: string }) {
-  const { data: silo } = useApiQuery('siloView', { path: { silo: siloId } })
+  const { data: silo } = useQuery(apiq('siloView', { path: { silo: siloId } }))
 
   if (!silo) return <SkeletonCell />
 
@@ -371,11 +371,10 @@ function LinkSiloModal({ onDismiss }: { onDismiss: () => void }) {
     linkSilo.mutate({ path: { pool }, body: { silo, isDefault: false } })
   }
 
-  const linkedSilos = useApiQuery('ipPoolSiloList', {
-    path: { pool },
-    query: { limit: ALL_ISH },
-  })
-  const allSilos = useApiQuery('siloList', { query: { limit: ALL_ISH } })
+  const linkedSilos = useQuery(
+    apiq('ipPoolSiloList', { path: { pool }, query: { limit: ALL_ISH } })
+  )
+  const allSilos = useQuery(apiq('siloList', { query: { limit: ALL_ISH } }))
 
   // in order to get the list of remaining unlinked silos, we have to get the
   // list of all silos and remove the already linked ones

--- a/app/pages/system/networking/IpPoolsPage.tsx
+++ b/app/pages/system/networking/IpPoolsPage.tsx
@@ -6,16 +6,17 @@
  * Copyright Oxide Computer Company
  */
 
+import { useQuery } from '@tanstack/react-query'
 import { createColumnHelper } from '@tanstack/react-table'
 import { useCallback, useMemo } from 'react'
 import { Outlet, useNavigate } from 'react-router'
 
 import {
+  apiq,
   apiQueryClient,
   getListQFn,
   queryClient,
   useApiMutation,
-  useApiQuery,
   type IpPool,
 } from '@oxide/api'
 import { IpGlobal16Icon, IpGlobal24Icon } from '@oxide/design-system/icons/react'
@@ -50,7 +51,7 @@ const EmptyState = () => (
 )
 
 function UtilizationCell({ pool }: { pool: string }) {
-  const { data } = useApiQuery('ipPoolUtilizationView', { path: { pool } })
+  const { data } = useQuery(apiq('ipPoolUtilizationView', { path: { pool } }))
   if (!data) return <SkeletonCell />
   return (
     <div>

--- a/app/table/cells/InstanceLinkCell.tsx
+++ b/app/table/cells/InstanceLinkCell.tsx
@@ -6,7 +6,9 @@
  * Copyright Oxide Computer Company
  */
 
-import { useApiQuery } from '@oxide/api'
+import { useQuery } from '@tanstack/react-query'
+
+import { apiq } from '@oxide/api'
 
 import { useProjectSelector } from '~/hooks/use-params'
 import { pb } from '~/util/path-builder'
@@ -16,10 +18,8 @@ import { LinkCell } from './LinkCell'
 
 export const InstanceLinkCell = ({ instanceId }: { instanceId?: string | null }) => {
   const { project } = useProjectSelector()
-  const { data: instance } = useApiQuery(
-    'instanceView',
-    { path: { instance: instanceId! } },
-    { enabled: !!instanceId }
+  const { data: instance } = useQuery(
+    apiq('instanceView', { path: { instance: instanceId! } }, { enabled: !!instanceId })
   )
 
   // has to be after the hooks because hooks can't be executed conditionally

--- a/app/table/cells/RouterLinkCell.tsx
+++ b/app/table/cells/RouterLinkCell.tsx
@@ -6,9 +6,11 @@
  * Copyright Oxide Computer Company
  */
 
+import { useQuery } from '@tanstack/react-query'
+
+import { apiq } from '@oxide/api'
 import { Badge } from '@oxide/design-system/ui'
 
-import { useApiQuery } from '~/api'
 import { useVpcSelector } from '~/hooks/use-params'
 import { pb } from '~/util/path-builder'
 
@@ -17,10 +19,8 @@ import { LinkCell } from './LinkCell'
 
 export const RouterLinkCell = ({ routerId }: { routerId?: string | null }) => {
   const { project, vpc } = useVpcSelector()
-  const { data: router, isError } = useApiQuery(
-    'vpcRouterView',
-    { path: { router: routerId! } }, // it's an ID, so no parent selector
-    { enabled: !!routerId }
+  const { data: router, isError } = useQuery(
+    apiq('vpcRouterView', { path: { router: routerId! } }, { enabled: !!routerId })
   )
   if (!routerId) return <EmptyCell />
   // probably not possible but let’s be safe


### PR DESCRIPTION
Switch everything to the new `apiq` helper. This is a very old chore, made trivial with LLMs.