### PR TITLE
Show a message that this site requires JavaScript

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
     <noscript>
       <div class="min-h-screen grid place-content-center">
         <p class="max-w-lg p-8 text-center text-balance">
-          This site requires JavaScript. If you don't want to enable JavaScript, see the <a href="https://docs.oxide.computer/" target="_blank" rel="noopener noreferrer">Oxide docs</a> to learn about accessing the API through the CLI or SDKs.
+          This site requires JavaScript. If you don't want to enable JavaScript, see the <a href="https://docs.oxide.computer/" class="external-link" target="_blank" rel="noopener noreferrer">Oxide docs</a> to learn about accessing the API through the CLI or SDKs.
         </p>
       </div>
     </noscript>


### PR DESCRIPTION
Adds a noscript tag that displays a message that this site requires JavaScript to run.

The easiest way to test this locally is to use Chrome since it can disable JavaScript per tab instead of globally. Open the dev console and click the gear icon and check "Disable "JavaScript" in the Debugger section.

I skipped adding a test since it is a static change and playwright requires js to run.

resolves #2928