### PR TITLE
Remove ctrl-n/p shortcuts in quick actions

### DIFF
--- a/app/ui/lib/ActionMenu.tsx
+++ b/app/ui/lib/ActionMenu.tsx
@@ -109,11 +109,11 @@ export function ActionMenu(props: ActionMenuProps) {
                   e.preventDefault()
                   onDismiss()
                 }
-              } else if (e.key === KEYS.down || (e.ctrlKey && e.key === 'n')) {
+              } else if (e.key === KEYS.down) {
                 e.preventDefault()
                 const newIdx = selectedIdx === lastIdx ? 0 : selectedIdx + 1
                 setSelectedIdx(newIdx)
-              } else if (e.key === KEYS.up || (e.ctrlKey && e.key === 'p')) {
+              } else if (e.key === KEYS.up) {
                 e.preventDefault()
                 const newIdx = selectedIdx === 0 ? lastIdx : selectedIdx - 1
                 setSelectedIdx(newIdx)

--- a/test/e2e/action-menu.e2e.ts
+++ b/test/e2e/action-menu.e2e.ts
@@ -29,30 +29,6 @@ test('Enter key does not prematurely submit a linked form', async ({ page }) => 
   await expectNotVisible(page, [page.getByText('Name is required')])
 })
 
-test('Ctrl+N/P navigate up and down', async ({ page }) => {
-  await page.goto('/projects/mock-project/instances')
-  await openActionMenu(page)
-
-  // wait for instance list to load so the items don't shift mid-test
-  await expect(page.getByRole('option', { name: 'db1' })).toBeVisible()
-
-  const selected = getSelectedItem(page)
-  // first item is selected by default
-  await expect(selected).toHaveText('New instance')
-
-  // Ctrl+N moves down
-  await page.keyboard.press('Control+n')
-  await expect(selected).toHaveText('db1')
-
-  // Ctrl+P moves back up
-  await page.keyboard.press('Control+p')
-  await expect(selected).toHaveText('New instance')
-
-  // Ctrl+N again gets the same second item
-  await page.keyboard.press('Control+n')
-  await expect(selected).toHaveText('db1')
-})
-
 test('Arrow keys navigate up and down', async ({ page }) => {
   await page.goto('/projects/mock-project/instances')
   await openActionMenu(page)


### PR DESCRIPTION
It occurred to me they don't work on Linux. Had someone confirm — they found that ctrl-p worked but ctrl-n still opened a new window.