### PR TITLE
Terminal: Disable bold, tweak line height

### DIFF
--- a/app/components/Terminal.tsx
+++ b/app/components/Terminal.tsx
@@ -58,7 +58,9 @@ function getOptions(): ITerminalOptions {
     fontFamily: '"GT America Mono", monospace',
     fontSize: 13,
     lineHeight: 1,
-    fontWeightBold: 'normal',
+    fontWeightBold: 400,
+    drawBoldTextInBrightColors: true,
+    letterSpacing: 0,
     windowOptions: {
       fullscreenWin: true,
       refreshWin: true,

--- a/app/components/Terminal.tsx
+++ b/app/components/Terminal.tsx
@@ -57,7 +57,8 @@ function getOptions(): ITerminalOptions {
     screenReaderMode: true,
     fontFamily: '"GT America Mono", monospace',
     fontSize: 13,
-    lineHeight: 1.2,
+    lineHeight: 1,
+    fontWeightBold: 'normal',
     windowOptions: {
       fullscreenWin: true,
       refreshWin: true,

--- a/app/ui/styles/index.css
+++ b/app/ui/styles/index.css
@@ -281,3 +281,7 @@
     display: none;
   }
 }
+
+.xterm-bold {
+  -webkit-text-stroke: 0.75px currentColor;
+}

--- a/mock-api/serial-console.txt
+++ b/mock-api/serial-console.txt
@@ -2,7 +2,8 @@ Terminal theme test:
 [31mred[0m [32mgreen[0m [33myellow[0m [34mblue[0m [35mmagenta[0m [36mcyan[0m [37mwhite[0m
 [91mbright-red[0m [92mbright-green[0m [93mbright-yellow[0m [94mbright-blue[0m [95mbright-magenta[0m [96mbright-cyan[0m [97mbright-white[0m [90mbright-black[0m
 
-[1mBold text[0m
+[1mBold A Bold A[0m
+Bold A Bold A
 
 Booting `Debian GNU/Linux'
 

--- a/mock-api/serial-console.txt
+++ b/mock-api/serial-console.txt
@@ -2,7 +2,25 @@ Terminal theme test:
 [31mred[0m [32mgreen[0m [33myellow[0m [34mblue[0m [35mmagenta[0m [36mcyan[0m [37mwhite[0m
 [91mbright-red[0m [92mbright-green[0m [93mbright-yellow[0m [94mbright-blue[0m [95mbright-magenta[0m [96mbright-cyan[0m [97mbright-white[0m [90mbright-black[0m
 
+[1mBold text[0m
+
 Booting `Debian GNU/Linux'
+
+               [31m([m
+           [31m.    )   .[m
+       [31m~.   .  (  .   .~[m
+    [31m~_   '._.-'''-._.'   _~[m
+      [31m'~..'         '..~'[m
+   [31m~~._ /             \ _.~~[m
+       [31m;[33m/____\   /____\[31m;[m
+[31m~~~~~~~|[33m`     ) (     `[31m|~~~~~~~[m
+      [31m_:     [33m(   )[31m     ;_[m
+   [31m~~'  \             /  '~~[m
+     [31m_.~''.   [33m~~~[31m   .''~._[m
+    [31m~    .''-.....-''.    ~[m
+       [31m~'   '  )  '   '~[m
+          [31m'   (   '[m
+               [31m)[m
 
 Loading Linux 6.12.38+deb13-amd64 ...
 Loading initial ramdisk ...


### PR DESCRIPTION
**Line Height**
In xterm.js, `lineHeight` is a multiplier on the *measured* cell height, not the font size. So a `lineHeight` of 1 is actually closer to what we'd expect here.

**Bold**
There seems to be a bug where setting bold makes the cell width wider. Not sure if this is on `xterm.js` or its the font metrics. Better instead to just disable bold.

Before:
<img width="320" height="419" alt="image" src="https://github.com/user-attachments/assets/a65cc31c-6f01-4065-8825-291007e424fb" />

After:
<img width="315" height="350" alt="image" src="https://github.com/user-attachments/assets/8dd5ce6e-ee9e-41fb-b964-d58620aacc2d" />