### PR TITLE
Use the ModalForm component for Ephemeral IPs

### DIFF
--- a/app/components/AttachEphemeralIpModal.tsx
+++ b/app/components/AttachEphemeralIpModal.tsx
@@ -21,12 +21,12 @@ import {
   type IpVersion,
 } from '~/api'
 import { ListboxField } from '~/components/form/fields/ListboxField'
+import { ModalForm } from '~/components/form/ModalForm'
 import { HL } from '~/components/HL'
 import { toPoolItem } from '~/components/PoolListboxItem'
 import { useInstanceSelector } from '~/hooks/use-params'
 import { addToast } from '~/stores/toast'
 import { Message } from '~/ui/lib/Message'
-import { Modal } from '~/ui/lib/Modal'
 import { ALL_ISH } from '~/util/consts'
 
 type AttachEphemeralIpModalProps = {
@@ -70,7 +70,7 @@ export const AttachEphemeralIpModal = ({
   const form = useForm({ defaultValues: { pool: defaultPool } })
   const pool = form.watch('pool')
 
-  const disabledReason =
+  const submitDisabled =
     compatibleUnicastPools.length === 0
       ? 'No compatible unicast pools available for this instance'
       : !pool
@@ -78,41 +78,32 @@ export const AttachEphemeralIpModal = ({
         : undefined
 
   return (
-    <Modal isOpen title="Attach ephemeral IP" onDismiss={onDismiss}>
-      <Modal.Body>
-        <Modal.Section>
-          {infoMessage && <Message variant="info" content={infoMessage} />}
-          <form>
-            <ListboxField
-              name="pool"
-              label="Pool"
-              control={form.control}
-              items={sortPools(compatibleUnicastPools).map(toPoolItem)}
-              disabled={compatibleUnicastPools.length === 0}
-              placeholder="Select a pool"
-              noItemsPlaceholder="No pools available"
-            />
-          </form>
-          {instanceEphemeralIpAttach.error && (
-            <p className="text-error mt-4">{instanceEphemeralIpAttach.error.message}</p>
-          )}
-        </Modal.Section>
-      </Modal.Body>
-      <Modal.Footer
-        actionText="Attach"
-        disabled={!!disabledReason}
-        disabledReason={disabledReason}
-        onAction={() => {
-          instanceEphemeralIpAttach.mutate({
-            path: { instance },
-            query: { project },
-            body: {
-              poolSelector: { type: 'explicit', pool },
-            },
-          })
-        }}
-        onDismiss={onDismiss}
-      ></Modal.Footer>
-    </Modal>
+    <ModalForm
+      form={form}
+      title="Attach ephemeral IP"
+      onDismiss={onDismiss}
+      submitLabel="Attach"
+      submitError={instanceEphemeralIpAttach.error}
+      loading={instanceEphemeralIpAttach.isPending}
+      submitDisabled={submitDisabled}
+      onSubmit={({ pool }) =>
+        instanceEphemeralIpAttach.mutate({
+          path: { instance },
+          query: { project },
+          body: { poolSelector: { type: 'explicit', pool } },
+        })
+      }
+    >
+      {infoMessage && <Message variant="info" content={infoMessage} />}
+      <ListboxField
+        name="pool"
+        label="Pool"
+        control={form.control}
+        items={sortPools(compatibleUnicastPools).map(toPoolItem)}
+        disabled={compatibleUnicastPools.length === 0}
+        placeholder="Select a pool"
+        noItemsPlaceholder="No pools available"
+      />
+    </ModalForm>
   )
 }

--- a/app/components/AttachFloatingIpModal.tsx
+++ b/app/components/AttachFloatingIpModal.tsx
@@ -103,7 +103,7 @@ export const AttachFloatingIpModal = ({
           body: { kind: 'instance', parent: instance.id },
         })
       }
-      submitDisabled={!floatingIp}
+      submitDisabled={!floatingIp ? 'Select a floating IP' : undefined}
     >
       <Message
         variant="info"

--- a/app/components/form/ModalForm.tsx
+++ b/app/components/form/ModalForm.tsx
@@ -18,8 +18,8 @@ type ModalFormProps<TFieldValues extends FieldValues> = {
   form: UseFormReturn<TFieldValues>
   children: ReactNode
 
-  /** Must be provided with a reason describing why it's disabled */
-  submitDisabled?: boolean
+  /** When set, disables the submit button and shows this string as the disabled reason */
+  submitDisabled?: string
   onSubmit: (values: TFieldValues) => void
   submitLabel: string
 
@@ -35,7 +35,7 @@ export function ModalForm<TFieldValues extends FieldValues>({
   form,
   children,
   onDismiss,
-  submitDisabled = false,
+  submitDisabled,
   submitError,
   title,
   onSubmit,
@@ -77,7 +77,8 @@ export function ModalForm<TFieldValues extends FieldValues>({
         onDismiss={onDismiss}
         formId={id}
         actionText={submitLabel}
-        disabled={submitDisabled}
+        disabled={!!submitDisabled}
+        disabledReason={submitDisabled}
         actionLoading={loading || isSubmitting}
       />
     </Modal>


### PR DESCRIPTION
Currently, our Attach Ephemeral IP modal is using a custom modal component, when we can use the ModalForm component to bring in the benefits of a loading spinner and an error message, like we have on the Attach Floating IP modal.
This builds on #3192, which moved the messages from toasts into the modals.

<img width="461" height="405" alt="Screenshot 2026-04-23 at 11 25 31 PM" src="https://github.com/user-attachments/assets/7e92a031-3f18-4535-b798-7f7d801dd174" />

The spinner is a little high on the button, but that's just because it's hard to capture the moment, and the spinner drops in on the button.
<img width="395" height="279" alt="Screenshot 2026-04-23 at 11 28 24 PM" src="https://github.com/user-attachments/assets/71345478-72c9-4d15-a154-dd252acc7d5f" />

Closes #3197 