### PR TITLE
Make sure anti-affinity fail badge shows up on table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@floating-ui/react": "^0.26.23",
         "@headlessui/react": "^2.2.9",
-        "@oxide/design-system": "^4.0.2",
+        "@oxide/design-system": "^4.0.3",
         "@radix-ui/react-accordion": "^1.2.0",
         "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-tabs": "^1.1.0",
@@ -1537,9 +1537,9 @@
       "license": "MIT"
     },
     "node_modules/@oxide/design-system": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@oxide/design-system/-/design-system-4.0.2.tgz",
-      "integrity": "sha512-DQd/nhUj1vMnPMeEWA5Vp4wec7mdXvud+OdxxP0apknOpifnJRZoE8XdUdO0iVWpCefnnL4xceiRMPwQRdYpEA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@oxide/design-system/-/design-system-4.0.3.tgz",
+      "integrity": "sha512-vsxJZfCtU1nHrzR/BFEnySnouOXgvB0f1DvJAFswKxo4oOYxDTS+fv7dQgMYeaYlRc2ULrHr6vD/TiWYLtRpPw==",
       "license": "MPL 2.0",
       "dependencies": {
         "@floating-ui/react": "^0.27.16",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@floating-ui/react": "^0.26.23",
     "@headlessui/react": "^2.2.9",
-    "@oxide/design-system": "^4.0.2",
+    "@oxide/design-system": "^4.0.3",
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-tabs": "^1.1.0",


### PR DESCRIPTION
So it seems that `<Badge color="neutral" variant="solid">{policy}</Badge>` doesn't show up as expected.
<img width="2516" height="886" alt="image" src="https://github.com/user-attachments/assets/a719740d-1cc5-4733-8a09-13bc2d7f72c6" />

Claude's analysis was that it comes down to how the Tailwind classes are constructed:
---
The CSS classes are defined in /Users/charliepark/oxide/console/node_modules/@oxide/design-system/styles/dist/main.css using CSS custom
   properties (CSS variables). These map to Tailwind utility classes.

  The actual bug: bg-inverse-tertiary doesn't exist in the design system

  Looking at the available inverse CSS variables:
  --surface-inverse-raise: var(--content-raise);
  --surface-inverse-primary: var(--content-default);
  --surface-inverse-secondary: var(--content-secondary);
  --content-inverse: var(--surface-default);
  --content-inverse-raise: var(--surface-raise);
  --content-inverse-secondary: var(--surface-secondary);

  There's no --surface-inverse-tertiary defined, which means the Tailwind class bg-inverse-tertiary doesn't exist in the compiled CSS

  So when the Badge used:
  neutral: 'bg-inverse-tertiary text-inverse'

  It would render as:
  - text-inverse → --content-inverse → #080F11 (very dark text)
  - bg-inverse-tertiary → class doesn't exist → no background applied
  - Result: Dark text on dark background = invisible "fail" badge
---

We can either change the color or the variant if we want them to be visually distinct, which I think was the original goal. In light of just fixing the bug so we can focus on more pressing issues, I have made both badges the same color, but am open to other thoughts, like using other variant/colors, fixing the design system, etc.

What this PR has:
<img width="1197" height="169" alt="Screenshot 2026-01-26 at 7 46 45 PM" src="https://github.com/user-attachments/assets/7bd4eb25-86fa-42e3-b786-c73c842bfd02" />

Though I played with a few other options; including for completeness:
<img width="1197" height="170" alt="Screenshot 2026-01-26 at 7 38 33 PM" src="https://github.com/user-attachments/assets/2518dd39-76ce-404e-8339-92455f5a9825" />
<img width="1195" height="167" alt="Screenshot 2026-01-26 at 7 41 04 PM" src="https://github.com/user-attachments/assets/e78bdfc9-7b00-415f-ba99-651e33724892" />

Closes #3016 