### PR TITLE
Fix progress bar accent colour

### DIFF
--- a/app/ui/lib/Progress.tsx
+++ b/app/ui/lib/Progress.tsx
@@ -25,7 +25,7 @@ export const Progress = (props: ProgressProps) => (
     {...ariaLabel(props)}
   >
     <div
-      className="bg-accent h-1 rounded-[1px]"
+      className="bg-accent-inverse h-1 rounded-[1px]"
       style={{
         width: `${props.value}%`,
         transition:


### PR DESCRIPTION
Latest design system update means`bg-accent` is now `bg-accent-inverse`. Confusing change? Yes, but semantically much better now.

<img width="1360" height="1216" alt="image" src="https://github.com/user-attachments/assets/fdccc888-7fcb-419c-9c19-f46b3c4f040f" />
