### PR TITLE
Upgrade design system

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@base-ui/react": "^1.1.0",
         "@floating-ui/react": "^0.26.23",
         "@headlessui/react": "^2.2.9",
-        "@oxide/design-system": "^6.2.1",
+        "@oxide/design-system": "^6.3.0",
         "@react-aria/live-announcer": "^3.3.4",
         "@tailwindcss/container-queries": "^0.1.1",
         "@tailwindcss/vite": "^4.2.4",
@@ -1332,9 +1332,9 @@
       }
     },
     "node_modules/@oxide/design-system": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@oxide/design-system/-/design-system-6.2.1.tgz",
-      "integrity": "sha512-1QBu1CVLx20AI9QHOo/m7yFslghpYfHhHxa7r/74NV6Ff/RawkUQjl7X+NgFxLyf3jJehWgWBhcycxM+Bw1q3A==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@oxide/design-system/-/design-system-6.3.0.tgz",
+      "integrity": "sha512-AX3zviv4RuH6AKZkETGMqLnqVucNRSPaAw4zVMqYzJdhDfQUqJUljJsQA7jqWnSWn7BK9T0gvEKrrL7+jrtX4w==",
       "license": "MPL 2.0",
       "dependencies": {
         "@floating-ui/react": "^0.27.16",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@base-ui/react": "^1.1.0",
     "@floating-ui/react": "^0.26.23",
     "@headlessui/react": "^2.2.9",
-    "@oxide/design-system": "^6.2.1",
+    "@oxide/design-system": "^6.3.0",
     "@react-aria/live-announcer": "^3.3.4",
     "@tailwindcss/container-queries": "^0.1.1",
     "@tailwindcss/vite": "^4.2.4",


### PR DESCRIPTION
Upgraded design system includes tweaked type tokens.
Existing `text-sans-*` callsites continue to work so that's all left the same.

Will switch out for semantic responsive versions in some places when I work on responsive console.

https://github.com/oxidecomputer/design-system/pull/189