### PR TITLE
don't always use default silo when selecting default pool

### DIFF
--- a/mock-api/msw/db.ts
+++ b/mock-api/msw/db.ts
@@ -68,7 +68,7 @@ export const resolvePoolSelector = (
     | { pool: string; type: 'explicit' }
     | { type: 'auto'; ip_version?: IpVersion | null }
     | undefined,
-  poolType?: IpPoolType,
+  poolType: IpPoolType,
   siloId: string = defaultSilo.id
 ) => {
   if (poolSelector?.type === 'explicit') {
@@ -84,8 +84,7 @@ export const resolvePoolSelector = (
     const pool = db.ipPools.find((p) => p.id === ips.ip_pool_id)
     if (!pool) return false
 
-    // If poolType specified, filter by it
-    if (poolType && pool.pool_type !== poolType) return false
+    if (pool.pool_type !== poolType) return false
 
     // If IP version specified, filter by it
     if (poolSelector?.ip_version && pool.ip_version !== poolSelector.ip_version) {

--- a/mock-api/msw/db.ts
+++ b/mock-api/msw/db.ts
@@ -68,14 +68,15 @@ export const resolvePoolSelector = (
     | { pool: string; type: 'explicit' }
     | { type: 'auto'; ip_version?: IpVersion | null }
     | undefined,
-  poolType?: IpPoolType
+  poolType?: IpPoolType,
+  siloId: string = defaultSilo.id
 ) => {
   if (poolSelector?.type === 'explicit') {
     return lookup.ipPool({ pool: poolSelector.pool })
   }
 
   // For 'auto' type, find the default pool for the specified IP version and pool type
-  const silo = lookup.silo({ silo: defaultSilo.id })
+  const silo = lookup.silo({ silo: siloId })
   const links = db.ipPoolSilos.filter((ips) => ips.silo_id === silo.id && ips.is_default)
 
   // Filter candidate pools by both IP version and pool type
@@ -108,7 +109,7 @@ export const resolvePoolSelector = (
   if (!link) {
     const typeStr = poolType ? ` ${poolType}` : ''
     const versionStr = poolSelector?.ip_version ? ` ${poolSelector.ip_version}` : ''
-    throw notFoundErr(`default${typeStr}${versionStr} pool for silo '${defaultSilo.id}'`)
+    throw notFoundErr(`default${typeStr}${versionStr} pool for silo '${siloId}'`)
   }
   return lookupById(db.ipPools, link.ip_pool_id)
 }

--- a/mock-api/msw/db.ts
+++ b/mock-api/msw/db.ts
@@ -106,9 +106,8 @@ export const resolvePoolSelector = (
 
   const link = candidateLinks[0]
   if (!link) {
-    const typeStr = poolType ? ` ${poolType}` : ''
     const versionStr = poolSelector?.ip_version ? ` ${poolSelector.ip_version}` : ''
-    throw notFoundErr(`default${typeStr}${versionStr} pool for silo '${siloId}'`)
+    throw notFoundErr(`default ${poolType}${versionStr} pool for silo '${siloId}'`)
   }
   return lookupById(db.ipPools, link.ip_pool_id)
 }

--- a/mock-api/msw/handlers.ts
+++ b/mock-api/msw/handlers.ts
@@ -395,10 +395,10 @@ export const handlers = makeHandlers({
           return true // For mock purposes, just use first unicast pool
         })
       })
-      pool = poolWithIp || resolvePoolSelector(undefined, 'unicast')
+      pool = poolWithIp || resolvePoolSelector(undefined, 'unicast', project.silo_id)
     } else {
       // type === 'auto'
-      pool = resolvePoolSelector(addressAllocator.pool_selector, 'unicast')
+      pool = resolvePoolSelector(addressAllocator.pool_selector, 'unicast', project.silo_id)
       ip = getIpFromPool(pool)
     }
 
@@ -640,7 +640,7 @@ export const handlers = makeHandlers({
         // which aren't quite as good as checking that there are actually IPs
         // available, but they are good things to check
         // Ephemeral IPs must use unicast pools
-        const pool = resolvePoolSelector(ip.pool_selector, 'unicast')
+        const pool = resolvePoolSelector(ip.pool_selector, 'unicast', project.silo_id)
         getIpFromPool(pool)
 
         // Validate that external IP version matches NIC's IP stack
@@ -773,7 +773,7 @@ export const handlers = makeHandlers({
         floatingIp.instance_id = instanceId
       } else if (ip.type === 'ephemeral') {
         // Ephemeral IPs must use unicast pools
-        const pool = resolvePoolSelector(ip.pool_selector, 'unicast')
+        const pool = resolvePoolSelector(ip.pool_selector, 'unicast', project.silo_id)
         const firstAvailableAddress = getIpFromPool(pool)
 
         db.ephemeralIps.push({
@@ -959,8 +959,9 @@ export const handlers = makeHandlers({
   },
   instanceEphemeralIpAttach({ path, query: projectParams, body }) {
     const instance = lookup.instance({ ...path, ...projectParams })
+    const instanceProject = lookup.project(projectParams)
     // Ephemeral IPs must use unicast pools
-    const pool = resolvePoolSelector(body.pool_selector, 'unicast')
+    const pool = resolvePoolSelector(body.pool_selector, 'unicast', instanceProject.silo_id)
     const ip = getIpFromPool(pool)
 
     // Validate that external IP version matches primary NIC's IP stack


### PR DESCRIPTION
This PR just pulls a small fix to the mock API out of #3033, which I'll be closing shortly. I don't expect this to change much in day-to-day usage of the mock API.

In short, when auto-selecting an IP Pool, the mock API currently selects the default pool from the default silo, regardless of what silo you're actually interacting with. To be clear, this is just an issue in the mock backend we use for local development / testing of the console app, not an underlying issue with Omicron.

The fix here involves passing in the actual silo the project belongs to, instead of just going with the default silo's default pool.