### PR TITLE
minor: Add `API_VERSION` to tarball

### DIFF
--- a/.github/workflows/upload-assets.yaml
+++ b/.github/workflows/upload-assets.yaml
@@ -29,6 +29,8 @@ jobs:
         run: ls dist/assets/*.{js,css,map} | xargs gzip --keep
       - name: add console_version file
         run: echo ${{ github.sha }} > dist/VERSION
+      - name: add API_VERSION file
+        run: cp app/api/__generated__/API_VERSION dist/API_VERSION
       - run: mkdir -p releases/console
       - name: Make <sha>.tar.gz
         run: tar czf releases/console/${{ github.sha }}.tar.gz --directory=dist .


### PR DESCRIPTION
Put it in the tarball so we don't have to fetch the file from GitHub in the releng script.

https://github.com/oxidecomputer/omicron/pull/10596#discussion_r3424998012