### PR TITLE
Rewrite `api-diff` for new versioned API

### DIFF
--- a/tools/deno/api-diff.ts
+++ b/tools/deno/api-diff.ts
@@ -162,20 +162,16 @@ Dependencies:
   - Optional: fzf for PR picker https://github.com/junegunn/fzf`
   )
   .helpOption('-h, --help', 'Show help')
-  .option('-f, --force', 'Re-download spec and regenerate client even if cached')
+  .option('--force', 'Redo everything even if cached')
   .type('format', ({ value }) => {
     if (value !== 'ts' && value !== 'schema') {
       throw new ValidationError(`Invalid format: '${value}'. Must be 'ts' or 'schema'`)
     }
     return value
   })
-  .option(
-    '--format <format:format>',
-    'Output format: ts (generated client) or schema (raw JSON)',
-    {
-      default: 'ts' as const,
-    }
-  )
+  .option('-f, --format <format:format>', "Output format: 'ts' or 'schema'", {
+    default: 'ts' as const,
+  })
   .arguments('[ref1:string] [ref2:string]')
   .action(async (options, ref?: string, ref2?: string) => {
     const target = await resolveTarget(ref, ref2)


### PR DESCRIPTION
It's a full rewrite, so the diff is not easy to read. Changes:

* Use `cliffy` to make it a proper CLI with automatic arg parsing and help generation
* Instead of comparing a well-known filename on two different commits, for a single PR, we are now comparing the latest and previous schema file on the same commit (the head commit of the PR)
* When we compare two different commits, the file name is still not well known because we need to look at the schema marked latest on both commits, which could be different.
* The tool can now output either the diff for the generated TS client (the old behavior), or it can also output the diff of the schema itself.
  * Needed because the schema diff is now no longer easy to see on the omicron PR in question. 

<img width="823" height="424" alt="image" src="https://github.com/user-attachments/assets/457c7551-3661-4de2-81c1-d234450a37bb" />
