### PR TITLE
adjust badge color for selected dropdown item

### DIFF
--- a/app/ui/styles/themes/selection.css
+++ b/app/ui/styles/themes/selection.css
@@ -28,7 +28,7 @@
   & .ox-tag,
   & .ox-button:not(.btn-ghost),
   & .ox-radio-card {
-    --content-default: var(--content-inverse);
+    --content-default: var(--content-accent-secondary);
     --content-accent: var(--content-inverse);
     --surface-accent-secondary: var(--theme-accent-100);
     --surface-accent-secondary-hover: var(--theme-accent-200);


### PR DESCRIPTION
As a fix for these two …
<img width="469" height="382" alt="Image" src="https://github.com/user-attachments/assets/f015c4db-8532-47f2-80a0-517e975365e5" />
<img width="462" height="368" alt="Image" src="https://github.com/user-attachments/assets/aa89cda9-57bf-4569-bd66-6817224e63b5" />

We adjust the text for badges on selected dropdown items:
<img width="446" height="371" alt="Image" src="https://github.com/user-attachments/assets/2c9d80f4-af25-4a60-b6b3-77c8481fe217" />
<img width="465" height="368" alt="Image" src="https://github.com/user-attachments/assets/beb5cad4-0fc5-4eee-90af-fe8da7d74b65" />