### PR TITLE
Disable renovate for now

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,33 +1,4 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
-  extends: ['config:base'],
-  enabledManagers: ['npm'],
-  packageRules: [
-    // Disable all npm dependency updates by default
-    {
-      managers: ['npm'],
-      depTypeList: ['dependencies', 'devDependencies', 'peerDependencies'],
-      packagePatterns: ['*'],
-      enabled: false,
-    },
-    // Disable all engine updates by default
-    {
-      managers: ['npm'],
-      depTypeList: ['engines'],
-      packagePatterns: ['*'],
-      enabled: false,
-    },
-    // Packages to auto update and auto merge if CI passes
-    {
-      managers: ['npm'],
-      packageNames: ['typescript'],
-      enabled: true,
-    },
-    // Open PRs for any oxide packages
-    {
-      managers: ['npm'],
-      packagePatterns: ['@oxide/*'],
-      enabled: true,
-    },
-  ],
+  enabled: false,
 }


### PR DESCRIPTION
We close renovate PRs pretty much every time. Last merged Renovate PRs:

- 2026-03-06 — #3103 @oxide/design-system v5.0.0--canary.163 (~6 weeks ago)
- 2025-10-21 — #2908 typescript 5.9.3
- 2025-03-17 — #2757 @oxide/design-system v2.5.0