### PR TITLE
minor: test more fields in IdP create e2e

### DIFF
--- a/mock-api/msw/handlers.ts
+++ b/mock-api/msw/handlers.ts
@@ -1945,6 +1945,7 @@ export const handlers = makeHandlers({
         'slo_url',
         'sp_client_id',
         'technical_contact_email',
+        'group_attribute_name',
       ]),
       public_cert,
       ...getTimestamps(),

--- a/test/e2e/silos.e2e.ts
+++ b/test/e2e/silos.e2e.ts
@@ -241,6 +241,19 @@ test('Identity providers', async ({ page }) => {
   await acsUrlCheckbox.click()
   await expect(acsUrlField).toHaveValue(acsUrl)
 
+  // fill the rest of the form so we can check the values round-trip
+  await dialog.getByLabel('Description').fill('test provider description')
+  await dialog.getByLabel('Technical contact email').fill('admin@test-provider.example.com')
+  await dialog.getByLabel('Service provider client ID').fill('test-sp-client-id')
+  await dialog
+    .getByLabel('Single Logout (SLO) URL')
+    .fill('https://test-provider.example.com/slo')
+  await dialog.getByLabel('Entity ID').fill('https://test-provider.example.com/entity')
+  await dialog.getByLabel('Group attribute name').fill('test-groups')
+  await dialog
+    .getByLabel('Metadata source URL')
+    .fill('https://test-provider.example.com/metadata')
+
   await page.getByRole('button', { name: 'Create provider' }).click()
 
   await closeToast(page)
@@ -250,7 +263,7 @@ test('Identity providers', async ({ page }) => {
   await expectRowVisible(page.getByRole('table'), {
     name: 'test-provider',
     Type: 'saml',
-    description: '—',
+    description: 'test provider description',
   })
 
   await page.getByRole('link', { name: 'test-provider' }).click()
@@ -258,6 +271,20 @@ test('Identity providers', async ({ page }) => {
   await expect(nameField).toBeDisabled()
   await expect(acsUrlField).toHaveValue(acsUrl)
   await expect(acsUrlField).toBeDisabled()
+  await expect(dialog.getByLabel('Description')).toHaveValue('test provider description')
+  await expect(dialog.getByLabel('Technical contact email')).toHaveValue(
+    'admin@test-provider.example.com'
+  )
+  await expect(dialog.getByLabel('Service provider client ID')).toHaveValue(
+    'test-sp-client-id'
+  )
+  await expect(dialog.getByLabel('Single Logout (SLO) URL')).toHaveValue(
+    'https://test-provider.example.com/slo'
+  )
+  await expect(dialog.getByLabel('Entity ID')).toHaveValue(
+    'https://test-provider.example.com/entity'
+  )
+  await expect(dialog.getByLabel('Group attribute name')).toHaveValue('test-groups')
 })
 
 test('Silo IP pools', async ({ page }) => {


### PR DESCRIPTION
Nothing to see here, just clearing out old todo list items now that it's trivial to have the robot do them.