### PR TITLE
Add `contact_support` on update status page

### DIFF
--- a/app/pages/system/UpdatePage.tsx
+++ b/app/pages/system/UpdatePage.tsx
@@ -203,9 +203,8 @@ export default function UpdatePage() {
           content={
             <>
               The system has detected one or more known conditions that require Oxide
-              support to resolve. Contact support (
-              <Link to="mailto:support@oxide.computer">support@oxide.computer</Link>) before
-              starting any update, and immediately if an update has recently completed.
+              support to resolve. Do not start an update until you contact support at{' '}
+              <Link to="mailto:support@oxide.computer">support@oxide.computer</Link>.
             </>
           }
           cta={{

--- a/app/pages/system/UpdatePage.tsx
+++ b/app/pages/system/UpdatePage.tsx
@@ -38,6 +38,7 @@ import { CardBlock } from '~/ui/lib/CardBlock'
 import { DateTime } from '~/ui/lib/DateTime'
 import { Divider } from '~/ui/lib/Divider'
 import * as DropdownMenu from '~/ui/lib/DropdownMenu'
+import { Message } from '~/ui/lib/Message'
 import { PageHeader, PageTitle } from '~/ui/lib/PageHeader'
 import { PropertiesTable } from '~/ui/lib/PropertiesTable'
 import { TipIcon } from '~/ui/lib/TipIcon'
@@ -191,21 +192,26 @@ export default function UpdatePage() {
         >
           {status.suspended ? 'Yes' : 'No'}
         </PropertiesTable.Row>
-        <PropertiesTable.Row
-          label={
+      </PropertiesTable>
+
+      {status.contactSupport && (
+        <Message
+          className="mt-4"
+          variant="notice"
+          title="Contact Oxide support"
+          content={
             <>
-              Contact support?{' '}
-              <TipIcon className="ml-1.5">
-                If yes, the system has detected one or more known conditions that require
-                Oxide support to resolve. Contact support before starting any update, and
-                immediately if an update has recently completed.
+              The system has detected one or more known conditions that require Oxide
+              support to resolve.{' '}
+              <TipIcon className="ml-0.5 [&>svg]:text-[var(--content-accent-secondary)]">
+                Contact support before starting any update, and immediately if an update has
+                recently completed. The checks underlying this state are not exhaustive, so
+                the absence of this message does not mean the system is completely healthy.
               </TipIcon>
             </>
           }
-        >
-          {status.contactSupport ? 'Yes' : 'No'}
-        </PropertiesTable.Row>
-      </PropertiesTable>
+        />
+      )}
 
       <Divider className="my-8" />
 

--- a/app/pages/system/UpdatePage.tsx
+++ b/app/pages/system/UpdatePage.tsx
@@ -8,6 +8,7 @@
 
 import { differenceInMinutes } from 'date-fns'
 import { useMemo } from 'react'
+import { Link } from 'react-router'
 import * as R from 'remeda'
 import { lt as semverLt } from 'semver'
 
@@ -198,18 +199,19 @@ export default function UpdatePage() {
         <Message
           className="mt-4"
           variant="notice"
-          title="Contact Oxide support"
+          title="Support required"
           content={
             <>
               The system has detected one or more known conditions that require Oxide
-              support to resolve.{' '}
-              <TipIcon className="ml-0.5 [&>svg]:text-[var(--content-accent-secondary)]">
-                Contact support before starting any update, and immediately if an update has
-                recently completed. The checks underlying this state are not exhaustive, so
-                the absence of this message does not mean the system is completely healthy.
-              </TipIcon>
+              support to resolve. Contact support (
+              <Link to="mailto:support@oxide.computer">support@oxide.computer</Link>) before
+              starting any update, and immediately if an update has recently completed.
             </>
           }
+          cta={{
+            text: 'Contact Support',
+            link: 'mailto:support@oxide.computer',
+          }}
         />
       )}
 

--- a/app/pages/system/UpdatePage.tsx
+++ b/app/pages/system/UpdatePage.tsx
@@ -14,6 +14,7 @@ import { lt as semverLt } from 'semver'
 
 import {
   Images24Icon,
+  OpenLink12Icon,
   SoftwareUpdate16Icon,
   SoftwareUpdate24Icon,
 } from '@oxide/design-system/icons/react'
@@ -106,6 +107,21 @@ function calcProgress(status: UpdateStatus) {
     percentage: round(percentage(current, total), 0, 'trunc'),
   }
 }
+
+// wrapper div keeps the link out of the Message content's [&>a]:tint-underline
+const ContactSupportCta = () => (
+  <div>
+    <Link
+      className="text-mono-xs text-accent group mt-3 inline-flex items-center gap-1.5"
+      to="https://support.oxide.computer"
+      target="_blank"
+      rel="noreferrer"
+    >
+      Contact Support
+      <OpenLink12Icon />
+    </Link>
+  </div>
+)
 
 export default function UpdatePage() {
   const { data: status } = usePrefetchedQuery(statusQuery)
@@ -203,14 +219,10 @@ export default function UpdatePage() {
           content={
             <>
               The system has detected one or more known conditions that require Oxide
-              support to resolve. Do not start an update until you contact support at{' '}
-              <Link to="mailto:support@oxide.computer">support@oxide.computer</Link>.
+              support to resolve.
+              <ContactSupportCta />
             </>
           }
-          cta={{
-            text: 'Contact Support',
-            link: 'mailto:support@oxide.computer',
-          }}
         />
       )}
 

--- a/app/pages/system/UpdatePage.tsx
+++ b/app/pages/system/UpdatePage.tsx
@@ -191,6 +191,20 @@ export default function UpdatePage() {
         >
           {status.suspended ? 'Yes' : 'No'}
         </PropertiesTable.Row>
+        <PropertiesTable.Row
+          label={
+            <>
+              Contact support?{' '}
+              <TipIcon className="ml-1.5">
+                If yes, the system has detected one or more known conditions that require
+                Oxide support to resolve. Contact support before starting any update, and
+                immediately if an update has recently completed.
+              </TipIcon>
+            </>
+          }
+        >
+          {status.contactSupport ? 'Yes' : 'No'}
+        </PropertiesTable.Row>
       </PropertiesTable>
 
       <Divider className="my-8" />

--- a/app/ui/lib/Message.tsx
+++ b/app/ui/lib/Message.tsx
@@ -10,8 +10,8 @@ import type { ReactElement, ReactNode } from 'react'
 import { Link, type To } from 'react-router'
 
 import {
-  DirectionRightIcon,
   Error12Icon,
+  OpenLink12Icon,
   Success12Icon,
   Warning12Icon,
 } from '@oxide/design-system/icons/react'
@@ -21,7 +21,6 @@ type Variant = 'success' | 'error' | 'notice' | 'info'
 export interface MessageProps {
   title?: string
   content: ReactNode
-  append?: ReactNode
   className?: string
   variant?: Variant
   cta?: {
@@ -49,7 +48,6 @@ export const Message = ({
   title,
   // TODO: convert content to a children prop
   content,
-  append,
   className,
   variant = 'info',
   cta,
@@ -70,7 +68,7 @@ export const Message = ({
         </div>
       )}
       <div className="flex-1">
-        {title && <div className="text-sans-semi-md">{title}</div>}
+        {title && <div className="text-sans-semi-md mb-1">{title}</div>}
         {/* group gives HL the right color */}
         <div className="text-sans-md text-accent-secondary [&>a]:tint-underline group max-w-3xl">
           {content}
@@ -78,15 +76,13 @@ export const Message = ({
 
         {cta && (
           <Link
-            className="text-mono-xs text-accent group mt-3 flex items-center gap-2"
+            className="text-sans-md text-accent-secondary hover:text-accent mt-1 flex items-center underline"
             to={cta.link}
           >
             {cta.text}
-            <DirectionRightIcon className="translate-x-0 transition-transform group-hover:translate-x-0.5" />
+            <OpenLink12Icon className="ml-1" />
           </Link>
         )}
-
-        {append}
       </div>
     </div>
   )

--- a/app/ui/lib/Message.tsx
+++ b/app/ui/lib/Message.tsx
@@ -10,8 +10,8 @@ import type { ReactElement, ReactNode } from 'react'
 import { Link, type To } from 'react-router'
 
 import {
+  DirectionRightIcon,
   Error12Icon,
-  OpenLink12Icon,
   Success12Icon,
   Warning12Icon,
 } from '@oxide/design-system/icons/react'
@@ -21,6 +21,7 @@ type Variant = 'success' | 'error' | 'notice' | 'info'
 export interface MessageProps {
   title?: string
   content: ReactNode
+  append?: ReactNode
   className?: string
   variant?: Variant
   cta?: {
@@ -48,6 +49,7 @@ export const Message = ({
   title,
   // TODO: convert content to a children prop
   content,
+  append,
   className,
   variant = 'info',
   cta,
@@ -70,19 +72,21 @@ export const Message = ({
       <div className="flex-1">
         {title && <div className="text-sans-semi-md">{title}</div>}
         {/* group gives HL the right color */}
-        <div className="text-sans-md text-accent-secondary [&>a]:tint-underline group">
+        <div className="text-sans-md text-accent-secondary [&>a]:tint-underline group max-w-3xl">
           {content}
         </div>
 
         {cta && (
           <Link
-            className="text-sans-md text-accent-secondary hover:text-accent mt-1 flex items-center underline"
+            className="text-mono-xs text-accent group mt-3 flex items-center gap-2"
             to={cta.link}
           >
             {cta.text}
-            <OpenLink12Icon className="ml-1" />
+            <DirectionRightIcon className="translate-x-0 transition-transform group-hover:translate-x-0.5" />
           </Link>
         )}
+
+        {append}
       </div>
     </div>
   )

--- a/mock-api/system-update.ts
+++ b/mock-api/system-update.ts
@@ -36,7 +36,7 @@ export const updateStatus: Json<UpdateStatus> = {
     '17.0.0': 12,
     '16.0.0': 5,
   },
-  contact_support: false,
+  contact_support: true,
   suspended: false,
   target_release: {
     version: '17.0.0',


### PR DESCRIPTION
New boolean `contact_support` field on update status added in https://github.com/oxidecomputer/omicron/pull/10271.

I tried it inside the properties table as `Contact support: Yes` and it felt terrible.

<details>
<summary>
Robot notes on the API logic behind <code>contact_support</code>
</summary>

[omicron#10271](https://github.com/oxidecomputer/omicron/pull/10271) adds a `contact_support: bool` field to the `system/update/status` API. It is the last piece of a minimal system health check tied to update status, intended as a stopgap until the fault management subsystem lands ([RFD 612](https://rfd.shared.oxide.computer/rfd/0612)).

## What it means

When `contact_support` is `true`, Nexus has detected one or more known conditions in the latest inventory collection (plus a few additional checks) that require Oxide support to resolve. The field collapses several sub-checks into a single boolean because none of the individual conditions are actionable by the customer — the only action is to call support. The detailed breakdown is logged server-side and lands in support bundles.

The intended usage maps to two cases:

- **Before an update**: if `contact_support` is true, the customer should not start an update — resolve the issue with support first.
- **After an update**: if `contact_support` is true, something went wrong; the customer should call support immediately.

## Conditions that trigger `contact_support: true`

- **Unhealthy zpools** — any zpool not in `online` state (e.g., degraded).
- **Enabled SMF services not online** — services that should be running but are in `maintenance`, `offline`, or `degraded`.
- **Stuck sagas** — sagas that have been running longer than ~15 minutes. (A sample of 10,000 done sagas on dogfood showed only 3 exceeded 15 minutes from creation to completion.)
- **Stale inventory collection** — no recent inventory collection (~15 min threshold), meaning Nexus has lost visibility into rack state.
- **Stalled update** — an update is supposed to be in progress but the planner hasn't taken a step in ~30 minutes.

The list is explicitly minimal and not exhaustive — `contact_support: false` does not guarantee the system is fully healthy.

## Suppression during an active update

Health checks often fail transiently during an update, so the API suppresses `contact_support: true` while an update is genuinely in progress. The field only surfaces a true value when either (1) there is no update in progress, or (2) an in-progress update has stalled past the threshold (matching the [10–15 minute guidance](https://github.com/oxidecomputer/omicron/blob/main/docs/reconfigurator-ops-guide.adoc#debug-stuck)) in the Reconfigurator Ops Guide for when support considers an update stuck).

In practice this means the field always presents in one of two contexts: the system is idle (pre-update or post-update), or the update has stalled long enough that the result is no longer a transient artifact.

</details>


## Issues to resolve

- Explain the situation without overdoing it
- Tooltip looks terrible in message box, what if we link to docs instead
- Should probably link to a way to actually contact support, probably the support email that goes to Zendesk

<img width="808" height="381" alt="image" src="https://github.com/user-attachments/assets/bd8a75ed-7550-440f-81a3-6fc5319b79fb" />
