### PR TITLE
Remove unicast/multicast from IP pool create form for now

### DIFF
--- a/app/forms/ip-pool-create.tsx
+++ b/app/forms/ip-pool-create.tsx
@@ -75,6 +75,9 @@ export default function CreateIpPoolSideModalForm() {
           { value: 'v6', label: 'v6' },
         ]}
       />
+      {/*
+      // leaving this out for now because multicast is only partly supported
+      // field default value is unicast, so that will go out with all creates
       <RadioField
         name="poolType"
         label="Type"
@@ -85,6 +88,7 @@ export default function CreateIpPoolSideModalForm() {
           { value: 'multicast', label: 'Multicast' },
         ]}
       />
+      */}
       <SideModalFormDocs docs={[docLinks.systemIpPools]} />
     </SideModalForm>
   )

--- a/app/pages/project/floating-ips/FloatingIpsPage.tsx
+++ b/app/pages/project/floating-ips/FloatingIpsPage.tsx
@@ -99,7 +99,7 @@ const staticCols = [
     cell: (info) => <IpPoolCell ipPoolId={info.getValue()} />,
   }),
   colHelper.accessor('instanceId', {
-    header: 'Attached to instance',
+    header: 'Instance',
     cell: (info) => <InstanceLinkCell instanceId={info.getValue()} />,
   }),
 ]

--- a/test/e2e/floating-ip-create.e2e.ts
+++ b/test/e2e/floating-ip-create.e2e.ts
@@ -54,7 +54,7 @@ test('can detach and attach a floating IP', async ({ page }) => {
   await expectRowVisible(page.getByRole('table'), {
     name: 'cola-float',
     'IP address': '123.4.56.5',
-    'Attached to instance': 'db1',
+    Instance: 'db1',
   })
   await clickRowAction(page, 'cola-float', 'Detach')
   await page.getByRole('button', { name: 'Confirm' }).click()
@@ -83,6 +83,6 @@ test('can detach and attach a floating IP', async ({ page }) => {
   await expectRowVisible(page.getByRole('table'), {
     name: 'cola-float',
     'IP address': '123.4.56.5',
-    'Attached to instance': 'db1',
+    Instance: 'db1',
   })
 })

--- a/test/e2e/ip-pools.e2e.ts
+++ b/test/e2e/ip-pools.e2e.ts
@@ -238,16 +238,13 @@ test('IP pool create v4', async ({ page }) => {
   await page.getByRole('textbox', { name: 'Name' }).fill('another-pool')
   await page.getByRole('textbox', { name: 'Description' }).fill('whatever')
 
-  // Select multicast pool type
-  await page.getByRole('radio', { name: 'Multicast' }).click()
-
   await page.getByRole('button', { name: 'Create IP pool' }).click()
 
   await expect(modal).toBeHidden()
   await expectRowVisible(page.getByRole('table'), {
     name: 'another-pool',
     description: 'whatever',
-    Type: 'multicast',
+    Type: 'unicast',
     'IPs REMAINING': '0 / 0',
   })
 })


### PR DESCRIPTION
Leaving it in the table since you can still create multicast pools through the API. Also snuck in a fix for the super long header name on the floating IPs "attached to instance" column.

<img width="511" height="661" alt="image" src="https://github.com/user-attachments/assets/e0eb8f99-4f83-49cf-a7f0-a92495d85ab8" />
