### PR TITLE
trivial: upgrade tsgo to beta release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "@types/react-is": "^19.2.0",
         "@types/semver": "^7.7.1",
         "@types/uuid": "^10.0.0",
-        "@typescript/native-preview": "^7.0.0-dev.20260212.1",
+        "@typescript/native-preview": "^7.0.0-dev.20260421.2",
         "@vitejs/plugin-basic-ssl": "^2.1.0",
         "@vitejs/plugin-react-swc": "^4.2.1",
         "autoprefixer": "^10.4.20",
@@ -6271,28 +6271,28 @@
       "license": "MIT"
     },
     "node_modules/@typescript/native-preview": {
-      "version": "7.0.0-dev.20260212.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260212.1.tgz",
-      "integrity": "sha512-VHAVbp8d2VGm90EK//brKIYvT3iPrLXMq4/LApCdkKww/Hfn33zPRVmig4rswNaJiVu8XhcdHld5yfMw6d5A9Q==",
+      "version": "7.0.0-dev.20260421.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260421.2.tgz",
+      "integrity": "sha512-CmajHI25HpVWE9R1XFoxr+cphJPxoYD3eFioQtAvXYkMFKnLdICMS9pXre9Pybizb75ejRxjKD5/CVG055rEIg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsgo": "bin/tsgo.js"
       },
       "optionalDependencies": {
-        "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260212.1",
-        "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260212.1",
-        "@typescript/native-preview-linux-arm": "7.0.0-dev.20260212.1",
-        "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260212.1",
-        "@typescript/native-preview-linux-x64": "7.0.0-dev.20260212.1",
-        "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260212.1",
-        "@typescript/native-preview-win32-x64": "7.0.0-dev.20260212.1"
+        "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260421.2",
+        "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260421.2",
+        "@typescript/native-preview-linux-arm": "7.0.0-dev.20260421.2",
+        "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260421.2",
+        "@typescript/native-preview-linux-x64": "7.0.0-dev.20260421.2",
+        "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260421.2",
+        "@typescript/native-preview-win32-x64": "7.0.0-dev.20260421.2"
       }
     },
     "node_modules/@typescript/native-preview-darwin-arm64": {
-      "version": "7.0.0-dev.20260212.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260212.1.tgz",
-      "integrity": "sha512-HH4bOVbNW6ITv00VSaE3aZjCuU2d+amgFZKdhbq7NpcJDxFvxyy9GT9gkKV0D1DXz5qoxZIcyBEIbwrhABb9vg==",
+      "version": "7.0.0-dev.20260421.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260421.2.tgz",
+      "integrity": "sha512-fHv1r3ZmVo6zxuAIFmuX3w9QxbcauoG0SsWhmDwm6VmRubLlOJIcmTtlmV3JAb9oOnq8LuzZljzT7Q39fSMQDw==",
       "cpu": [
         "arm64"
       ],
@@ -6304,9 +6304,9 @@
       ]
     },
     "node_modules/@typescript/native-preview-darwin-x64": {
-      "version": "7.0.0-dev.20260212.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260212.1.tgz",
-      "integrity": "sha512-vnQ2xRJscbtyS/jHO5QY2xAZ3c11Yn1ZAor/XODDrxd7N7jIrm0Vtc2CIwsi51oncLS1SZtUd9cHZmJg5zUJrQ==",
+      "version": "7.0.0-dev.20260421.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260421.2.tgz",
+      "integrity": "sha512-KWTR6xbW9t+JS7D5DQIzo75pqVXVWUxF9PMv/+S6xsnOjCVd6g0ixHcFpFMJMKSUQpGPr8Z5f7b8ks6LHW01jg==",
       "cpu": [
         "x64"
       ],
@@ -6318,9 +6318,9 @@
       ]
     },
     "node_modules/@typescript/native-preview-linux-arm": {
-      "version": "7.0.0-dev.20260212.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260212.1.tgz",
-      "integrity": "sha512-T8sF3YtYtODhWnFNhVuL/GABCHpKJs6ZxTtSC1LtXoM/CE0Ai06k5WKOxJG5rJrBtLIW+Dempk7qKPfhNliDTA==",
+      "version": "7.0.0-dev.20260421.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260421.2.tgz",
+      "integrity": "sha512-BWLQO3nemLDSV5PoE5GPHe1dU9Dth77Kv8/cle9Ujcp4LhPo0KincdPqFH/qKeU/xvW25mgFueflZ1nc4rKuww==",
       "cpu": [
         "arm"
       ],
@@ -6332,9 +6332,9 @@
       ]
     },
     "node_modules/@typescript/native-preview-linux-arm64": {
-      "version": "7.0.0-dev.20260212.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260212.1.tgz",
-      "integrity": "sha512-suA5OryrhL/tE7AiQXiNNV88XwKEOfO0sypJQj+cfg/fpQ2trFyDZcsdMLYVZ7J0zirDai6H3TDETYYoNFE1/g==",
+      "version": "7.0.0-dev.20260421.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260421.2.tgz",
+      "integrity": "sha512-VLMEuml3BhUb+jaL0TXQ4xvVODxJF+RhkI+tBWvlynsJI4khTXEiwWh+wPOJrsfBRYFRMXEu28Odl/HXkYze8w==",
       "cpu": [
         "arm64"
       ],
@@ -6346,9 +6346,9 @@
       ]
     },
     "node_modules/@typescript/native-preview-linux-x64": {
-      "version": "7.0.0-dev.20260212.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260212.1.tgz",
-      "integrity": "sha512-w687rpZKJM0Lev0ya0GYJlnFCITTUmN8jDpwLXn60jrNEZzL2J4F7biA6papr2sMdKRfWvRklhjB1TKHbJ6FKA==",
+      "version": "7.0.0-dev.20260421.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260421.2.tgz",
+      "integrity": "sha512-qUrJWTB5/wv4wnRG0TRXElAxc2kykNiRNyEIEqBbLmzDlrcvAW7RRy8MXoY1ZyTiKGMu14itZ3x9oW6+blFpRw==",
       "cpu": [
         "x64"
       ],
@@ -6360,9 +6360,9 @@
       ]
     },
     "node_modules/@typescript/native-preview-win32-arm64": {
-      "version": "7.0.0-dev.20260212.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260212.1.tgz",
-      "integrity": "sha512-NhCXPQF6OTNEZl8iwRE1ef/zHiqit5p3m7hdT2vfAOi1iA2eoazX0zTSdhgjX83o9cLjen3V1R7nbSYehFHaqw==",
+      "version": "7.0.0-dev.20260421.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260421.2.tgz",
+      "integrity": "sha512-Rc6NsWlZmCs5YUKVzKgwoBOoRUGsPzct4BDMRX0csD1devLBBc4AbUXWKsJRbpwIAnqMO1ld4sNHEb+wXgfNHQ==",
       "cpu": [
         "arm64"
       ],
@@ -6374,9 +6374,9 @@
       ]
     },
     "node_modules/@typescript/native-preview-win32-x64": {
-      "version": "7.0.0-dev.20260212.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260212.1.tgz",
-      "integrity": "sha512-0yqSBlASRx9rqM12QvaWc227w+bIsuI2EwAiNsoB1ybRbCXoXMah1RQlfjjTpD02eWCe/029vwrNhq+FLn7Z8A==",
+      "version": "7.0.0-dev.20260421.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260421.2.tgz",
+      "integrity": "sha512-GQv1+dya1t6EqF2Cpsb+xoozovdX10JUSf6Kl/8xNkTapzmlHd+uMr+8ku3jIASTxoRGn0Mklgjj3MDKrOTuLg==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@types/react-is": "^19.2.0",
     "@types/semver": "^7.7.1",
     "@types/uuid": "^10.0.0",
-    "@typescript/native-preview": "^7.0.0-dev.20260212.1",
+    "@typescript/native-preview": "^7.0.0-dev.20260421.2",
     "@vitejs/plugin-basic-ssl": "^2.1.0",
     "@vitejs/plugin-react-swc": "^4.2.1",
     "autoprefixer": "^10.4.20",


### PR DESCRIPTION
We were already on the alpha, so there's nothing to do.

https://devblogs.microsoft.com/typescript/announcing-typescript-7-0-beta/