### PR TITLE
minor: Fix flaky silo form scroll test in Firefox

### DIFF
--- a/test/e2e/image-upload.e2e.ts
+++ b/test/e2e/image-upload.e2e.ts
@@ -44,7 +44,7 @@ async function fillForm(page: Page, name: string) {
   await page.fill('role=textbox[name="Description"]', 'image description')
   await page.fill('role=textbox[name="OS"]', 'Ubuntu')
   await page.fill('role=textbox[name="Version"]', 'Dapper Drake')
-  await chooseFile(page, page.getByLabel('Image file'))
+  await chooseFile(page.getByLabel('Image file'))
 }
 
 test.describe('Image upload', () => {
@@ -114,7 +114,7 @@ test.describe('Image upload', () => {
     await expectNotVisible(page, [nameRequired])
 
     // now set the file, clear it, and submit again
-    await chooseFile(page, page.getByLabel('Image file'))
+    await chooseFile(page.getByLabel('Image file'))
     await expectNotVisible(page, [fileRequired])
 
     await page.click('role=button[name="Clear file"]')

--- a/test/e2e/silos.e2e.ts
+++ b/test/e2e/silos.e2e.ts
@@ -97,8 +97,8 @@ test('Create silo', async ({ page }) => {
   // Validation error for missing name + key and cert files
   await expectVisible(page, [certRequired, keyRequired, nameRequired])
 
-  await chooseFile(page, page.getByLabel('Cert', { exact: true }), 'small')
-  await chooseFile(page, page.getByLabel('Key'), 'small')
+  await chooseFile(page.getByLabel('Cert', { exact: true }), 'small')
+  await chooseFile(page.getByLabel('Key'), 'small')
   const certName = certDialog.getByRole('textbox', { name: 'Name' })
   await certName.fill('test-cert')
 
@@ -118,8 +118,8 @@ test('Create silo', async ({ page }) => {
 
   // Change the name so it's unique
   await certName.fill('test-cert-2')
-  await chooseFile(page, page.getByLabel('Cert', { exact: true }), 'small')
-  await chooseFile(page, page.getByLabel('Key'), 'small')
+  await chooseFile(page.getByLabel('Cert', { exact: true }), 'small')
+  await chooseFile(page.getByLabel('Key'), 'small')
   await certSubmit.click()
   await expect(page.getByRole('cell', { name: 'test-cert-2', exact: true })).toBeVisible()
 

--- a/test/e2e/utils.ts
+++ b/test/e2e/utils.ts
@@ -254,15 +254,8 @@ export const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve
 const bigFile = Buffer.alloc(3 * MiB, 'a')
 const smallFile = Buffer.alloc(0.1 * MiB, 'a')
 
-export async function chooseFile(
-  page: Page,
-  inputLocator: Locator,
-  size: 'large' | 'small' = 'large'
-) {
-  const fileChooserPromise = page.waitForEvent('filechooser')
-  await inputLocator.click({ force: true })
-  const fileChooser = await fileChooserPromise
-  await fileChooser.setFiles({
+export async function chooseFile(input: Locator, size: 'large' | 'small' = 'large') {
+  await input.setInputFiles({
     name: 'my-image.iso',
     mimeType: 'application/octet-stream',
     // fill with nonzero content, otherwise we'll skip the whole thing, which
@@ -288,8 +281,8 @@ export async function addTlsCert(page: Page) {
     .getByRole('dialog', { name: 'Add TLS certificate' })
     .getByRole('textbox', { name: 'Name' })
     .fill('test-cert')
-  await chooseFile(page, page.getByLabel('Cert', { exact: true }), 'small')
-  await chooseFile(page, page.getByLabel('Key'), 'small')
+  await chooseFile(page.getByLabel('Cert', { exact: true }), 'small')
+  await chooseFile(page.getByLabel('Key'), 'small')
   await page.getByRole('button', { name: 'Add Certificate' }).click()
 }
 


### PR DESCRIPTION
Use setInputFiles directly instead of waitForEvent("filechooser") + click, which intermittently times out in Firefox inside a Base UI Dialog.

This is one of a few new flakes we're seeing after #3089, and the only one I was able to repro locally with the `--repeat-each` trick.