### PR TITLE
Move theme arrow to left of dropdown

### DIFF
--- a/app/components/TopBar.tsx
+++ b/app/components/TopBar.tsx
@@ -10,7 +10,6 @@ import { Link } from 'react-router'
 
 import { api, navToLogin, useApiMutation } from '@oxide/api'
 import {
-  DirectionLeftIcon,
   Monitor12Icon,
   Moon12Icon,
   Organization16Icon,
@@ -148,15 +147,9 @@ function UserMenu() {
         </div>
       </DropdownMenu.Trigger>
       <DropdownMenu.Content gap={8}>
-        <DropdownMenu.LinkItem className="pl-8" to={pb.profile()}>
-          Settings
-        </DropdownMenu.LinkItem>
+        <DropdownMenu.LinkItem to={pb.profile()}>Settings</DropdownMenu.LinkItem>
         <ThemeSubmenu />
-        <DropdownMenu.Item
-          className="pl-8"
-          onSelect={() => logout.mutate({})}
-          label="Sign out"
-        />
+        <DropdownMenu.Item onSelect={() => logout.mutate({})} label="Sign out" />
       </DropdownMenu.Content>
     </DropdownMenu.Root>
   )
@@ -166,11 +159,7 @@ function ThemeSubmenu() {
   const { theme, setTheme } = useThemeStore()
   return (
     <DropdownMenu.Submenu>
-      <DropdownMenu.SubmenuTrigger className="DropdownMenuItem ox-menu-item border-secondary border-b pl-8">
-        <DirectionLeftIcon
-          className="text-quaternary absolute top-1/2 left-2 -translate-y-1/2"
-          aria-hidden
-        />
+      <DropdownMenu.SubmenuTrigger className="DropdownMenuItem ox-menu-item border-secondary border-b">
         Theme
       </DropdownMenu.SubmenuTrigger>
       <DropdownMenu.SubContent>


### PR DESCRIPTION
This moves the Theme arrow from the right-hand side of the row to the left-hand side of the row, so that it points to the modal extension menu.
<img width="317" height="207" alt="Screenshot 2026-03-12 at 3 53 21 PM" src="https://github.com/user-attachments/assets/55379051-f3b1-4612-908f-23dfd9621ab0" />
