### PR TITLE
minor: delete unused cta prop on Message

### DIFF
--- a/app/ui/lib/Message.tsx
+++ b/app/ui/lib/Message.tsx
@@ -7,14 +7,8 @@
  */
 import cn from 'classnames'
 import type { ReactElement, ReactNode } from 'react'
-import { Link, type To } from 'react-router'
 
-import {
-  Error12Icon,
-  OpenLink12Icon,
-  Success12Icon,
-  Warning12Icon,
-} from '@oxide/design-system/icons/react'
+import { Error12Icon, Success12Icon, Warning12Icon } from '@oxide/design-system/icons/react'
 
 type Variant = 'success' | 'error' | 'notice' | 'info'
 
@@ -23,10 +17,6 @@ export interface MessageProps {
   content: ReactNode
   className?: string
   variant?: Variant
-  cta?: {
-    text: string
-    link: To
-  }
   showIcon?: boolean
 }
 
@@ -50,7 +40,6 @@ export const Message = ({
   content,
   className,
   variant = 'info',
-  cta,
   showIcon = true,
 }: MessageProps) => {
   return (
@@ -73,16 +62,6 @@ export const Message = ({
         <div className="text-sans-md text-accent-secondary [&>a]:tint-underline group max-w-3xl">
           {content}
         </div>
-
-        {cta && (
-          <Link
-            className="text-sans-md text-accent-secondary hover:text-accent mt-1 flex items-center underline"
-            to={cta.link}
-          >
-            {cta.text}
-            <OpenLink12Icon className="ml-1" />
-          </Link>
-        )}
       </div>
     </div>
   )


### PR DESCRIPTION
In #3226 I realized we can do this directly in the `content` prop. If we decide we want it to look that way all the time, we can bring this prop back.