### PR TITLE
Cap floating IPs table width to max-w-lg on instance create form

### DIFF
--- a/app/forms/instance-create.tsx
+++ b/app/forms/instance-create.tsx
@@ -1001,7 +1001,7 @@ const NetworkingSection = ({
             />
           </div>
         ) : (
-          <div className="flex flex-col items-start gap-3">
+          <div className="flex max-w-lg flex-col items-start gap-3">
             <MiniTable
               ariaLabel="Floating IPs"
               items={attachedFloatingIpsData}


### PR DESCRIPTION
The floating IPs MiniTable container was unconstrained, causing it to stretch wider than other fields. Add max-w-lg to match the empty state and other sections in the form.

<img width="559" height="196" alt="image" src="https://github.com/user-attachments/assets/b0679702-e1f6-42a2-8562-00cd1f859d16" />

Closes #3078 

https://claude.ai/code/session_01JAbgycxitZnU3ii4FzFuNd