### PR TITLE
minor: fix image upload cleanup refs

### DIFF
--- a/app/forms/image-upload.tsx
+++ b/app/forms/image-upload.tsx
@@ -508,7 +508,9 @@ export default function ImageCreate() {
     // now delete the snapshot and the disk. don't use cleanup() because that
     // uses different mutations
     await deleteSnapshot.mutateAsync({ path: { snapshot: snapshot.current.id } })
+    snapshot.current = null
     await deleteDisk.mutateAsync({ path: { disk: disk.current.id } })
+    disk.current = null
 
     setAllDone(true)
   }


### PR DESCRIPTION
A small bug the robot caught while looking at #3222.

At the end of a successful image upload, we delete the temporary snapshot and disk. If snapshot deletion succeeded but disk deletion failed, the catch path called `cleanup()` while `snapshot.current` still pointed at the already-deleted snapshot. Cleanup would then try to delete that snapshot again, fail with 404, and never reach the remaining disk cleanup.

Fix: Clear each ref immediately after its successful delete so later cleanup only retries resources that still exist.

It would be nice to have a test for this but it would be pretty elaborate for little gain.