### PR TITLE
Add OS and version columns to image lists

### DIFF
--- a/app/pages/SiloImagesPage.tsx
+++ b/app/pages/SiloImagesPage.tsx
@@ -23,6 +23,7 @@ import { HL } from '~/components/HL'
 import { useQuickActions } from '~/hooks/use-quick-actions'
 import { confirmDelete } from '~/stores/confirm-delete'
 import { addToast } from '~/stores/toast'
+import { EmptyCell } from '~/table/cells/EmptyCell'
 import { makeLinkCell } from '~/table/cells/LinkCell'
 import { useColsWithActions, type MenuAction } from '~/table/columns/action-col'
 import { Columns } from '~/table/columns/common'
@@ -60,6 +61,13 @@ const staticCols = [
     cell: makeLinkCell((image) => pb.siloImageEdit({ image })),
   }),
   colHelper.accessor('description', Columns.description),
+  colHelper.accessor('os', {
+    header: 'OS',
+    cell: (info) => info.getValue() || <EmptyCell />,
+  }),
+  colHelper.accessor('version', {
+    cell: (info) => info.getValue() || <EmptyCell />,
+  }),
   colHelper.accessor('size', Columns.size),
   colHelper.accessor('timeCreated', Columns.timeCreated),
 ]

--- a/app/pages/project/images/ImagesPage.tsx
+++ b/app/pages/project/images/ImagesPage.tsx
@@ -20,6 +20,7 @@ import { getProjectSelector, useProjectSelector } from '~/hooks/use-params'
 import { useQuickActions } from '~/hooks/use-quick-actions'
 import { confirmDelete } from '~/stores/confirm-delete'
 import { addToast } from '~/stores/toast'
+import { EmptyCell } from '~/table/cells/EmptyCell'
 import { makeLinkCell } from '~/table/cells/LinkCell'
 import { getActionsCol, type MenuAction } from '~/table/columns/action-col'
 import { Columns } from '~/table/columns/common'
@@ -98,6 +99,13 @@ export default function ImagesPage() {
         cell: makeLinkCell((image) => pb.projectImageEdit({ project, image })),
       }),
       colHelper.accessor('description', Columns.description),
+      colHelper.accessor('os', {
+        header: 'OS',
+        cell: (info) => info.getValue() || <EmptyCell />,
+      }),
+      colHelper.accessor('version', {
+        cell: (info) => info.getValue() || <EmptyCell />,
+      }),
       colHelper.accessor('size', Columns.size),
       colHelper.accessor('timeCreated', Columns.timeCreated),
       getActionsCol(makeActions),

--- a/test/e2e/images.e2e.ts
+++ b/test/e2e/images.e2e.ts
@@ -12,11 +12,30 @@ import {
   clipboardText,
   expect,
   expectNotVisible,
+  expectRowVisible,
   expectToast,
   expectVisible,
   getPageAsUser,
   selectOption,
 } from './utils'
+
+test('shows OS and Version columns', async ({ page }) => {
+  await page.goto('/images')
+  await expectRowVisible(page.getByRole('table'), {
+    name: 'ubuntu-22-04',
+    OS: 'ubuntu',
+    version: '22.04',
+    size: '1 GiB',
+  })
+
+  await page.goto('/projects/mock-project/images')
+  await expectRowVisible(page.getByRole('table'), {
+    name: 'image-1',
+    OS: 'alpine',
+    version: 'edge1',
+    size: '4 GiB',
+  })
+})
 
 test('can promote an image from silo', async ({ page }) => {
   await page.goto('/images')


### PR DESCRIPTION
This adds the OS and version columns to the Silo and Project image lists. The data're already there; this just pulls it to a more useful location when looking at the image lists. HT to @sudomateo for the idea.

<img width="1175" height="361" alt="Screenshot 2026-06-11 at 6 09 41 PM" src="https://github.com/user-attachments/assets/d2ffe9a6-9a9e-425a-943b-9ac46a434403" />