### PR TITLE
minor: image edit "shared with" -> "visibility"

### DIFF
--- a/app/forms/image-edit.tsx
+++ b/app/forms/image-edit.tsx
@@ -50,7 +50,7 @@ export function EditImageSideModalForm({
       loading={false}
     >
       <PropertiesTable>
-        <PropertiesTable.Row label="Shared with">{type}</PropertiesTable.Row>
+        <PropertiesTable.Row label="Visibility">{type}</PropertiesTable.Row>
         <PropertiesTable.IdRow id={image.id} />
         <PropertiesTable.Row label="Size">
           <span>{bytesToGiB(image.size)}</span>


### PR DESCRIPTION
Saw "shared with" and had a reaction of visceral fear and confusion. I think visibility is slightly better. Experimented with putting the project name in there but couldn't get the visual treatment to feel right. This is at least a marginal improvement.

<img width="500" height="219" alt="image" src="https://github.com/user-attachments/assets/b7f4fbb5-ccd3-40dd-a771-7ae20b4f5a4d" />
