### PR TITLE
minor: fix instance detail refresh not invalidating the right queries

### DIFF
--- a/app/pages/project/instances/InstancePage.tsx
+++ b/app/pages/project/instances/InstancePage.tsx
@@ -83,7 +83,9 @@ async function refreshData() {
     queryClient.invalidateEndpoint('instanceExternalIpList'),
     queryClient.invalidateEndpoint('instanceNetworkInterfaceList'),
     queryClient.invalidateEndpoint('instanceDiskList'), // storage tab
-    queryClient.invalidateEndpoint('antiAffinityGroupMemberList'),
+    queryClient.invalidateEndpoint('instanceAntiAffinityGroupList'), // settings tab
+    queryClient.invalidateEndpoint('antiAffinityGroupList'), // settings tab
+    queryClient.invalidateEndpoint('antiAffinityGroupMemberList'), // settings tab
     // note that we do not include timeseriesQuery because the charts on the
     // metrics tab will manage their own refresh intervals when we turn that
     // back on


### PR DESCRIPTION
One of a few small bugs that came up when I pointed Claude at the codebase and asked it to find some bugs.

`refreshData()` was invalidating `antiAffinityGroupMemberList` but not `instanceAntiAffinityGroupList` or `antiAffinityGroupList`. The Settings tab reads from all three, so clicking Refresh had no effect on the instance's group membership or the list of available groups.