### PR TITLE
ICMPv4 + v6 in firewall rules

### DIFF
--- a/app/components/ProtocolBadge.tsx
+++ b/app/components/ProtocolBadge.tsx
@@ -9,6 +9,7 @@
 import { Badge } from '@oxide/design-system/ui'
 
 import type { VpcFirewallRuleProtocol } from '~/api'
+import { getIcmpLabel } from '~/util/protocol'
 
 type ProtocolBadgeProps = {
   protocol: VpcFirewallRuleProtocol
@@ -19,7 +20,7 @@ export const ProtocolBadge = ({ protocol }: ProtocolBadgeProps) => {
     return <Badge>{protocol.type.toUpperCase()}</Badge>
   }
 
-  const label = protocol.type === 'icmp' ? 'ICMPv4' : 'ICMPv6'
+  const label = getIcmpLabel(protocol.type)
 
   if (protocol.value === null) {
     return <Badge>{label}</Badge>

--- a/app/components/ProtocolBadge.tsx
+++ b/app/components/ProtocolBadge.tsx
@@ -6,31 +6,36 @@
  * Copyright Oxide Computer Company
  */
 
+import { match } from 'ts-pattern'
+
 import { Badge } from '@oxide/design-system/ui'
 
 import type { VpcFirewallRuleProtocol } from '~/api'
 import { PROTOCOL_LABELS } from '~/util/protocol'
 
 export const ProtocolBadge = ({ protocol }: { protocol: VpcFirewallRuleProtocol }) => {
-  const label = PROTOCOL_LABELS[protocol.type]
-  if (protocol.type === 'tcp' || protocol.type === 'udp') return <Badge>{label}</Badge>
-  if (protocol.value === null) return <Badge>{label}</Badge>
-
-  const { icmpType, code } = protocol.value
+  // only ICMP v4/v6 carry a nullable type/code value; tcp/udp have none
+  const value = match(protocol)
+    .with({ type: 'tcp' }, { type: 'udp' }, () => null)
+    .with({ type: 'icmp' }, { type: 'icmp6' }, (p) => p.value)
+    .exhaustive()
   return (
     <div className="space-x-0.5">
-      <Badge>{label}</Badge>
-      <Badge variant="solid">
-        <span className="flex items-center gap-1.5">
-          <span>type {icmpType}</span>
-          {code && (
-            <>
-              <span className="border-l-accent-secondary h-2.5 border-l" />
-              <span>code {code}</span>
-            </>
-          )}
-        </span>
-      </Badge>
+      <Badge>{PROTOCOL_LABELS[protocol.type]}</Badge>
+      {/* null value (or tcp/udp) means all types, so there's no type/code badge */}
+      {value !== null && (
+        <Badge variant="solid">
+          <span className="flex items-center gap-1.5">
+            <span>type {value.icmpType}</span>
+            {value.code && (
+              <>
+                <span className="border-l-accent-secondary h-2.5 border-l" />
+                <span>code {value.code}</span>
+              </>
+            )}
+          </span>
+        </Badge>
+      )}
     </div>
   )
 }

--- a/app/components/ProtocolBadge.tsx
+++ b/app/components/ProtocolBadge.tsx
@@ -19,14 +19,15 @@ export const ProtocolBadge = ({ protocol }: ProtocolBadgeProps) => {
     return <Badge>{protocol.type.toUpperCase()}</Badge>
   }
 
+  const label = protocol.type === 'icmp' ? 'ICMPv4' : 'ICMPv6'
+
   if (protocol.value === null) {
-    // All ICMP types
-    return <Badge>ICMP</Badge>
+    return <Badge>{label}</Badge>
   }
 
   return (
     <div className="space-x-0.5">
-      <Badge>ICMP</Badge>
+      <Badge>{label}</Badge>
       <Badge variant="solid">
         <span className="flex items-center gap-1.5">
           <span>type {protocol.value.icmpType}</span>

--- a/app/components/ProtocolBadge.tsx
+++ b/app/components/ProtocolBadge.tsx
@@ -9,33 +9,24 @@
 import { Badge } from '@oxide/design-system/ui'
 
 import type { VpcFirewallRuleProtocol } from '~/api'
-import { getIcmpLabel } from '~/util/protocol'
+import { PROTOCOL_LABELS } from '~/util/protocol'
 
-type ProtocolBadgeProps = {
-  protocol: VpcFirewallRuleProtocol
-}
+export const ProtocolBadge = ({ protocol }: { protocol: VpcFirewallRuleProtocol }) => {
+  const label = PROTOCOL_LABELS[protocol.type]
+  if (protocol.type === 'tcp' || protocol.type === 'udp') return <Badge>{label}</Badge>
+  if (protocol.value === null) return <Badge>{label}</Badge>
 
-export const ProtocolBadge = ({ protocol }: ProtocolBadgeProps) => {
-  if (protocol.type === 'tcp' || protocol.type === 'udp') {
-    return <Badge>{protocol.type.toUpperCase()}</Badge>
-  }
-
-  const label = getIcmpLabel(protocol.type)
-
-  if (protocol.value === null) {
-    return <Badge>{label}</Badge>
-  }
-
+  const { icmpType, code } = protocol.value
   return (
     <div className="space-x-0.5">
       <Badge>{label}</Badge>
       <Badge variant="solid">
         <span className="flex items-center gap-1.5">
-          <span>type {protocol.value.icmpType}</span>
-          {protocol.value.code && (
+          <span>type {icmpType}</span>
+          {code && (
             <>
-              <span className="border-l-accent-secondary h-[10px] border-l" />
-              <span>code {protocol.value.code}</span>
+              <span className="border-l-accent-secondary h-2.5 border-l" />
+              <span>code {code}</span>
             </>
           )}
         </span>

--- a/app/forms/firewall-rules-common.tsx
+++ b/app/forms/firewall-rules-common.tsx
@@ -373,8 +373,11 @@ type ParseResult<T> = { success: true; data: T } | { success: false; message: st
 
 const parseIcmpType = (value: string | undefined): ParseResult<number | undefined> => {
   if (value === undefined || value === '') return { success: true, data: undefined }
+  if (!/^\d+$/.test(value)) {
+    return { success: false, message: `ICMP type must be a number between 0 and 255` }
+  }
   const parsed = parseInt(value, 10)
-  if (isNaN(parsed) || parsed < 0 || parsed > 255) {
+  if (parsed < 0 || parsed > 255) {
     return { success: false, message: `ICMP type must be a number between 0 and 255` }
   }
   return { success: true, data: parsed }

--- a/app/forms/firewall-rules-common.tsx
+++ b/app/forms/firewall-rules-common.tsx
@@ -8,7 +8,6 @@
 
 import { useEffect, type ReactNode } from 'react'
 import { useController, useForm, type Control } from 'react-hook-form'
-import { match } from 'ts-pattern'
 
 import { Badge } from '@oxide/design-system/ui'
 
@@ -54,11 +53,10 @@ import { ALL_ISH } from '~/util/consts'
 import { validateIp, validateIpNet } from '~/util/ip'
 import { links } from '~/util/links'
 import {
-  getIcmpLabel,
   getProtocolDisplayName,
   getProtocolKey,
-  ICMPV4_TYPES,
-  ICMPV6_TYPES,
+  ICMP_TYPES,
+  PROTOCOL_LABELS,
 } from '~/util/protocol'
 import { capitalize, normalizeDashes } from '~/util/str'
 
@@ -296,13 +294,12 @@ const directionItems: Array<{ value: VpcFirewallRuleDirection; label: string }> 
   { value: 'outbound', label: 'Outbound' },
 ]
 
-const protocolTypeItems: Array<{ value: VpcFirewallRuleProtocol['type']; label: string }> =
-  [
-    { value: 'tcp', label: 'TCP' },
-    { value: 'udp', label: 'UDP' },
-    { value: 'icmp', label: 'ICMPv4' },
-    { value: 'icmp6', label: 'ICMPv6' },
-  ]
+const protocolTypeItems = [
+  { value: 'tcp', label: 'TCP' },
+  { value: 'udp', label: 'UDP' },
+  { value: 'icmp', label: 'ICMPv4' },
+  { value: 'icmp6', label: 'ICMPv6' },
+] satisfies Array<{ value: VpcFirewallRuleProtocol['type']; label: string }>
 
 const buildIcmpTypeItems = (types: Record<number, string>) => [
   { value: '', label: 'All types', selectedLabel: 'All types' },
@@ -313,8 +310,10 @@ const buildIcmpTypeItems = (types: Record<number, string>) => [
   })),
 ]
 
-const icmpV4TypeItems = buildIcmpTypeItems(ICMPV4_TYPES)
-const icmpV6TypeItems = buildIcmpTypeItems(ICMPV6_TYPES)
+const icmpTypeItems = {
+  icmp: buildIcmpTypeItems(ICMP_TYPES.icmp),
+  icmp6: buildIcmpTypeItems(ICMP_TYPES.icmp6),
+}
 
 const targetAndHostTableColumns = [
   {
@@ -486,17 +485,14 @@ const ProtocolFilters = ({ control }: { control: Control<FirewallRuleValues> }) 
           {(selectedProtocolType === 'icmp' || selectedProtocolType === 'icmp6') && (
             <>
               <ComboboxField
-                label={`${getIcmpLabel(selectedProtocolType)} type`}
+                label={`${PROTOCOL_LABELS[selectedProtocolType]} type`}
                 name="icmpType"
                 control={protocolForm.control}
                 description="Leave blank to match any type"
                 placeholder=""
                 allowArbitraryValues
                 onInputChange={(value) => protocolForm.setValue('icmpType', value)}
-                items={match(selectedProtocolType)
-                  .with('icmp', () => icmpV4TypeItems)
-                  .with('icmp6', () => icmpV6TypeItems)
-                  .exhaustive()}
+                items={icmpTypeItems[selectedProtocolType]}
                 validate={(value) => {
                   const result = parseIcmpType(value)
                   if (!result.success) return result.message
@@ -505,7 +501,7 @@ const ProtocolFilters = ({ control }: { control: Control<FirewallRuleValues> }) 
 
               {selectedIcmpType !== undefined && selectedIcmpType !== '' && (
                 <TextField
-                  label={`${getIcmpLabel(selectedProtocolType)} code`}
+                  label={`${PROTOCOL_LABELS[selectedProtocolType]} code`}
                   name="icmpCode"
                   control={protocolForm.control}
                   description={

--- a/app/forms/firewall-rules-common.tsx
+++ b/app/forms/firewall-rules-common.tsx
@@ -475,10 +475,13 @@ const ProtocolFilters = ({ control }: { control: Control<FirewallRuleValues> }) 
             placeholder=""
             items={protocolTypeItems}
             // ICMPv4 and ICMPv6 type numbers mean different things, so clear the
-            // selected ICMP type/code when switching protocol
+            // selected ICMP type/code when switching protocol. Also clear errors:
+            // setValue doesn't revalidate, so a stale type error would otherwise
+            // linger on the now-empty field.
             onChange={() => {
               protocolForm.setValue('icmpType', '')
               protocolForm.setValue('icmpCode', '')
+              protocolForm.clearErrors(['icmpType', 'icmpCode'])
             }}
           />
 

--- a/app/forms/firewall-rules-common.tsx
+++ b/app/forms/firewall-rules-common.tsx
@@ -52,7 +52,12 @@ import { KEYS } from '~/ui/util/keys'
 import { ALL_ISH } from '~/util/consts'
 import { validateIp, validateIpNet } from '~/util/ip'
 import { links } from '~/util/links'
-import { getProtocolDisplayName, getProtocolKey, ICMP_TYPES } from '~/util/protocol'
+import {
+  getProtocolDisplayName,
+  getProtocolKey,
+  ICMPV4_TYPES,
+  ICMPV6_TYPES,
+} from '~/util/protocol'
 import { capitalize, normalizeDashes } from '~/util/str'
 
 import { type FirewallRuleValues } from './firewall-rules-util'
@@ -293,17 +298,21 @@ const protocolTypeItems: Array<{ value: VpcFirewallRuleProtocol['type']; label: 
   [
     { value: 'tcp', label: 'TCP' },
     { value: 'udp', label: 'UDP' },
-    { value: 'icmp', label: 'ICMP' },
+    { value: 'icmp', label: 'ICMPv4' },
+    { value: 'icmp6', label: 'ICMPv6' },
   ]
 
-const icmpTypeItems = [
+const buildIcmpTypeItems = (types: Record<number, string>) => [
   { value: '', label: 'All types', selectedLabel: 'All types' },
-  ...Object.entries(ICMP_TYPES).map(([type, name]) => ({
+  ...Object.entries(types).map(([type, name]) => ({
     value: type,
     label: `${type} - ${name}`,
     selectedLabel: type,
   })),
 ]
+
+const icmpV4TypeItems = buildIcmpTypeItems(ICMPV4_TYPES)
+const icmpV6TypeItems = buildIcmpTypeItems(ICMPV6_TYPES)
 
 const targetAndHostTableColumns = [
   {
@@ -343,13 +352,15 @@ const isDuplicateProtocol = (
     return existingProtocols.some((p) => p.type === newProtocol.type)
   }
 
-  if (newProtocol.type === 'icmp') {
+  if (newProtocol.type === 'icmp' || newProtocol.type === 'icmp6') {
     if (newProtocol.value === null) {
-      return existingProtocols.some((p) => p.type === 'icmp' && p.value === null)
+      return existingProtocols.some(
+        (p) => p.type === newProtocol.type && p.value === null
+      )
     }
     return existingProtocols.some(
       (p) =>
-        p.type === 'icmp' &&
+        p.type === newProtocol.type &&
         p.value?.icmpType === newProtocol.value?.icmpType &&
         p.value?.code === newProtocol.value?.code
     )
@@ -423,7 +434,7 @@ const ProtocolFilters = ({ control }: { control: Control<FirewallRuleValues> }) 
   const submitProtocol = protocolForm.handleSubmit((values) => {
     if (values.protocolType === 'tcp' || values.protocolType === 'udp') {
       addProtocolIfUnique({ type: values.protocolType })
-    } else if (values.protocolType === 'icmp') {
+    } else if (values.protocolType === 'icmp' || values.protocolType === 'icmp6') {
       // this parse should never fail because we've already validated, but doing
       // it this way keeps the just-in-case early return logic consistent
       const parseResult = parseIcmpType(values.icmpType)
@@ -432,14 +443,14 @@ const ProtocolFilters = ({ control }: { control: Control<FirewallRuleValues> }) 
       const icmpType = parseResult.data
       if (icmpType === undefined) {
         // All ICMP types
-        addProtocolIfUnique({ type: 'icmp', value: null })
+        addProtocolIfUnique({ type: values.protocolType, value: null })
       } else {
         // Specific ICMP type
         const icmpValue: VpcFirewallIcmpFilter = { icmpType }
         if (values.icmpCode) {
           icmpValue.code = values.icmpCode
         }
-        addProtocolIfUnique({ type: 'icmp', value: icmpValue })
+        addProtocolIfUnique({ type: values.protocolType, value: icmpValue })
       }
     }
     protocolForm.reset()
@@ -461,19 +472,25 @@ const ProtocolFilters = ({ control }: { control: Control<FirewallRuleValues> }) 
             control={protocolForm.control}
             placeholder=""
             items={protocolTypeItems}
+            // ICMPv4 and ICMPv6 type numbers mean different things, so clear the
+            // selected ICMP type/code when switching protocol
+            onChange={() => {
+              protocolForm.setValue('icmpType', '')
+              protocolForm.setValue('icmpCode', '')
+            }}
           />
 
-          {selectedProtocolType === 'icmp' && (
+          {(selectedProtocolType === 'icmp' || selectedProtocolType === 'icmp6') && (
             <>
               <ComboboxField
-                label="ICMP type"
+                label={`${selectedProtocolType === 'icmp' ? 'ICMPv4' : 'ICMPv6'} type`}
                 name="icmpType"
                 control={protocolForm.control}
                 description="Leave blank to match any type"
                 placeholder=""
                 allowArbitraryValues
                 onInputChange={(value) => protocolForm.setValue('icmpType', value)}
-                items={icmpTypeItems}
+                items={selectedProtocolType === 'icmp' ? icmpV4TypeItems : icmpV6TypeItems}
                 validate={(value) => {
                   const result = parseIcmpType(value)
                   if (!result.success) return result.message
@@ -482,7 +499,7 @@ const ProtocolFilters = ({ control }: { control: Control<FirewallRuleValues> }) 
 
               {selectedIcmpType !== undefined && selectedIcmpType !== '' && (
                 <TextField
-                  label="ICMP code"
+                  label={`${selectedProtocolType === 'icmp' ? 'ICMPv4' : 'ICMPv6'} code`}
                   name="icmpCode"
                   control={protocolForm.control}
                   description={

--- a/app/forms/firewall-rules-common.tsx
+++ b/app/forms/firewall-rules-common.tsx
@@ -8,6 +8,7 @@
 
 import { useEffect, type ReactNode } from 'react'
 import { useController, useForm, type Control } from 'react-hook-form'
+import { match } from 'ts-pattern'
 
 import { Badge } from '@oxide/design-system/ui'
 
@@ -53,6 +54,7 @@ import { ALL_ISH } from '~/util/consts'
 import { validateIp, validateIpNet } from '~/util/ip'
 import { links } from '~/util/links'
 import {
+  getIcmpLabel,
   getProtocolDisplayName,
   getProtocolKey,
   ICMPV4_TYPES,
@@ -354,9 +356,7 @@ const isDuplicateProtocol = (
 
   if (newProtocol.type === 'icmp' || newProtocol.type === 'icmp6') {
     if (newProtocol.value === null) {
-      return existingProtocols.some(
-        (p) => p.type === newProtocol.type && p.value === null
-      )
+      return existingProtocols.some((p) => p.type === newProtocol.type && p.value === null)
     }
     return existingProtocols.some(
       (p) =>
@@ -483,14 +483,17 @@ const ProtocolFilters = ({ control }: { control: Control<FirewallRuleValues> }) 
           {(selectedProtocolType === 'icmp' || selectedProtocolType === 'icmp6') && (
             <>
               <ComboboxField
-                label={`${selectedProtocolType === 'icmp' ? 'ICMPv4' : 'ICMPv6'} type`}
+                label={`${getIcmpLabel(selectedProtocolType)} type`}
                 name="icmpType"
                 control={protocolForm.control}
                 description="Leave blank to match any type"
                 placeholder=""
                 allowArbitraryValues
                 onInputChange={(value) => protocolForm.setValue('icmpType', value)}
-                items={selectedProtocolType === 'icmp' ? icmpV4TypeItems : icmpV6TypeItems}
+                items={match(selectedProtocolType)
+                  .with('icmp', () => icmpV4TypeItems)
+                  .with('icmp6', () => icmpV6TypeItems)
+                  .exhaustive()}
                 validate={(value) => {
                   const result = parseIcmpType(value)
                   if (!result.success) return result.message
@@ -499,7 +502,7 @@ const ProtocolFilters = ({ control }: { control: Control<FirewallRuleValues> }) 
 
               {selectedIcmpType !== undefined && selectedIcmpType !== '' && (
                 <TextField
-                  label={`${selectedProtocolType === 'icmp' ? 'ICMPv4' : 'ICMPv6'} code`}
+                  label={`${getIcmpLabel(selectedProtocolType)} code`}
                   name="icmpCode"
                   control={protocolForm.control}
                   description={

--- a/app/forms/firewall-rules-common.tsx
+++ b/app/forms/firewall-rules-common.tsx
@@ -371,11 +371,14 @@ const isDuplicateProtocol = (
 type ParseResult<T> = { success: true; data: T } | { success: false; message: string }
 
 const parseIcmpType = (value: string | undefined): ParseResult<number | undefined> => {
-  if (value === undefined || value === '') return { success: true, data: undefined }
-  if (!/^\d+$/.test(value)) {
+  const trimmedValue = value?.trim()
+  if (trimmedValue === undefined || trimmedValue === '') {
+    return { success: true, data: undefined }
+  }
+  if (!/^\d+$/.test(trimmedValue)) {
     return { success: false, message: `ICMP type must be a number between 0 and 255` }
   }
-  const parsed = parseInt(value, 10)
+  const parsed = parseInt(trimmedValue, 10)
   if (parsed < 0 || parsed > 255) {
     return { success: false, message: `ICMP type must be a number between 0 and 255` }
   }
@@ -449,8 +452,9 @@ const ProtocolFilters = ({ control }: { control: Control<FirewallRuleValues> }) 
       } else {
         // Specific ICMP type
         const icmpValue: VpcFirewallIcmpFilter = { icmpType }
-        if (values.icmpCode) {
-          icmpValue.code = values.icmpCode
+        const icmpCode = values.icmpCode?.trim()
+        if (icmpCode) {
+          icmpValue.code = icmpCode
         }
         addProtocolIfUnique({ type: values.protocolType, value: icmpValue })
       }

--- a/app/table/cells/ProtocolCell.tsx
+++ b/app/table/cells/ProtocolCell.tsx
@@ -13,20 +13,32 @@ import { Tooltip } from '~/ui/lib/Tooltip'
 
 import { EmptyCell } from './EmptyCell'
 
+const protocolLabel = (protocol: VpcFirewallRuleProtocol) => {
+  if (protocol.type === 'icmp') return 'ICMPv4'
+  if (protocol.type === 'icmp6') return 'ICMPv6'
+  return protocol.type.toUpperCase()
+}
+
+const isIcmp = (
+  protocol: VpcFirewallRuleProtocol
+): protocol is Extract<VpcFirewallRuleProtocol, { type: 'icmp' | 'icmp6' }> =>
+  protocol.type === 'icmp' || protocol.type === 'icmp6'
+
 export const ProtocolCell = ({ protocol }: { protocol: VpcFirewallRuleProtocol }) => (
-  <Badge>{protocol.type.toUpperCase()}</Badge>
+  <Badge>{protocolLabel(protocol)}</Badge>
 )
 
 /** Generate tooltip content for empty protocol cells in the mini table */
 const protocolEmptyCellTooltipContent = (protocol: VpcFirewallRuleProtocol): string => {
   if (protocol.type === 'tcp') return 'This firewall rule will match all TCP traffic'
   if (protocol.type === 'udp') return 'This firewall rule will match all UDP traffic'
+  const label = protocolLabel(protocol)
   // in this case, the user could be looking at the type column or the code column, but both get the same tooltip
   if (protocol.value === null) {
-    return 'This firewall rule will match all ICMP traffic'
+    return `This firewall rule will match all ${label} traffic`
   }
   // in this case, there's an icmpType but no code, which means the user is looking at the code column
-  return `This firewall rule will match all ICMP traffic of type ${protocol.value.icmpType}`
+  return `This firewall rule will match all ${label} traffic of type ${protocol.value.icmpType}`
 }
 
 export const ProtocolEmptyCell = ({ protocol }: { protocol: VpcFirewallRuleProtocol }) => (
@@ -39,7 +51,7 @@ export const ProtocolEmptyCell = ({ protocol }: { protocol: VpcFirewallRuleProto
 
 export const ProtocolTypeCell = ({ protocol }: { protocol: VpcFirewallRuleProtocol }) =>
   // icmpType could be zero, so we check for `not undefined`
-  protocol.type === 'icmp' && protocol.value?.icmpType !== undefined ? (
+  isIcmp(protocol) && protocol.value?.icmpType !== undefined ? (
     protocol.value.icmpType
   ) : (
     <ProtocolEmptyCell protocol={protocol} />
@@ -47,7 +59,7 @@ export const ProtocolTypeCell = ({ protocol }: { protocol: VpcFirewallRuleProtoc
 
 export const ProtocolCodeCell = ({ protocol }: { protocol: VpcFirewallRuleProtocol }) =>
   // code could be zero, so we check for `not undefined`
-  protocol.type === 'icmp' && protocol.value?.code !== undefined ? (
+  isIcmp(protocol) && protocol.value?.code !== undefined ? (
     protocol.value.code
   ) : (
     <ProtocolEmptyCell protocol={protocol} />

--- a/app/table/cells/ProtocolCell.tsx
+++ b/app/table/cells/ProtocolCell.tsx
@@ -6,6 +6,8 @@
  * Copyright Oxide Computer Company
  */
 
+import { match } from 'ts-pattern'
+
 import { Badge } from '@oxide/design-system/ui'
 
 import type { VpcFirewallRuleProtocol } from '~/api'
@@ -13,11 +15,13 @@ import { Tooltip } from '~/ui/lib/Tooltip'
 
 import { EmptyCell } from './EmptyCell'
 
-const protocolLabel = (protocol: VpcFirewallRuleProtocol) => {
-  if (protocol.type === 'icmp') return 'ICMPv4'
-  if (protocol.type === 'icmp6') return 'ICMPv6'
-  return protocol.type.toUpperCase()
-}
+const protocolLabel = (protocol: VpcFirewallRuleProtocol) =>
+  match(protocol.type)
+    .with('tcp', () => 'TCP')
+    .with('udp', () => 'UDP')
+    .with('icmp', () => 'ICMPv4')
+    .with('icmp6', () => 'ICMPv6')
+    .exhaustive()
 
 const isIcmp = (
   protocol: VpcFirewallRuleProtocol

--- a/app/table/cells/ProtocolCell.tsx
+++ b/app/table/cells/ProtocolCell.tsx
@@ -6,42 +6,26 @@
  * Copyright Oxide Computer Company
  */
 
-import { match } from 'ts-pattern'
-
 import { Badge } from '@oxide/design-system/ui'
 
 import type { VpcFirewallRuleProtocol } from '~/api'
 import { Tooltip } from '~/ui/lib/Tooltip'
+import { PROTOCOL_LABELS } from '~/util/protocol'
 
 import { EmptyCell } from './EmptyCell'
 
-const protocolLabel = (protocol: VpcFirewallRuleProtocol) =>
-  match(protocol.type)
-    .with('tcp', () => 'TCP')
-    .with('udp', () => 'UDP')
-    .with('icmp', () => 'ICMPv4')
-    .with('icmp6', () => 'ICMPv6')
-    .exhaustive()
-
-const isIcmp = (
-  protocol: VpcFirewallRuleProtocol
-): protocol is Extract<VpcFirewallRuleProtocol, { type: 'icmp' | 'icmp6' }> =>
-  protocol.type === 'icmp' || protocol.type === 'icmp6'
-
 export const ProtocolCell = ({ protocol }: { protocol: VpcFirewallRuleProtocol }) => (
-  <Badge>{protocolLabel(protocol)}</Badge>
+  <Badge>{PROTOCOL_LABELS[protocol.type]}</Badge>
 )
 
 /** Generate tooltip content for empty protocol cells in the mini table */
 const protocolEmptyCellTooltipContent = (protocol: VpcFirewallRuleProtocol): string => {
-  if (protocol.type === 'tcp') return 'This firewall rule will match all TCP traffic'
-  if (protocol.type === 'udp') return 'This firewall rule will match all UDP traffic'
-  const label = protocolLabel(protocol)
-  // in this case, the user could be looking at the type column or the code column, but both get the same tooltip
-  if (protocol.value === null) {
+  const label = PROTOCOL_LABELS[protocol.type]
+  if (protocol.type === 'tcp' || protocol.type === 'udp' || protocol.value === null) {
     return `This firewall rule will match all ${label} traffic`
   }
-  // in this case, there's an icmpType but no code, which means the user is looking at the code column
+  // type column shows nothing only when value is null (handled above), so
+  // reaching here means we're in the code column and there is a type but no code
   return `This firewall rule will match all ${label} traffic of type ${protocol.value.icmpType}`
 }
 
@@ -55,7 +39,8 @@ export const ProtocolEmptyCell = ({ protocol }: { protocol: VpcFirewallRuleProto
 
 export const ProtocolTypeCell = ({ protocol }: { protocol: VpcFirewallRuleProtocol }) =>
   // icmpType could be zero, so we check for `not undefined`
-  isIcmp(protocol) && protocol.value?.icmpType !== undefined ? (
+  (protocol.type === 'icmp' || protocol.type === 'icmp6') &&
+  protocol.value?.icmpType !== undefined ? (
     protocol.value.icmpType
   ) : (
     <ProtocolEmptyCell protocol={protocol} />
@@ -63,7 +48,8 @@ export const ProtocolTypeCell = ({ protocol }: { protocol: VpcFirewallRuleProtoc
 
 export const ProtocolCodeCell = ({ protocol }: { protocol: VpcFirewallRuleProtocol }) =>
   // code could be zero, so we check for `not undefined`
-  isIcmp(protocol) && protocol.value?.code !== undefined ? (
+  (protocol.type === 'icmp' || protocol.type === 'icmp6') &&
+  protocol.value?.code !== undefined ? (
     protocol.value.code
   ) : (
     <ProtocolEmptyCell protocol={protocol} />

--- a/app/util/protocol.ts
+++ b/app/util/protocol.ts
@@ -6,6 +6,8 @@
  * Copyright Oxide Computer Company
  */
 
+import { match } from 'ts-pattern'
+
 import type { VpcFirewallRuleProtocol } from '~/api'
 
 export const ICMPV4_TYPES: Record<number, string> = {
@@ -39,17 +41,22 @@ export const ICMPV6_TYPES: Record<number, string> = {
 export type IcmpVariant = 'icmp' | 'icmp6'
 
 const typesFor = (variant: IcmpVariant) =>
-  variant === 'icmp' ? ICMPV4_TYPES : ICMPV6_TYPES
+  match(variant)
+    .with('icmp', () => ICMPV4_TYPES)
+    .with('icmp6', () => ICMPV6_TYPES)
+    .exhaustive()
 
-const labelFor = (variant: IcmpVariant) => (variant === 'icmp' ? 'ICMPv4' : 'ICMPv6')
+export const getIcmpLabel = (variant: IcmpVariant) =>
+  match(variant)
+    .with('icmp', () => 'ICMPv4' as const)
+    .with('icmp6', () => 'ICMPv6' as const)
+    .exhaustive()
 
 /**
  * Get the human-readable name for an ICMP type
  */
-export const getIcmpTypeName = (
-  variant: IcmpVariant,
-  type: number
-): string | undefined => typesFor(variant)[type]
+export const getIcmpTypeName = (variant: IcmpVariant, type: number): string | undefined =>
+  typesFor(variant)[type]
 
 /**
  * Get a display name for a protocol, including ICMP types and codes
@@ -58,7 +65,7 @@ export const getProtocolDisplayName = (protocol: VpcFirewallRuleProtocol): strin
   if (protocol.type === 'tcp' || protocol.type === 'udp') {
     return protocol.type.toUpperCase()
   }
-  const label = labelFor(protocol.type)
+  const label = getIcmpLabel(protocol.type)
   if (protocol.value === null) {
     return `${label} (All types)`
   }

--- a/app/util/protocol.ts
+++ b/app/util/protocol.ts
@@ -10,6 +10,8 @@ import { match } from 'ts-pattern'
 
 import type { VpcFirewallRuleProtocol } from '~/api'
 
+// IANA ICMP Type Numbers registry:
+// https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml#icmp-parameters-types
 export const ICMPV4_TYPES: Record<number, string> = {
   0: 'Echo Reply',
   3: 'Destination Unreachable',
@@ -23,7 +25,8 @@ export const ICMPV4_TYPES: Record<number, string> = {
   14: 'Timestamp Reply',
 }
 
-// ICMPv6 type assignments per RFC 4443 and related RFCs.
+// IANA ICMPv6 Type Numbers registry:
+// https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml#icmpv6-parameters-2
 export const ICMPV6_TYPES: Record<number, string> = {
   1: 'Destination Unreachable',
   2: 'Packet Too Big',
@@ -31,6 +34,9 @@ export const ICMPV6_TYPES: Record<number, string> = {
   4: 'Parameter Problem',
   128: 'Echo Request',
   129: 'Echo Reply',
+  130: 'Multicast Listener Query',
+  131: 'Multicast Listener Report',
+  132: 'Multicast Listener Done',
   133: 'Router Solicitation',
   134: 'Router Advertisement',
   135: 'Neighbor Solicitation',

--- a/app/util/protocol.ts
+++ b/app/util/protocol.ts
@@ -6,14 +6,12 @@
  * Copyright Oxide Computer Company
  */
 
-import { match } from 'ts-pattern'
-
 import type { VpcFirewallRuleProtocol } from '~/api'
 
 // Common suggestions from the IANA ICMP Type Numbers registry. Users may enter
 // any valid type number, including types not listed here.
 // https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml#icmp-parameters-types
-export const ICMPV4_TYPES: Record<number, string> = {
+const ICMPV4_TYPES: Record<number, string> = {
   0: 'Echo Reply',
   3: 'Destination Unreachable',
   5: 'Redirect Message',
@@ -29,7 +27,7 @@ export const ICMPV4_TYPES: Record<number, string> = {
 // Common suggestions from the IANA ICMPv6 Type Numbers registry. Users may enter
 // any valid type number, including types not listed here.
 // https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml#icmpv6-parameters-2
-export const ICMPV6_TYPES: Record<number, string> = {
+const ICMPV6_TYPES: Record<number, string> = {
   1: 'Destination Unreachable',
   2: 'Packet Too Big',
   3: 'Time Exceeded',
@@ -46,39 +44,25 @@ export const ICMPV6_TYPES: Record<number, string> = {
   137: 'Redirect Message',
 }
 
-export type IcmpVariant = 'icmp' | 'icmp6'
+export const ICMP_TYPES: Record<'icmp' | 'icmp6', Record<number, string>> = {
+  icmp: ICMPV4_TYPES,
+  icmp6: ICMPV6_TYPES,
+}
 
-const typesFor = (variant: IcmpVariant) =>
-  match(variant)
-    .with('icmp', () => ICMPV4_TYPES)
-    .with('icmp6', () => ICMPV6_TYPES)
-    .exhaustive()
+export const PROTOCOL_LABELS = {
+  tcp: 'TCP',
+  udp: 'UDP',
+  icmp: 'ICMPv4',
+  icmp6: 'ICMPv6',
+} as const satisfies Record<VpcFirewallRuleProtocol['type'], string>
 
-export const getIcmpLabel = (variant: IcmpVariant) =>
-  match(variant)
-    .with('icmp', () => 'ICMPv4' as const)
-    .with('icmp6', () => 'ICMPv6' as const)
-    .exhaustive()
-
-/**
- * Get the human-readable name for an ICMP type
- */
-export const getIcmpTypeName = (variant: IcmpVariant, type: number): string | undefined =>
-  typesFor(variant)[type]
-
-/**
- * Get a display name for a protocol, including ICMP types and codes
- */
+/** Get a display name for a protocol, including ICMP types and codes */
 export const getProtocolDisplayName = (protocol: VpcFirewallRuleProtocol): string => {
-  if (protocol.type === 'tcp' || protocol.type === 'udp') {
-    return protocol.type.toUpperCase()
-  }
-  const label = getIcmpLabel(protocol.type)
-  if (protocol.value === null) {
-    return `${label} (All types)`
-  }
+  const label = PROTOCOL_LABELS[protocol.type]
+  if (protocol.type === 'tcp' || protocol.type === 'udp') return label
+  if (protocol.value === null) return `${label} (All types)`
   const typeName =
-    typesFor(protocol.type)[protocol.value.icmpType] || `Type ${protocol.value.icmpType}`
+    ICMP_TYPES[protocol.type][protocol.value.icmpType] || `Type ${protocol.value.icmpType}`
   const codePart = protocol.value.code ? ` | Code ${protocol.value.code}` : ''
   return `${label} ${protocol.value.icmpType} - ${typeName}${codePart}`
 }

--- a/app/util/protocol.ts
+++ b/app/util/protocol.ts
@@ -10,7 +10,8 @@ import { match } from 'ts-pattern'
 
 import type { VpcFirewallRuleProtocol } from '~/api'
 
-// IANA ICMP Type Numbers registry:
+// Common suggestions from the IANA ICMP Type Numbers registry. Users may enter
+// any valid type number, including types not listed here.
 // https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml#icmp-parameters-types
 export const ICMPV4_TYPES: Record<number, string> = {
   0: 'Echo Reply',
@@ -25,7 +26,8 @@ export const ICMPV4_TYPES: Record<number, string> = {
   14: 'Timestamp Reply',
 }
 
-// IANA ICMPv6 Type Numbers registry:
+// Common suggestions from the IANA ICMPv6 Type Numbers registry. Users may enter
+// any valid type number, including types not listed here.
 // https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml#icmpv6-parameters-2
 export const ICMPV6_TYPES: Record<number, string> = {
   1: 'Destination Unreachable',

--- a/app/util/protocol.ts
+++ b/app/util/protocol.ts
@@ -8,7 +8,7 @@
 
 import type { VpcFirewallRuleProtocol } from '~/api'
 
-export const ICMP_TYPES: Record<number, string> = {
+export const ICMPV4_TYPES: Record<number, string> = {
   0: 'Echo Reply',
   3: 'Destination Unreachable',
   5: 'Redirect Message',
@@ -21,26 +21,51 @@ export const ICMP_TYPES: Record<number, string> = {
   14: 'Timestamp Reply',
 }
 
+// ICMPv6 type assignments per RFC 4443 and related RFCs.
+export const ICMPV6_TYPES: Record<number, string> = {
+  1: 'Destination Unreachable',
+  2: 'Packet Too Big',
+  3: 'Time Exceeded',
+  4: 'Parameter Problem',
+  128: 'Echo Request',
+  129: 'Echo Reply',
+  133: 'Router Solicitation',
+  134: 'Router Advertisement',
+  135: 'Neighbor Solicitation',
+  136: 'Neighbor Advertisement',
+  137: 'Redirect Message',
+}
+
+export type IcmpVariant = 'icmp' | 'icmp6'
+
+const typesFor = (variant: IcmpVariant) =>
+  variant === 'icmp' ? ICMPV4_TYPES : ICMPV6_TYPES
+
+const labelFor = (variant: IcmpVariant) => (variant === 'icmp' ? 'ICMPv4' : 'ICMPv6')
+
 /**
  * Get the human-readable name for an ICMP type
  */
-export const getIcmpTypeName = (type: number): string | undefined => ICMP_TYPES[type]
+export const getIcmpTypeName = (
+  variant: IcmpVariant,
+  type: number
+): string | undefined => typesFor(variant)[type]
 
 /**
  * Get a display name for a protocol, including ICMP types and codes
  */
 export const getProtocolDisplayName = (protocol: VpcFirewallRuleProtocol): string => {
-  if (protocol.type === 'icmp') {
-    if (protocol.value === null) {
-      return 'ICMP (All types)'
-    } else {
-      const typeName =
-        ICMP_TYPES[protocol.value.icmpType] || `Type ${protocol.value.icmpType}`
-      const codePart = protocol.value.code ? ` | Code ${protocol.value.code}` : ''
-      return `ICMP ${protocol.value.icmpType} - ${typeName}${codePart}`
-    }
+  if (protocol.type === 'tcp' || protocol.type === 'udp') {
+    return protocol.type.toUpperCase()
   }
-  return protocol.type.toUpperCase()
+  const label = labelFor(protocol.type)
+  if (protocol.value === null) {
+    return `${label} (All types)`
+  }
+  const typeName =
+    typesFor(protocol.type)[protocol.value.icmpType] || `Type ${protocol.value.icmpType}`
+  const codePart = protocol.value.code ? ` | Code ${protocol.value.code}` : ''
+  return `${label} ${protocol.value.icmpType} - ${typeName}${codePart}`
 }
 
 /**
@@ -52,6 +77,6 @@ export const getProtocolKey = (protocol: VpcFirewallRuleProtocol): string => {
     return protocol.type
   }
   return protocol.value === null
-    ? 'icmp|all'
-    : `icmp|${protocol.value.icmpType}|${protocol.value.code || 'all'}`
+    ? `${protocol.type}|all`
+    : `${protocol.type}|${protocol.value.icmpType}|${protocol.value.code || 'all'}`
 }

--- a/mock-api/vpc.ts
+++ b/mock-api/vpc.ts
@@ -321,7 +321,11 @@ export const firewallRules: Json<VpcFirewallRule[]> = [
     description: 'we just want to test with lots of filters',
     filters: {
       ports: ['3389', '45-89'],
-      protocols: [{ type: 'tcp' }, { type: 'icmp', value: { icmp_type: 5, code: '1-3' } }],
+      protocols: [
+        { type: 'tcp' },
+        { type: 'icmp', value: { icmp_type: 5, code: '1-3' } },
+        { type: 'icmp6', value: { icmp_type: 128 } },
+      ],
       hosts: [
         { type: 'instance', value: 'hello-friend' },
         { type: 'subnet', value: 'my-subnet' },

--- a/test/e2e/firewall-rules.e2e.ts
+++ b/test/e2e/firewall-rules.e2e.ts
@@ -141,15 +141,15 @@ test('firewall rule targets and filters overflow', async ({ page }) => {
   ).toBeVisible()
 
   await expect(
-    page.getByRole('cell', { name: 'instance hello-friend +6', exact: true })
+    page.getByRole('cell', { name: 'instance hello-friend +7', exact: true })
   ).toBeVisible()
 
   // scroll table sideways past the filters cell
   await page.getByText('Enabled').first().scrollIntoViewIfNeeded()
 
-  await page.getByText('+6').hover()
+  await page.getByText('+7').hover()
   const tooltip = page.getByRole('tooltip', {
-    name: 'Other filters subnet my-subnet ip 148.38.89.5 TCP ICMP type 5 code 1-3 Port 3389 Port 45-89',
+    name: 'Other filters subnet my-subnet ip 148.38.89.5 TCP ICMPv4 type 5 code 1-3 ICMPv6 type 128 Port 3389 Port 45-89',
     exact: true,
   })
   await expect(tooltip).toBeVisible()
@@ -434,16 +434,16 @@ test('can update firewall rule', async ({ page }) => {
 
   // protocol is populated in the table
   const protocolTable = page.getByRole('table', { name: 'Protocol filters' })
-  await expect(protocolTable.getByText('ICMP')).toBeVisible()
+  await expect(protocolTable.getByText('ICMPv4')).toBeVisible()
 
   // remove the existing ICMP protocol filter
   await protocolTable.getByRole('button', { name: 'remove' }).click()
 
   // add a new ICMP protocol filter with type 3 and code 0
-  await selectOption(page, 'Protocol filters', 'ICMP')
-  const icmpTypeField = page.getByRole('combobox', { name: 'ICMP Type' })
+  await selectOption(page, 'Protocol filters', 'ICMPv4')
+  const icmpTypeField = page.getByRole('combobox', { name: 'ICMPv4 type' })
   await fillAndSelect(icmpTypeField, page, '3', '3 - Destination Unreachable')
-  await page.getByRole('textbox', { name: 'ICMP Code' }).fill('0')
+  await page.getByRole('textbox', { name: 'ICMPv4 code' }).fill('0')
   await page.getByRole('button', { name: 'Add protocol' }).click()
 
   // update name
@@ -477,7 +477,7 @@ test('can update firewall rule', async ({ page }) => {
   await expect(rows).toHaveCount(3)
 
   // new host filter shows up in filters cell, along with the new ICMP protocol
-  await expect(page.locator('text=subnetedit-filter-subnetICMP')).toBeVisible()
+  await expect(page.locator('text=subnetedit-filter-subnetICMPv4')).toBeVisible()
 
   // scroll table sideways past the filters cell to see the full content
   await page.getByText('Enabled').first().scrollIntoViewIfNeeded()
@@ -509,7 +509,7 @@ test('create from existing rule', async ({ page }) => {
 
   // protocol is populated in the table
   const protocolTable = modal.getByRole('table', { name: 'Protocol filters' })
-  await expect(protocolTable.getByText('ICMP')).toBeVisible()
+  await expect(protocolTable.getByText('ICMPv4')).toBeVisible()
   await expect(protocolTable.getByText('TCP')).toBeHidden()
   await expect(protocolTable.getByText('UDP')).toBeHidden()
 
@@ -537,7 +537,7 @@ test('create from existing rule', async ({ page }) => {
   // protocol is populated in the table
   await expect(protocolTable.getByText('TCP')).toBeVisible()
   await expect(protocolTable.getByText('UDP')).toBeHidden()
-  await expect(protocolTable.getByText('ICMP')).toBeHidden()
+  await expect(protocolTable.getByText('ICMPv4')).toBeHidden()
 
   await expect(targets.getByRole('row', { name: 'vpc default' })).toBeVisible()
 })
@@ -670,14 +670,55 @@ test('arbitrary values combobox', async ({ page }) => {
   // triggering a validation error for bad input. without onInputChange binding
   // the input value to the form value, this does not trigger an error because
   // the form thinks the input is empyt.
-  await selectOption(page, 'Protocol filters', 'ICMP')
-  await page.getByRole('combobox', { name: 'ICMP type' }).pressSequentially('abc')
+  await selectOption(page, 'Protocol filters', 'ICMPv4')
+  await page.getByRole('combobox', { name: 'ICMPv4 type' }).pressSequentially('abc')
   const error = page
     .getByRole('dialog')
     .getByText('ICMP type must be a number between 0 and 255')
   await expect(error).toBeHidden()
   await page.getByRole('button', { name: 'Add protocol filter' }).click()
   await expect(error).toBeVisible()
+})
+
+test('can add ICMPv4 and ICMPv6 protocol filters', async ({ page }) => {
+  await page.goto('/projects/mock-project/vpcs/mock-vpc/firewall-rules-new')
+
+  const protocolTable = page.getByRole('table', { name: 'Protocol filters' })
+  await expect(protocolTable).toBeHidden()
+
+  // add an ICMPv4 filter with a specific type
+  const protocolListbox = page.getByRole('button', { name: 'Protocol filters' })
+  await protocolListbox.click()
+  await page.getByRole('option', { name: 'ICMPv4', exact: true }).click()
+  await fillAndSelect(
+    page.getByRole('combobox', { name: 'ICMPv4 type' }),
+    page,
+    '8',
+    '8 - Echo Request'
+  )
+  await page.getByRole('button', { name: 'Add protocol filter' }).click()
+  await expectRowVisible(protocolTable, { Protocol: 'ICMPv4', Type: '8' })
+
+  // add an ICMPv6 filter with a different type number; v4 type 8 is Echo
+  // Request, v6 type 128 is Echo Request — different numbers, same intent
+  await protocolListbox.click()
+  await page.getByRole('option', { name: 'ICMPv6', exact: true }).click()
+  await fillAndSelect(
+    page.getByRole('combobox', { name: 'ICMPv6 type' }),
+    page,
+    '128',
+    '128 - Echo Request'
+  )
+  await page.getByRole('button', { name: 'Add protocol filter' }).click()
+  await expectRowVisible(protocolTable, { Protocol: 'ICMPv6', Type: '128' })
+
+  // both rows are present
+  await expect(protocolTable.getByRole('row')).toHaveCount(3) // header + 2
+
+  // switching protocol type clears the previously selected ICMP type
+  await protocolListbox.click()
+  await page.getByRole('option', { name: 'ICMPv4', exact: true }).click()
+  await expect(page.getByRole('combobox', { name: 'ICMPv4 type' })).toHaveValue('')
 })
 
 // Regression test: when typing a partial match in an arbitrary-values combobox,

--- a/test/e2e/firewall-rules.e2e.ts
+++ b/test/e2e/firewall-rules.e2e.ts
@@ -710,8 +710,16 @@ test('can add ICMPv4 and ICMPv6 protocol filters', async ({ page }) => {
   await page.getByRole('button', { name: 'Add protocol filter' }).click()
   await expectRowVisible(protocolTable, { Protocol: 'ICMPv6', Type: '128' })
 
+  // manually typed values are trimmed before being stored
+  await protocolListbox.click()
+  await page.getByRole('option', { name: 'ICMPv4', exact: true }).click()
+  await v4Type.fill(' 42 ')
+  await page.getByRole('textbox', { name: 'ICMPv4 code' }).fill(' 0 ')
+  await page.getByRole('button', { name: 'Add protocol filter' }).click()
+  await expectRowVisible(protocolTable, { Protocol: 'ICMPv4', Type: '42', Code: '0' })
+
   // both rows are present
-  await expect(protocolTable.getByRole('row')).toHaveCount(3) // header + 2
+  await expect(protocolTable.getByRole('row')).toHaveCount(4) // header + 3
 
   // switching protocol type clears the previously selected ICMP type
   await protocolListbox.click()

--- a/test/e2e/firewall-rules.e2e.ts
+++ b/test/e2e/firewall-rules.e2e.ts
@@ -696,12 +696,8 @@ test('can add ICMPv4 and ICMPv6 protocol filters', async ({ page }) => {
   const protocolListbox = page.getByRole('button', { name: 'Protocol filters' })
   await protocolListbox.click()
   await page.getByRole('option', { name: 'ICMPv4', exact: true }).click()
-  await fillAndSelect(
-    page.getByRole('combobox', { name: 'ICMPv4 type' }),
-    page,
-    '8',
-    '8 - Echo Request'
-  )
+  const v4Type = page.getByRole('combobox', { name: 'ICMPv4 type' })
+  await fillAndSelect(v4Type, page, '8', '8 - Echo Request')
   await page.getByRole('button', { name: 'Add protocol filter' }).click()
   await expectRowVisible(protocolTable, { Protocol: 'ICMPv4', Type: '8' })
 
@@ -709,12 +705,8 @@ test('can add ICMPv4 and ICMPv6 protocol filters', async ({ page }) => {
   // Request, v6 type 128 is Echo Request — different numbers, same intent
   await protocolListbox.click()
   await page.getByRole('option', { name: 'ICMPv6', exact: true }).click()
-  await fillAndSelect(
-    page.getByRole('combobox', { name: 'ICMPv6 type' }),
-    page,
-    '128',
-    '128 - Echo Request'
-  )
+  const v6Type = page.getByRole('combobox', { name: 'ICMPv6 type' })
+  await fillAndSelect(v6Type, page, '128', '128 - Echo Request')
   await page.getByRole('button', { name: 'Add protocol filter' }).click()
   await expectRowVisible(protocolTable, { Protocol: 'ICMPv6', Type: '128' })
 
@@ -724,12 +716,7 @@ test('can add ICMPv4 and ICMPv6 protocol filters', async ({ page }) => {
   // switching protocol type clears the previously selected ICMP type
   await protocolListbox.click()
   await page.getByRole('option', { name: 'ICMPv6', exact: true }).click()
-  await fillAndSelect(
-    page.getByRole('combobox', { name: 'ICMPv6 type' }),
-    page,
-    '128',
-    '128 - Echo Request'
-  )
+  await fillAndSelect(v6Type, page, '128', '128 - Echo Request')
   await protocolListbox.click()
   await page.getByRole('option', { name: 'ICMPv4', exact: true }).click()
   await expect(page.getByRole('combobox', { name: 'ICMPv4 type' })).toHaveValue('')

--- a/test/e2e/firewall-rules.e2e.ts
+++ b/test/e2e/firewall-rules.e2e.ts
@@ -717,6 +717,14 @@ test('can add ICMPv4 and ICMPv6 protocol filters', async ({ page }) => {
 
   // switching protocol type clears the previously selected ICMP type
   await protocolListbox.click()
+  await page.getByRole('option', { name: 'ICMPv6', exact: true }).click()
+  await fillAndSelect(
+    page.getByRole('combobox', { name: 'ICMPv6 type' }),
+    page,
+    '128',
+    '128 - Echo Request'
+  )
+  await protocolListbox.click()
   await page.getByRole('option', { name: 'ICMPv4', exact: true }).click()
   await expect(page.getByRole('combobox', { name: 'ICMPv4 type' })).toHaveValue('')
 })

--- a/test/e2e/firewall-rules.e2e.ts
+++ b/test/e2e/firewall-rules.e2e.ts
@@ -678,6 +678,12 @@ test('arbitrary values combobox', async ({ page }) => {
   await expect(error).toBeHidden()
   await page.getByRole('button', { name: 'Add protocol filter' }).click()
   await expect(error).toBeVisible()
+
+  // switching protocol clears the type value and its stale validation error,
+  // rather than leaving the error stranded on the now-empty field
+  await selectOption(page, 'Protocol filters', 'ICMPv6')
+  await expect(page.getByRole('combobox', { name: 'ICMPv6 type' })).toHaveValue('')
+  await expect(error).toBeHidden()
 })
 
 test('can add ICMPv4 and ICMPv6 protocol filters', async ({ page }) => {


### PR DESCRIPTION
Closes #3207 

This uses `ICMPv4` and `ICMPv6`. Generally we try to follow what the API calls things, but the strings in the API are `icmp` and `icmp6`, while all the human-readable stuff like doc comments, PR titles, and docs use the ICMPv6 version.

<img width="489" height="256" alt="Screenshot 2026-05-04 at 6 45 34 PM" src="https://github.com/user-attachments/assets/87a332a7-1431-426a-a990-462308ea82b1" />

<img width="482" height="492" alt="Screenshot 2026-05-04 at 6 45 47 PM" src="https://github.com/user-attachments/assets/ec2ac598-8fe0-44db-b758-13a7159343c2" />

<img width="476" height="489" alt="image" src="https://github.com/user-attachments/assets/ae4ecae3-8666-4df9-b191-5f3f81b1e35d" />

<img width="487" height="265" alt="Screenshot 2026-05-04 at 6 48 05 PM" src="https://github.com/user-attachments/assets/d7933e48-6baf-495c-97a0-a57005e6efb6" />
