### PR TITLE
Fix mini table header border

### DIFF
--- a/app/ui/lib/Table.tsx
+++ b/app/ui/lib/Table.tsx
@@ -50,7 +50,7 @@ Table.HeadCell = ({ className, children, ...props }: TableHeadCellProps) => (
   <th
     className={cn(
       className,
-      'text-mono-sm bg-secondary border-default *:first-child:border-0 h-9 border border-x-0 pr-px pl-0 text-left'
+      'text-mono-sm bg-secondary border-default h-9 border-y pr-px pl-0 text-left'
     )}
     {...props}
   >

--- a/app/ui/styles/components/mini-table.css
+++ b/app/ui/styles/components/mini-table.css
@@ -67,12 +67,12 @@
 
   & thead tr:first-of-type th:first-of-type {
     border-top-left-radius: var(--radius-lg);
-    @apply border-l;
+    @apply overflow-hidden border-l;
   }
 
   & thead tr:first-of-type th:last-of-type {
     border-top-right-radius: var(--radius-lg);
-    @apply w-8 border-r;
+    @apply w-8 overflow-hidden border-r;
   }
 
   & tbody tr:last-of-type td:first-of-type {


### PR DESCRIPTION
Before:
<img width="548" height="218" alt="image" src="https://github.com/user-attachments/assets/f596666c-003b-4f73-8a45-a0ba6749599b" />

After:
<img width="551" height="277" alt="image" src="https://github.com/user-attachments/assets/c063e829-a2d6-47e9-a318-00cd17b9b69a" />
