### PR TITLE
minor: fix window.oxide

### DIFF
--- a/app/api/window.ts
+++ b/app/api/window.ts
@@ -38,8 +38,8 @@ function logHeading(s: string) {
 }
 
 if (typeof window !== 'undefined') {
-  // @ts-expect-error
-  window.oxide = api.methods
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(window as any).oxide = api
   // @ts-expect-error
   window.oxql = {
     query: async (q: string) => {


### PR DESCRIPTION
Broke it in #2971 and the `@ts-expect-error` hid it. I made it slightly less error-hiding.