### PR TITLE
Fix dead space in combobox dropdown

### DIFF
--- a/app/ui/lib/Combobox.tsx
+++ b/app/ui/lib/Combobox.tsx
@@ -252,7 +252,7 @@ export const Combobox = ({
               {items.length > 0 && (
                 <ComboboxButton
                   className={cn(
-                    'border-secondary my-1.5 flex items-center border-l px-3',
+                    'relative flex items-center px-3 before:absolute before:inset-y-1.5 before:left-0 before:w-px before:content-[""] before:bg-(--stroke-secondary)',
                     disabled ? 'bg-disabled cursor-not-allowed' : 'bg-default'
                   )}
                   aria-hidden


### PR DESCRIPTION
This patches up the combobox by adding a pseudo element before the button, and then makes the button full-height.
Have checked it across browsers and all seems well.
<img width="611" alt="Screen Recording 2026-04-17 at 7 52 43 PM mov" src="https://github.com/user-attachments/assets/131e2f6d-2cb2-4031-893b-e5fe1f68c3cf" />

It was looking a little faint to me, but here's a quick comparison with the current style:

current:
<img width="611" alt="Screenshot 2026-04-17 at 7 55 56 PM" src="https://github.com/user-attachments/assets/2ac2935b-2a40-479f-9bf0-75b927a8cde2" />


with pseudo element:
<img width="611" alt="Screenshot 2026-04-17 at 7 56 29 PM" src="https://github.com/user-attachments/assets/d495c546-4e7b-4307-b4db-b08813852af6" />

Closes #3185 