### PR TITLE
Fix DateRangePicker truncation near viewport bottom

### DIFF
--- a/app/ui/lib/Popover.tsx
+++ b/app/ui/lib/Popover.tsx
@@ -39,7 +39,7 @@ export function Popover(props: PopoverProps) {
       <div
         {...popoverProps}
         ref={ref}
-        className="bg-raise light:bg-default shadow-menu absolute z-(--z-popover) my-2 rounded-lg overflow-auto"
+        className="bg-raise light:bg-default shadow-menu absolute z-(--z-popover) my-2 overflow-auto rounded-lg"
       >
         <DismissButton onDismiss={state.close} />
         {children}


### PR DESCRIPTION
Fixes #2734 . Previously, the DateRangePicker popover appeared correctly only when there was enough space below the anchor element to fully display it within the viewport. Otherwise, if the anchor element sat higher than 50% from the top edge of the viewport then the popover children would overflow their container (becoming inaccessible and "doing weird things"), or if it sat lower then the popover would not display at all.

These are 2 distinct issues, both related to the interaction of `@react-aria/overlays` and styling of the console's `<Popover>` component.

The first case (child overflow) is addressed by making the popover element's inner content scrollable with `overflow: auto;`. Alternatively we could allow the popover to expand beyond the viewport, but the popover does not scroll with the rest of the page while shown, so content beyond the viewport would still be unreachable except by expanding the browser window.

The other case (total disappearance) occurs when `@react-aria/overlays` positions the popover by the `bottom` property rather than `top`. Combined with the `top-full` class, this squeezes the popover from both sides to a height of zero. Removing the `top-full` class and adding margin for symmetry fixes this issue, and as far as I can tell does not affect any layouts elsewhere. (At this point, the `<Popover>` component is only used in DatePicker and DateRangePicker.)