### PR TITLE
Add brotli files to production asset bundle

### DIFF
--- a/.github/workflows/upload-assets.yaml
+++ b/.github/workflows/upload-assets.yaml
@@ -27,6 +27,10 @@ jobs:
         run: SHA=${{ github.sha }} npm run build
       - name: Gzip individual files (keep originals)
         run: ls dist/assets/*.{js,css,map} | xargs gzip --keep
+      # Brotli is ~14% smaller than gzip on our JS/CSS. Nexus serves .br when the
+      # client's Accept-Encoding allows it, falling back to .gz then identity.
+      - name: Brotli individual files (keep originals)
+        run: ls dist/assets/*.{js,css,map} | xargs brotli --keep --quality=11
       - name: add console_version file
         run: echo ${{ github.sha }} > dist/VERSION
       - run: mkdir -p releases/console


### PR DESCRIPTION
Closes #3233, see that issue for details and comparison of compression algos. This makes the files about 14% smaller than gzip, so we might as well. There will have to be an Omicron PR to go with it. I think I want to wait until after we cut this release to do this.