### PR TITLE
put in missing quick actions on VPC child tabs

### DIFF
--- a/app/pages/project/vpcs/VpcFirewallRulesTab.tsx
+++ b/app/pages/project/vpcs/VpcFirewallRulesTab.tsx
@@ -22,6 +22,7 @@ import {
 import { ListPlusCell } from '~/components/ListPlusCell'
 import { ProtocolBadge } from '~/components/ProtocolBadge'
 import { getVpcSelector, useVpcSelector } from '~/hooks/use-params'
+import { useQuickActions } from '~/hooks/use-quick-actions'
 import { confirmDelete } from '~/stores/confirm-delete'
 import { EnabledCell } from '~/table/cells/EnabledCell'
 import { LinkCell } from '~/table/cells/LinkCell'
@@ -168,6 +169,22 @@ export default function VpcFirewallRulesTab() {
   }, [navigate, rules, updateRules, vpcSelector])
 
   const table = useReactTable({ columns, data: rules, getCoreRowModel: getCoreRowModel() })
+
+  useQuickActions(
+    () => [
+      {
+        value: 'New firewall rule',
+        navGroup: 'Actions',
+        action: pb.vpcFirewallRulesNew(vpcSelector),
+      },
+      ...rules.map((r) => ({
+        value: r.name,
+        navGroup: 'Edit firewall rule',
+        action: pb.vpcFirewallRuleEdit({ ...vpcSelector, rule: r.name }),
+      })),
+    ],
+    [vpcSelector, rules]
+  )
 
   const emptyState = (
     <TableEmptyBox>

--- a/app/pages/project/vpcs/VpcRoutersTab.tsx
+++ b/app/pages/project/vpcs/VpcRoutersTab.tsx
@@ -14,6 +14,7 @@ import { api, getListQFn, q, queryClient, useApiMutation, type VpcRouter } from 
 import { HL } from '~/components/HL'
 import { routeFormMessage } from '~/forms/vpc-router-route-common'
 import { getVpcSelector, useVpcSelector } from '~/hooks/use-params'
+import { useQuickActions } from '~/hooks/use-quick-actions'
 import { confirmDelete } from '~/stores/confirm-delete'
 import { addToast } from '~/stores/toast'
 import { makeLinkCell } from '~/table/cells/LinkCell'
@@ -103,11 +104,27 @@ export default function VpcRoutersTab() {
   )
 
   const columns = useColsWithActions(staticColumns, makeActions)
-  const { table } = useQueryTable({
+  const { table, query } = useQueryTable({
     query: vpcRouterList({ project, vpc }),
     columns,
     emptyState,
   })
+
+  useQuickActions(
+    () => [
+      {
+        value: 'New router',
+        navGroup: 'Actions',
+        action: pb.vpcRoutersNew({ project, vpc }),
+      },
+      ...(query.data?.items || []).map((r) => ({
+        value: r.name,
+        navGroup: 'Edit router',
+        action: pb.vpcRouterEdit({ project, vpc, router: r.name }),
+      })),
+    ],
+    [project, vpc, query.data]
+  )
 
   return (
     <>

--- a/app/pages/project/vpcs/VpcSubnetsTab.tsx
+++ b/app/pages/project/vpcs/VpcSubnetsTab.tsx
@@ -12,6 +12,7 @@ import { Outlet, type LoaderFunctionArgs } from 'react-router'
 import { api, getListQFn, queryClient, useApiMutation, type VpcSubnet } from '@oxide/api'
 
 import { getVpcSelector, useVpcSelector } from '~/hooks/use-params'
+import { useQuickActions } from '~/hooks/use-quick-actions'
 import { confirmDelete } from '~/stores/confirm-delete'
 import { addToast } from '~/stores/toast'
 import { makeLinkCell } from '~/table/cells/LinkCell'
@@ -96,12 +97,28 @@ export default function VpcSubnetsTab() {
     />
   )
 
-  const { table } = useQueryTable({
+  const { table, query } = useQueryTable({
     query: subnetList(vpcSelector),
     columns,
     emptyState,
     rowHeight: 'large',
   })
+
+  useQuickActions(
+    () => [
+      {
+        value: 'New VPC subnet',
+        navGroup: 'Actions',
+        action: pb.vpcSubnetsNew(vpcSelector),
+      },
+      ...(query.data?.items || []).map((s) => ({
+        value: s.name,
+        navGroup: 'Edit VPC subnet',
+        action: pb.vpcSubnetsEdit({ ...vpcSelector, subnet: s.name }),
+      })),
+    ],
+    [vpcSelector, query.data]
+  )
 
   return (
     <>


### PR DESCRIPTION
Noticed there were no create/edit quick actions on firewall rules, VPC routers, or VPC subnets.

<img width="883" height="678" alt="image" src="https://github.com/user-attachments/assets/6d8f2749-5540-4b1d-8afc-08e88872c786" />
