### PR TITLE
fix: bump max instance vcpu to 254

### DIFF
--- a/app/api/util.ts
+++ b/app/api/util.ts
@@ -26,16 +26,15 @@ import type {
   VpcFirewallRuleUpdate,
 } from './__generated__/Api'
 
-// API limits encoded in https://github.com/oxidecomputer/omicron/blob/44e65c3/nexus/src/app/mod.rs#L130-L161
+// API limits encoded in https://github.com/oxidecomputer/omicron/blob/9dd23096de93c7d6d05ea21f6323de4410060652/nexus/src/app/mod.rs#L142
 
 // These are not actually used in app code, just the mock server. In the app we
 // can rely on API errors to communicate these limits.
 export const MAX_NICS_PER_INSTANCE = 8
 export const MAX_DISKS_PER_INSTANCE = 12
 
-// Limit is 254 on the backend but we haven't shipped any hardware that supports
-// that, so let's do 128 for now
-export const INSTANCE_MAX_CPU = 128
+// Limit is 254 on the backend.
+export const INSTANCE_MAX_CPU = 254
 
 export const INSTANCE_MIN_RAM_GiB = 1
 export const INSTANCE_MAX_RAM_GiB = 1536

--- a/mock-api/sled.ts
+++ b/mock-api/sled.ts
@@ -25,7 +25,7 @@ export const sleds: Json<Sled[]> = [
       serial: 'BRM02222869',
       revision: 0,
     },
-    usable_hardware_threads: 128,
+    usable_hardware_threads: 254,
     usable_physical_ram: 1_099_511_627_776,
   },
   {
@@ -43,7 +43,7 @@ export const sleds: Json<Sled[]> = [
       serial: 'BRM02222870',
       revision: 0,
     },
-    usable_hardware_threads: 128,
+    usable_hardware_threads: 254,
     usable_physical_ram: 1_099_511_627_776,
   },
   {
@@ -60,7 +60,7 @@ export const sleds: Json<Sled[]> = [
       serial: 'BRM02222868',
       revision: 0,
     },
-    usable_hardware_threads: 128,
+    usable_hardware_threads: 254,
     usable_physical_ram: 1_099_511_627_776,
   },
   {
@@ -77,7 +77,7 @@ export const sleds: Json<Sled[]> = [
       serial: 'BRM02222867',
       revision: 0,
     },
-    usable_hardware_threads: 128,
+    usable_hardware_threads: 254,
     usable_physical_ram: 1_099_511_627_776,
   },
 ]

--- a/test/e2e/instance-create.e2e.ts
+++ b/test/e2e/instance-create.e2e.ts
@@ -699,7 +699,7 @@ test('Validate CPU and RAM', async ({ page }) => {
 
   const submitButton = page.getByRole('button', { name: 'Create instance' })
 
-  const cpuMsg = page.getByText('Can be at most 128').first()
+  const cpuMsg = page.getByText('Can be at most 254').first()
   const memMsg = page.getByText('Can be at most 1536 GiB').first()
 
   await expect(cpuMsg).toBeHidden()


### PR DESCRIPTION
The Oxide control plane already supports 254 vCPUs per instance as of https://github.com/oxidecomputer/omicron/pull/9385, Turin only of course. Bumped the console code to match.

Closes https://github.com/oxidecomputer/console/issues/3109