### PR TITLE
trivial: fix `next_page`/`nextPage` confusion in `paginated` MSW util

### DIFF
--- a/mock-api/msw/handlers.ts
+++ b/mock-api/msw/handlers.ts
@@ -1144,10 +1144,10 @@ export const handlers = makeHandlers({
     return utilizationForSilo(silo)
   },
   siloUtilizationList({ query }) {
-    const { items: silos, nextPage } = paginated(query, db.silos)
+    const { items: silos, next_page } = paginated(query, db.silos)
     return {
       items: silos.map(utilizationForSilo),
-      nextPage,
+      next_page,
     }
   },
   vpcList({ query }) {

--- a/mock-api/msw/util.spec.ts
+++ b/mock-api/msw/util.spec.ts
@@ -17,7 +17,7 @@ describe('paginated', () => {
     const items = [{ id: 'a' }, { id: 'b' }, { id: 'c' }]
     const page = paginated({}, items)
     expect(page.items).toEqual([{ id: 'a' }, { id: 'b' }, { id: 'c' }])
-    expect(page.nextPage).toBeNull()
+    expect(page.next_page).toBeNull()
   })
 
   it('should return the first 100 items with no limit passed', () => {
@@ -25,10 +25,10 @@ describe('paginated', () => {
     const page = paginated({}, items)
     expect(page.items.length).toBe(100)
     expect(page.items).toEqual(items.slice(0, 100))
-    expect(page.nextPage).toBe('i100')
+    expect(page.next_page).toBe('i100')
   })
 
-  it('should return page with null `nextPage` if items equal page', () => {
+  it('should return page with null `next_page` if items equal page', () => {
     const items = [
       { id: 'a' },
       { id: 'b' },
@@ -44,7 +44,7 @@ describe('paginated', () => {
     const page = paginated({}, items)
     expect(page.items.length).toBe(10)
     expect(page.items).toEqual(items.slice(0, 10))
-    expect(page.nextPage).toBeNull()
+    expect(page.next_page).toBeNull()
   })
 
   it('should return 5 items with a limit of 5', () => {
@@ -59,7 +59,7 @@ describe('paginated', () => {
     const page = paginated({ limit: 5 }, items)
     expect(page.items.length).toBe(5)
     expect(page.items).toEqual(items.slice(0, 5))
-    expect(page.nextPage).toBe('f')
+    expect(page.next_page).toBe('f')
   })
 
   it('should return the second page when given a `page_token`', () => {
@@ -67,7 +67,7 @@ describe('paginated', () => {
     const page = paginated({ pageToken: 'b' }, items)
     expect(page.items.length).toBe(3)
     expect(page.items).toEqual([{ id: 'b' }, { id: 'c' }, { id: 'd' }])
-    expect(page.nextPage).toBeNull()
+    expect(page.next_page).toBeNull()
   })
 })
 

--- a/mock-api/msw/util.ts
+++ b/mock-api/msw/util.ts
@@ -43,7 +43,7 @@ interface PaginateOptions {
 }
 export interface ResultsPage<I extends { id: string }> {
   items: I[]
-  nextPage: string | null
+  next_page: string | null
 }
 
 export const paginated = <P extends PaginateOptions, I extends { id: string }>(
@@ -59,20 +59,20 @@ export const paginated = <P extends PaginateOptions, I extends { id: string }>(
   if (startIndex > items.length) {
     return {
       items: [],
-      nextPage: null,
+      next_page: null,
     }
   }
 
   if (limit + startIndex >= items.length) {
     return {
       items: items.slice(startIndex),
-      nextPage: null,
+      next_page: null,
     }
   }
 
   return {
     items: items.slice(startIndex, startIndex + limit),
-    nextPage: `${items[startIndex + limit].id}`,
+    next_page: `${items[startIndex + limit].id}`,
   }
 }
 


### PR DESCRIPTION
Just clearing out an old to-do list item. We were incorrectly using `nextPage` instead of `next_page` in the pagination helper. TypeScript allowed this because `next_page` is optional and TypeScript can't prevent you from adding extra keys (`nextPage`) that aren't in the specified return type. This didn't cause any problems because on the client side, the `next_page` is converted to `nextPage` anyway. So we were just putting the "right" key in there to begin with and it was being left alone by the camel-casing logic. I explored finding ways to enforce an exact type which would disallow unexpected keys in API responses, but TypeScript makes this really tough (see https://github.com/microsoft/TypeScript/issues/12936).