### PR TITLE
Improve "Jump To" (cmd-k) dialog

### DIFF
--- a/app/pages/ProjectsPage.tsx
+++ b/app/pages/ProjectsPage.tsx
@@ -96,11 +96,13 @@ export default function ProjectsPage() {
   )
 
   const columns = useColsWithActions(staticCols, makeActions)
-  const { table } = useQueryTable({ query: projectList, columns, emptyState: <EmptyState /> })
+  const { table } = useQueryTable({
+    query: projectList,
+    columns,
+    emptyState: <EmptyState />,
+  })
 
-  const { data: allProjects } = useQuery(
-    q(api.projectList, { query: { limit: ALL_ISH } })
-  )
+  const { data: allProjects } = useQuery(q(api.projectList, { query: { limit: ALL_ISH } }))
   useQuickActions(
     useMemo(
       () => [

--- a/app/pages/ProjectsPage.tsx
+++ b/app/pages/ProjectsPage.tsx
@@ -5,6 +5,7 @@
  *
  * Copyright Oxide Computer Company
  */
+import { useQuery } from '@tanstack/react-query'
 import { createColumnHelper } from '@tanstack/react-table'
 import { useCallback, useMemo } from 'react'
 import { Outlet, useNavigate } from 'react-router'
@@ -24,6 +25,7 @@ import { CreateLink } from '~/ui/lib/CreateButton'
 import { EmptyMessage } from '~/ui/lib/EmptyMessage'
 import { PageHeader, PageTitle } from '~/ui/lib/PageHeader'
 import { TableActions } from '~/ui/lib/Table'
+import { ALL_ISH } from '~/util/consts'
 import { docLinks } from '~/util/links'
 import { pb } from '~/util/path-builder'
 
@@ -94,11 +96,11 @@ export default function ProjectsPage() {
   )
 
   const columns = useColsWithActions(staticCols, makeActions)
-  const {
-    table,
-    query: { data: projects },
-  } = useQueryTable({ query: projectList, columns, emptyState: <EmptyState /> })
+  const { table } = useQueryTable({ query: projectList, columns, emptyState: <EmptyState /> })
 
+  const { data: allProjects } = useQuery(
+    q(api.projectList, { query: { limit: ALL_ISH } })
+  )
   useQuickActions(
     useMemo(
       () => [
@@ -106,13 +108,13 @@ export default function ProjectsPage() {
           value: 'New project',
           onSelect: () => navigate(pb.projectsNew()),
         },
-        ...(projects?.items || []).map((p) => ({
+        ...(allProjects?.items || []).map((p) => ({
           value: p.name,
           onSelect: () => navigate(pb.project({ project: p.name })),
           navGroup: 'Go to project',
         })),
       ],
-      [navigate, projects]
+      [navigate, allProjects]
     )
   )
 

--- a/app/pages/ProjectsPage.tsx
+++ b/app/pages/ProjectsPage.tsx
@@ -132,7 +132,7 @@ export default function ProjectsPage() {
         />
       </PageHeader>
       <TableActions>
-        <CreateLink to={pb.projectsNew()}>New Project</CreateLink>
+        <CreateLink to={pb.projectsNew()}>New project</CreateLink>
       </TableActions>
       {table}
       <Outlet />

--- a/app/pages/SiloAccessPage.tsx
+++ b/app/pages/SiloAccessPage.tsx
@@ -30,6 +30,7 @@ import {
   SiloAccessEditUserSideModal,
 } from '~/forms/silo-access'
 import { useCurrentUser } from '~/hooks/use-current-user'
+import { useQuickActions } from '~/hooks/use-quick-actions'
 import { confirmDelete } from '~/stores/confirm-delete'
 import { addToast } from '~/stores/toast'
 import { getActionsCol } from '~/table/columns/action-col'
@@ -163,6 +164,18 @@ export default function SiloAccessPage() {
     data: rows,
     getCoreRowModel: getCoreRowModel(),
   })
+
+  useQuickActions(
+    useMemo(
+      () => [
+        {
+          value: 'Add user or group',
+          onSelect: () => setAddModalOpen(true),
+        },
+      ],
+      []
+    )
+  )
 
   return (
     <>

--- a/app/pages/SiloImagesPage.tsx
+++ b/app/pages/SiloImagesPage.tsx
@@ -9,7 +9,7 @@ import { useQuery } from '@tanstack/react-query'
 import { createColumnHelper } from '@tanstack/react-table'
 import { useCallback, useMemo, useState } from 'react'
 import { useForm } from 'react-hook-form'
-import { Outlet } from 'react-router'
+import { Outlet, useNavigate } from 'react-router'
 
 import { api, getListQFn, q, queryClient, useApiMutation, type Image } from '@oxide/api'
 import { Images16Icon, Images24Icon } from '@oxide/design-system/icons/react'
@@ -20,6 +20,7 @@ import { toImageComboboxItem } from '~/components/form/fields/ImageSelectField'
 import { ListboxField } from '~/components/form/fields/ListboxField'
 import { ModalForm } from '~/components/form/ModalForm'
 import { HL } from '~/components/HL'
+import { useQuickActions } from '~/hooks/use-quick-actions'
 import { confirmDelete } from '~/stores/confirm-delete'
 import { addToast } from '~/stores/toast'
 import { makeLinkCell } from '~/table/cells/LinkCell'
@@ -32,6 +33,7 @@ import { EmptyMessage } from '~/ui/lib/EmptyMessage'
 import { Message } from '~/ui/lib/Message'
 import { PageHeader, PageTitle } from '~/ui/lib/PageHeader'
 import { TableActions } from '~/ui/lib/Table'
+import { ALL_ISH } from '~/util/consts'
 import { docLinks } from '~/util/links'
 import { pb } from '~/util/path-builder'
 
@@ -93,6 +95,26 @@ export default function SiloImagesPage() {
 
   const columns = useColsWithActions(staticCols, makeActions)
   const { table } = useQueryTable({ query: imageList, columns, emptyState: <EmptyState /> })
+
+  const navigate = useNavigate()
+  const { data: allImages } = useQuery(q(api.imageList, { query: { limit: ALL_ISH } }))
+  useQuickActions(
+    useMemo(
+      () => [
+        {
+          value: 'Promote image',
+          onSelect: () => setShowModal(true),
+        },
+        ...(allImages?.items || []).map((i) => ({
+          value: i.name,
+          onSelect: () => navigate(pb.siloImageEdit({ image: i.name })),
+          navGroup: 'Go to silo image',
+        })),
+      ],
+      [navigate, allImages]
+    )
+  )
+
   return (
     <>
       <PageHeader>

--- a/app/pages/project/access/ProjectAccessPage.tsx
+++ b/app/pages/project/access/ProjectAccessPage.tsx
@@ -35,6 +35,7 @@ import {
   ProjectAccessEditUserSideModal,
 } from '~/forms/project-access'
 import { getProjectSelector, useProjectSelector } from '~/hooks/use-params'
+import { useQuickActions } from '~/hooks/use-quick-actions'
 import { confirmDelete } from '~/stores/confirm-delete'
 import { addToast } from '~/stores/toast'
 import { getActionsCol } from '~/table/columns/action-col'
@@ -204,6 +205,18 @@ export default function ProjectAccessPage() {
     data: rows,
     getCoreRowModel: getCoreRowModel(),
   })
+
+  useQuickActions(
+    useMemo(
+      () => [
+        {
+          value: 'Add user or group',
+          onSelect: () => setAddModalOpen(true),
+        },
+      ],
+      []
+    )
+  )
 
   return (
     <>

--- a/app/pages/project/affinity/AffinityPage.tsx
+++ b/app/pages/project/affinity/AffinityPage.tsx
@@ -144,11 +144,17 @@ export default function AffinityPage() {
     useMemo(
       () => [
         {
-          value: 'New group',
+          value: 'New anti-affinity group',
           onSelect: () => navigate(pb.affinityNew({ project })),
         },
+        ...antiAffinityGroups.map((g) => ({
+          value: g.name,
+          onSelect: () =>
+            navigate(pb.antiAffinityGroup({ project, antiAffinityGroup: g.name })),
+          navGroup: 'Go to anti-affinity group',
+        })),
       ],
-      [navigate, project]
+      [navigate, project, antiAffinityGroups]
     )
   )
 

--- a/app/pages/project/affinity/AffinityPage.tsx
+++ b/app/pages/project/affinity/AffinityPage.tsx
@@ -7,8 +7,8 @@
  */
 
 import { createColumnHelper, getCoreRowModel, useReactTable } from '@tanstack/react-table'
-import { useCallback } from 'react'
-import { Outlet, type LoaderFunctionArgs } from 'react-router'
+import { useCallback, useMemo } from 'react'
+import { Outlet, useNavigate, type LoaderFunctionArgs } from 'react-router'
 
 import {
   api,
@@ -25,6 +25,7 @@ import { AffinityDocsPopover, AffinityPolicyHeader } from '~/components/Affinity
 import { HL } from '~/components/HL'
 import { antiAffinityGroupList, antiAffinityGroupMemberList } from '~/forms/affinity-util'
 import { getProjectSelector, useProjectSelector } from '~/hooks/use-params'
+import { useQuickActions } from '~/hooks/use-quick-actions'
 import { confirmDelete } from '~/stores/confirm-delete'
 import { addToast } from '~/stores/toast'
 import { EmptyCell, SkeletonCell } from '~/table/cells/EmptyCell'
@@ -137,6 +138,19 @@ export default function AffinityPage() {
     data: antiAffinityGroups,
     getCoreRowModel: getCoreRowModel(),
   })
+
+  const navigate = useNavigate()
+  useQuickActions(
+    useMemo(
+      () => [
+        {
+          value: 'New group',
+          onSelect: () => navigate(pb.affinityNew({ project })),
+        },
+      ],
+      [navigate, project]
+    )
+  )
 
   return (
     <>

--- a/app/pages/project/disks/DisksPage.tsx
+++ b/app/pages/project/disks/DisksPage.tsx
@@ -5,6 +5,7 @@
  *
  * Copyright Oxide Computer Company
  */
+import { useQuery } from '@tanstack/react-query'
 import { createColumnHelper } from '@tanstack/react-table'
 import { useCallback, useMemo } from 'react'
 import { Outlet, useNavigate, type LoaderFunctionArgs } from 'react-router'
@@ -38,6 +39,7 @@ import { CreateLink } from '~/ui/lib/CreateButton'
 import { EmptyMessage } from '~/ui/lib/EmptyMessage'
 import { PageHeader, PageTitle } from '~/ui/lib/PageHeader'
 import { TableActions } from '~/ui/lib/Table'
+import { ALL_ISH } from '~/util/consts'
 import { docLinks } from '~/util/links'
 import { pb } from '~/util/path-builder'
 import type * as PP from '~/util/path-params'
@@ -188,6 +190,9 @@ export default function DisksPage() {
   })
 
   const navigate = useNavigate()
+  const { data: allDisks } = useQuery(
+    q(api.diskList, { query: { project, limit: ALL_ISH } })
+  )
   useQuickActions(
     useMemo(
       () => [
@@ -195,8 +200,13 @@ export default function DisksPage() {
           value: 'New disk',
           onSelect: () => navigate(pb.disksNew({ project })),
         },
+        ...(allDisks?.items || []).map((d) => ({
+          value: d.name,
+          onSelect: () => navigate(pb.disk({ project, disk: d.name })),
+          navGroup: 'Go to disk',
+        })),
       ],
-      [navigate, project]
+      [navigate, project, allDisks]
     )
   )
 

--- a/app/pages/project/disks/DisksPage.tsx
+++ b/app/pages/project/disks/DisksPage.tsx
@@ -7,7 +7,7 @@
  */
 import { createColumnHelper } from '@tanstack/react-table'
 import { useCallback, useMemo } from 'react'
-import { Outlet, type LoaderFunctionArgs } from 'react-router'
+import { Outlet, useNavigate, type LoaderFunctionArgs } from 'react-router'
 
 import {
   api,
@@ -26,6 +26,7 @@ import { HL } from '~/components/HL'
 import { DiskStateBadge, DiskTypeBadge, ReadOnlyBadge } from '~/components/StateBadge'
 import { makeCrumb } from '~/hooks/use-crumbs'
 import { getProjectSelector, useProjectSelector } from '~/hooks/use-params'
+import { useQuickActions } from '~/hooks/use-quick-actions'
 import { confirmDelete } from '~/stores/confirm-delete'
 import { addToast } from '~/stores/toast'
 import { InstanceLinkCell } from '~/table/cells/InstanceLinkCell'
@@ -185,6 +186,19 @@ export default function DisksPage() {
     columns,
     emptyState: <EmptyState />,
   })
+
+  const navigate = useNavigate()
+  useQuickActions(
+    useMemo(
+      () => [
+        {
+          value: 'New disk',
+          onSelect: () => navigate(pb.disksNew({ project })),
+        },
+      ],
+      [navigate, project]
+    )
+  )
 
   return (
     <>

--- a/app/pages/project/disks/DisksPage.tsx
+++ b/app/pages/project/disks/DisksPage.tsx
@@ -212,7 +212,7 @@ export default function DisksPage() {
         />
       </PageHeader>
       <TableActions>
-        <CreateLink to={pb.disksNew({ project })}>New Disk</CreateLink>
+        <CreateLink to={pb.disksNew({ project })}>New disk</CreateLink>
       </TableActions>
       {table}
       <Outlet />

--- a/app/pages/project/floating-ips/FloatingIpsPage.tsx
+++ b/app/pages/project/floating-ips/FloatingIpsPage.tsx
@@ -5,8 +5,9 @@
  *
  * Copyright Oxide Computer Company
  */
+import { useQuery } from '@tanstack/react-query'
 import { createColumnHelper } from '@tanstack/react-table'
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { Outlet, useNavigate, type LoaderFunctionArgs } from 'react-router'
 
@@ -28,6 +29,7 @@ import { ModalForm } from '~/components/form/ModalForm'
 import { HL } from '~/components/HL'
 import { makeCrumb } from '~/hooks/use-crumbs'
 import { getProjectSelector, useProjectSelector } from '~/hooks/use-params'
+import { useQuickActions } from '~/hooks/use-quick-actions'
 import { confirmAction } from '~/stores/confirm-action'
 import { confirmDelete } from '~/stores/confirm-delete'
 import { addToast } from '~/stores/toast'
@@ -210,6 +212,26 @@ export default function FloatingIpsPage() {
     columns,
     emptyState: <EmptyState />,
   })
+
+  const { data: allFips } = useQuery(
+    q(api.floatingIpList, { query: { project, limit: ALL_ISH } })
+  )
+  useQuickActions(
+    useMemo(
+      () => [
+        {
+          value: 'New floating IP',
+          onSelect: () => navigate(pb.floatingIpsNew({ project })),
+        },
+        ...(allFips?.items || []).map((f) => ({
+          value: f.name,
+          onSelect: () => navigate(pb.floatingIpEdit({ project, floatingIp: f.name })),
+          navGroup: 'Go to floating IP',
+        })),
+      ],
+      [project, navigate, allFips]
+    )
+  )
 
   return (
     <>

--- a/app/pages/project/images/ImagesPage.tsx
+++ b/app/pages/project/images/ImagesPage.tsx
@@ -5,17 +5,19 @@
  *
  * Copyright Oxide Computer Company
  */
+import { useQuery } from '@tanstack/react-query'
 import { createColumnHelper } from '@tanstack/react-table'
 import { useCallback, useMemo, useState } from 'react'
-import { Outlet, type LoaderFunctionArgs } from 'react-router'
+import { Outlet, useNavigate, type LoaderFunctionArgs } from 'react-router'
 
-import { api, getListQFn, queryClient, useApiMutation, type Image } from '@oxide/api'
+import { api, getListQFn, q, queryClient, useApiMutation, type Image } from '@oxide/api'
 import { Images16Icon, Images24Icon } from '@oxide/design-system/icons/react'
 
 import { DocsPopover } from '~/components/DocsPopover'
 import { HL } from '~/components/HL'
 import { makeCrumb } from '~/hooks/use-crumbs'
 import { getProjectSelector, useProjectSelector } from '~/hooks/use-params'
+import { useQuickActions } from '~/hooks/use-quick-actions'
 import { confirmDelete } from '~/stores/confirm-delete'
 import { addToast } from '~/stores/toast'
 import { makeLinkCell } from '~/table/cells/LinkCell'
@@ -28,6 +30,7 @@ import { Message } from '~/ui/lib/Message'
 import { Modal } from '~/ui/lib/Modal'
 import { PageHeader, PageTitle } from '~/ui/lib/PageHeader'
 import { TableActions } from '~/ui/lib/Table'
+import { ALL_ISH } from '~/util/consts'
 import { docLinks } from '~/util/links'
 import { pb } from '~/util/path-builder'
 import type * as PP from '~/util/path-params'
@@ -105,6 +108,27 @@ export default function ImagesPage() {
     columns,
     emptyState: <EmptyState />,
   })
+
+  const navigate = useNavigate()
+  const { data: allImages } = useQuery(
+    q(api.imageList, { query: { project, limit: ALL_ISH } })
+  )
+  useQuickActions(
+    useMemo(
+      () => [
+        {
+          value: 'Upload image',
+          onSelect: () => navigate(pb.projectImagesNew({ project })),
+        },
+        ...(allImages?.items || []).map((i) => ({
+          value: i.name,
+          onSelect: () => navigate(pb.projectImageEdit({ project, image: i.name })),
+          navGroup: 'Go to project image',
+        })),
+      ],
+      [project, navigate, allImages]
+    )
+  )
 
   return (
     <>

--- a/app/pages/project/instances/InstancesPage.tsx
+++ b/app/pages/project/instances/InstancesPage.tsx
@@ -6,12 +6,12 @@
  * Copyright Oxide Computer Company
  */
 import { type UseQueryOptions } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { createColumnHelper } from '@tanstack/react-table'
 import { filesize } from 'filesize'
 import { useMemo, useRef, useState } from 'react'
 import { useNavigate, type LoaderFunctionArgs } from 'react-router'
 
-import { useQuery } from '@tanstack/react-query'
 import {
   api,
   getListQFn,
@@ -39,8 +39,8 @@ import { PageHeader, PageTitle } from '~/ui/lib/PageHeader'
 import { TableActions } from '~/ui/lib/Table'
 import { Tooltip } from '~/ui/lib/Tooltip'
 import { setDiff } from '~/util/array'
-import { toLocaleTimeString } from '~/util/date'
 import { ALL_ISH } from '~/util/consts'
+import { toLocaleTimeString } from '~/util/date'
 import { pb } from '~/util/path-builder'
 import { pluralize } from '~/util/str'
 

--- a/app/pages/project/instances/InstancesPage.tsx
+++ b/app/pages/project/instances/InstancesPage.tsx
@@ -11,9 +11,11 @@ import { filesize } from 'filesize'
 import { useMemo, useRef, useState } from 'react'
 import { useNavigate, type LoaderFunctionArgs } from 'react-router'
 
+import { useQuery } from '@tanstack/react-query'
 import {
   api,
   getListQFn,
+  q,
   queryClient,
   type ApiError,
   type Instance,
@@ -38,6 +40,7 @@ import { TableActions } from '~/ui/lib/Table'
 import { Tooltip } from '~/ui/lib/Tooltip'
 import { setDiff } from '~/util/array'
 import { toLocaleTimeString } from '~/util/date'
+import { ALL_ISH } from '~/util/consts'
 import { pb } from '~/util/path-builder'
 import { pluralize } from '~/util/str'
 
@@ -191,8 +194,11 @@ export default function InstancesPage() {
     emptyState: <EmptyState />,
   })
 
-  const { data: instances, dataUpdatedAt } = query
+  const { dataUpdatedAt } = query
 
+  const { data: allInstances } = useQuery(
+    q(api.instanceList, { query: { project, limit: ALL_ISH } })
+  )
   const navigate = useNavigate()
   useQuickActions(
     useMemo(
@@ -201,13 +207,13 @@ export default function InstancesPage() {
           value: 'New instance',
           onSelect: () => navigate(pb.instancesNew({ project })),
         },
-        ...(instances?.items || []).map((i) => ({
+        ...(allInstances?.items || []).map((i) => ({
           value: i.name,
           onSelect: () => navigate(pb.instance({ project, instance: i.name })),
           navGroup: 'Go to instance',
         })),
       ],
-      [project, instances, navigate]
+      [project, allInstances, navigate]
     )
   )
 

--- a/app/pages/project/instances/InstancesPage.tsx
+++ b/app/pages/project/instances/InstancesPage.tsx
@@ -5,8 +5,7 @@
  *
  * Copyright Oxide Computer Company
  */
-import { type UseQueryOptions } from '@tanstack/react-query'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query'
 import { createColumnHelper } from '@tanstack/react-table'
 import { filesize } from 'filesize'
 import { useMemo, useRef, useState } from 'react'

--- a/app/pages/project/snapshots/SnapshotsPage.tsx
+++ b/app/pages/project/snapshots/SnapshotsPage.tsx
@@ -7,7 +7,7 @@
  */
 import { useQuery } from '@tanstack/react-query'
 import { createColumnHelper } from '@tanstack/react-table'
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { Outlet, useNavigate, type LoaderFunctionArgs } from 'react-router'
 
 import {
@@ -27,6 +27,7 @@ import { DocsPopover } from '~/components/DocsPopover'
 import { SnapshotStateBadge } from '~/components/StateBadge'
 import { makeCrumb } from '~/hooks/use-crumbs'
 import { getProjectSelector, useProjectSelector } from '~/hooks/use-params'
+import { useQuickActions } from '~/hooks/use-quick-actions'
 import { DiskDetailSideModal } from '~/pages/project/disks/DiskDetailSideModal'
 import { confirmDelete } from '~/stores/confirm-delete'
 import { SkeletonCell } from '~/table/cells/EmptyCell'
@@ -164,6 +165,19 @@ export default function SnapshotsPage() {
     columns,
     emptyState: <EmptyState />,
   })
+
+  useQuickActions(
+    useMemo(
+      () => [
+        {
+          value: 'New snapshot',
+          onSelect: () => navigate(pb.snapshotsNew({ project })),
+        },
+      ],
+      [navigate, project]
+    )
+  )
+
   return (
     <>
       <PageHeader>

--- a/app/pages/project/vpcs/VpcsPage.tsx
+++ b/app/pages/project/vpcs/VpcsPage.tsx
@@ -29,6 +29,7 @@ import { CreateLink } from '~/ui/lib/CreateButton'
 import { EmptyMessage } from '~/ui/lib/EmptyMessage'
 import { PageHeader, PageTitle } from '~/ui/lib/PageHeader'
 import { TableActions } from '~/ui/lib/Table'
+import { ALL_ISH } from '~/util/consts'
 import { docLinks } from '~/util/links'
 import { pb } from '~/util/path-builder'
 import type * as PP from '~/util/path-params'
@@ -128,23 +129,27 @@ export default function VpcsPage() {
     [project, makeActions]
   )
 
-  const { table, query } = useQueryTable({
+  const { table } = useQueryTable({
     query: vpcList(project),
     columns,
     emptyState: <EmptyState />,
   })
 
-  const { data: vpcs } = query
-
+  const { data: allVpcs } = useQuery(q(api.vpcList, { query: { project, limit: ALL_ISH } }))
   useQuickActions(
     useMemo(
-      () =>
-        (vpcs?.items || []).map((v) => ({
+      () => [
+        {
+          value: 'New VPC',
+          onSelect: () => navigate(pb.vpcsNew({ project })),
+        },
+        ...(allVpcs?.items || []).map((v) => ({
           value: v.name,
           onSelect: () => navigate(pb.vpc({ project, vpc: v.name })),
           navGroup: 'Go to VPC',
         })),
-      [project, vpcs, navigate]
+      ],
+      [project, allVpcs, navigate]
     )
   )
 

--- a/app/pages/project/vpcs/VpcsPage.tsx
+++ b/app/pages/project/vpcs/VpcsPage.tsx
@@ -160,7 +160,7 @@ export default function VpcsPage() {
         <VpcDocsPopover />
       </PageHeader>
       <TableActions>
-        <CreateLink to={pb.vpcsNew({ project })}>New Vpc</CreateLink>
+        <CreateLink to={pb.vpcsNew({ project })}>New VPC</CreateLink>
       </TableActions>
       {table}
       <Outlet />

--- a/app/pages/system/networking/IpPoolsPage.tsx
+++ b/app/pages/system/networking/IpPoolsPage.tsx
@@ -31,6 +31,7 @@ import { CreateLink } from '~/ui/lib/CreateButton'
 import { EmptyMessage } from '~/ui/lib/EmptyMessage'
 import { PageHeader, PageTitle } from '~/ui/lib/PageHeader'
 import { TableActions } from '~/ui/lib/Table'
+import { ALL_ISH } from '~/util/consts'
 import { docLinks } from '~/util/links'
 import { pb } from '~/util/path-builder'
 
@@ -120,15 +121,15 @@ export default function IpPoolsPage() {
   )
 
   const columns = useColsWithActions(staticColumns, makeActions)
-  const { table, query } = useQueryTable({
+  const { table } = useQueryTable({
     query: ipPoolList,
     columns,
     // turn this back on if we expect to see IPv6 ranges regularly
     // rowHeight: 'large',
     emptyState: <EmptyState />,
   })
-  const { data: pools } = query
 
+  const { data: allPools } = useQuery(q(api.ipPoolList, { query: { limit: ALL_ISH } }))
   useQuickActions(
     useMemo(
       () => [
@@ -136,13 +137,13 @@ export default function IpPoolsPage() {
           value: 'New IP pool',
           onSelect: () => navigate(pb.ipPoolsNew()),
         },
-        ...(pools?.items || []).map((p) => ({
+        ...(allPools?.items || []).map((p) => ({
           value: p.name,
           onSelect: () => navigate(pb.ipPool({ pool: p.name })),
           navGroup: 'Go to IP pool',
         })),
       ],
-      [navigate, pools]
+      [navigate, allPools]
     )
   )
 

--- a/app/pages/system/networking/IpPoolsPage.tsx
+++ b/app/pages/system/networking/IpPoolsPage.tsx
@@ -129,7 +129,9 @@ export default function IpPoolsPage() {
     emptyState: <EmptyState />,
   })
 
-  const { data: allPools } = useQuery(q(api.ipPoolList, { query: { limit: ALL_ISH } }))
+  const { data: allPools } = useQuery(
+    q(api.systemIpPoolList, { query: { limit: ALL_ISH } })
+  )
   useQuickActions(
     useMemo(
       () => [

--- a/app/pages/system/silos/SilosPage.tsx
+++ b/app/pages/system/silos/SilosPage.tsx
@@ -107,7 +107,7 @@ export default function SilosPage() {
         ...(allSilos?.items || []).map((o) => ({
           value: o.name,
           onSelect: () => navigate(pb.silo({ silo: o.name })),
-          navGroup: 'Silo detail',
+          navGroup: 'Go to silo',
         })),
       ],
       [navigate, allSilos]

--- a/app/pages/system/silos/SilosPage.tsx
+++ b/app/pages/system/silos/SilosPage.tsx
@@ -5,11 +5,12 @@
  *
  * Copyright Oxide Computer Company
  */
+import { useQuery } from '@tanstack/react-query'
 import { createColumnHelper } from '@tanstack/react-table'
 import { useCallback, useMemo } from 'react'
 import { Outlet, useNavigate } from 'react-router'
 
-import { api, getListQFn, queryClient, useApiMutation, type Silo } from '@oxide/api'
+import { api, getListQFn, q, queryClient, useApiMutation, type Silo } from '@oxide/api'
 import { Cloud16Icon, Cloud24Icon } from '@oxide/design-system/icons/react'
 import { Badge } from '@oxide/design-system/ui'
 
@@ -28,6 +29,7 @@ import { CreateLink } from '~/ui/lib/CreateButton'
 import { EmptyMessage } from '~/ui/lib/EmptyMessage'
 import { PageHeader, PageTitle } from '~/ui/lib/PageHeader'
 import { TableActions } from '~/ui/lib/Table'
+import { ALL_ISH } from '~/util/consts'
 import { docLinks } from '~/util/links'
 import { pb } from '~/util/path-builder'
 
@@ -91,24 +93,24 @@ export default function SilosPage() {
   )
 
   const columns = useColsWithActions(staticCols, makeActions)
-  const { table, query } = useQueryTable({
+  const { table } = useQueryTable({
     query: siloList(),
     columns,
     emptyState: <EmptyState />,
   })
-  const { data: silos } = query
 
+  const { data: allSilos } = useQuery(q(api.siloList, { query: { limit: ALL_ISH } }))
   useQuickActions(
     useMemo(
       () => [
         { value: 'New silo', onSelect: () => navigate(pb.silosNew()) },
-        ...(silos?.items || []).map((o) => ({
+        ...(allSilos?.items || []).map((o) => ({
           value: o.name,
           onSelect: () => navigate(pb.silo({ silo: o.name })),
           navGroup: 'Silo detail',
         })),
       ],
-      [navigate, silos]
+      [navigate, allSilos]
     )
   )
 

--- a/test/e2e/click-everything.e2e.ts
+++ b/test/e2e/click-everything.e2e.ts
@@ -46,7 +46,7 @@ test('Click through disks page', async ({ page }) => {
   // TODO: assert that disks 1-3 are attached and 4 is not
 
   // Create disk form
-  await page.click('role=link[name="New Disk"]')
+  await page.click('role=link[name="New disk"]')
   await expectVisible(page, [
     'role=heading[name*="Create disk"]',
     'role=textbox[name="Name"]',

--- a/test/e2e/networking.e2e.ts
+++ b/test/e2e/networking.e2e.ts
@@ -31,7 +31,7 @@ test('Create and edit VPC', async ({ page }) => {
   await expect(table.getByRole('row')).toHaveCount(2) // header plus row
 
   // New VPC form
-  await page.getByRole('link', { name: 'New Vpc' }).click()
+  await page.getByRole('link', { name: 'New VPC' }).click()
   await page.getByRole('textbox', { name: 'Name', exact: true }).fill('another-vpc')
   await page.getByRole('textbox', { name: 'DNS name' }).fill('another-vpc')
   await page.getByRole('button', { name: 'Create VPC' }).click()

--- a/test/e2e/vpcs.e2e.ts
+++ b/test/e2e/vpcs.e2e.ts
@@ -425,7 +425,7 @@ test('collaborator can create VPC', async ({ browser }) => {
   const table = page.getByRole('table')
 
   // Create a new VPC
-  await page.getByRole('link', { name: 'New Vpc' }).click()
+  await page.getByRole('link', { name: 'New VPC' }).click()
   await page.getByRole('textbox', { name: 'Name', exact: true }).fill('collab-test-vpc')
   await page.getByRole('textbox', { name: 'DNS name' }).fill('collab-test-vpc')
   await page.getByRole('button', { name: 'Create VPC' }).click()
@@ -453,7 +453,7 @@ test('user in group with silo collaborator role can create VPC', async ({ browse
   const table = page.getByRole('table')
 
   // Create a new VPC
-  await page.getByRole('link', { name: 'New Vpc' }).click()
+  await page.getByRole('link', { name: 'New VPC' }).click()
   await page.getByRole('textbox', { name: 'Name', exact: true }).fill('group-test-vpc')
   await page.getByRole('textbox', { name: 'DNS name' }).fill('group-test-vpc')
   await page.getByRole('button', { name: 'Create VPC' }).click()
@@ -477,7 +477,7 @@ test('limited collaborator cannot create VPC', async ({ browser }) => {
   await page.goto('/projects/mock-project/vpcs')
 
   // Try to create a new VPC
-  await page.getByRole('link', { name: 'New Vpc' }).click()
+  await page.getByRole('link', { name: 'New VPC' }).click()
   await page.getByRole('textbox', { name: 'Name', exact: true }).fill('limited-test-vpc')
   await page.getByRole('textbox', { name: 'DNS name' }).fill('limited-test-vpc')
   await page.getByRole('button', { name: 'Create VPC' }).click()


### PR DESCRIPTION
- Closes: https://github.com/oxidecomputer/console/issues/3128
- Closes: https://github.com/oxidecomputer/console/issues/2572

I was initially excited about using `cmd-k` to navigate the UI with the keyboard but immediately ran into some limitations and so took a stab at improving them.

- Fix multi-page search in cmd-k: Projects, Project Instances, Project VPCs, Project IP Pools, Silos
- Add missing search to cmd-k: Project Floating IPs, Silo Images, Project Images
- Add action from button to cmd-k:
  - Project Affinity: "New Group"
  - Project Access: "Add user or group"
  - Project Disks: "New disk"
  - Project Floating IPs: "New Floating IP"
  - Project Images: "Upload Image"
  - Project Snapshots: "New Snapshot"
  - Project VPC: "New VPC"
  - Silo Access: "Add user or Group"
  - Silo Images: Add "Promote image"

This is my first PR to oxidecomputer/console and was Claude assisted.
I have tested locally and verified these changes seem to work as expected. (see images in #3128)
If this is the wrong approach / redundant, feel free to summarily close.