### PR TITLE
Add VPC ID and IPv6 prefix data to VPC page table

### DIFF
--- a/app/pages/project/vpcs/VpcPage.tsx
+++ b/app/pages/project/vpcs/VpcPage.tsx
@@ -70,7 +70,9 @@ export default function VpcPage() {
       <PropertiesTable columns={2} className="-mt-8 mb-8">
         <PropertiesTable.DescriptionRow description={vpc.description} />
         <PropertiesTable.Row label="DNS Name">{vpc.dnsName}</PropertiesTable.Row>
+        <PropertiesTable.CopyableRow label="IPv6 Prefix" text={vpc.ipv6Prefix} />
         <PropertiesTable.DateRow date={vpc.timeCreated} label="Created" />
+        <PropertiesTable.IdRow id={vpc.id} />
         <PropertiesTable.DateRow date={vpc.timeModified} label="Last Modified" />
       </PropertiesTable>
 

--- a/app/pages/settings/ProfilePage.tsx
+++ b/app/pages/settings/ProfilePage.tsx
@@ -44,7 +44,7 @@ export default function ProfilePage() {
 
       <PropertiesTable className="-mt-8 mb-8">
         <PropertiesTable.Row label="Display name">{me.displayName}</PropertiesTable.Row>
-        <PropertiesTable.CopyableRow label="User ID" text={me.id} />
+        <PropertiesTable.IdRow label="User ID" id={me.id} />
       </PropertiesTable>
 
       <TableTitle id="groups-label" className="mb-4">

--- a/app/pages/settings/ProfilePage.tsx
+++ b/app/pages/settings/ProfilePage.tsx
@@ -13,6 +13,7 @@ import { Settings24Icon } from '@oxide/design-system/icons/react'
 import { useCurrentUser } from '~/hooks/use-current-user'
 import { getActionsCol } from '~/table/columns/action-col'
 import { Table } from '~/table/Table'
+import { CopyToClipboard } from '~/ui/lib/CopyToClipboard'
 import { PageHeader, PageTitle } from '~/ui/lib/PageHeader'
 import { PropertiesTable } from '~/ui/lib/PropertiesTable'
 import { TableTitle } from '~/ui/lib/Table'
@@ -44,7 +45,10 @@ export default function ProfilePage() {
 
       <PropertiesTable className="-mt-8 mb-8">
         <PropertiesTable.Row label="Display name">{me.displayName}</PropertiesTable.Row>
-        <PropertiesTable.IdRow label="User ID" id={me.id} />
+        <PropertiesTable.Row label="User ID">
+          {me.id}
+          <CopyToClipboard className="ml-1" text={me.id} />
+        </PropertiesTable.Row>
       </PropertiesTable>
 
       <TableTitle id="groups-label" className="mb-4">

--- a/app/pages/settings/ProfilePage.tsx
+++ b/app/pages/settings/ProfilePage.tsx
@@ -13,7 +13,6 @@ import { Settings24Icon } from '@oxide/design-system/icons/react'
 import { useCurrentUser } from '~/hooks/use-current-user'
 import { getActionsCol } from '~/table/columns/action-col'
 import { Table } from '~/table/Table'
-import { CopyToClipboard } from '~/ui/lib/CopyToClipboard'
 import { PageHeader, PageTitle } from '~/ui/lib/PageHeader'
 import { PropertiesTable } from '~/ui/lib/PropertiesTable'
 import { TableTitle } from '~/ui/lib/Table'
@@ -45,10 +44,7 @@ export default function ProfilePage() {
 
       <PropertiesTable className="-mt-8 mb-8">
         <PropertiesTable.Row label="Display name">{me.displayName}</PropertiesTable.Row>
-        <PropertiesTable.Row label="User ID">
-          {me.id}
-          <CopyToClipboard className="ml-1" text={me.id} />
-        </PropertiesTable.Row>
+        <PropertiesTable.CopyableRow label="User ID" text={me.id} />
       </PropertiesTable>
 
       <TableTitle id="groups-label" className="mb-4">

--- a/app/ui/lib/PropertiesTable.tsx
+++ b/app/ui/lib/PropertiesTable.tsx
@@ -74,7 +74,11 @@ PropertiesTable.Row = ({ label, children }: PropertiesTableRowProps) => (
 
 PropertiesTable.IdRow = ({ id, label = 'ID' }: { id?: string | null; label?: string }) => (
   <PropertiesTable.Row label={label}>
-    {id ? <Truncate text={id} maxLength={32} hasCopyButton /> : <EmptyCell />}
+    {id ? (
+      <Truncate text={id} maxLength={32} hasCopyButton position="middle" />
+    ) : (
+      <EmptyCell />
+    )}
   </PropertiesTable.Row>
 )
 

--- a/app/ui/lib/PropertiesTable.tsx
+++ b/app/ui/lib/PropertiesTable.tsx
@@ -74,7 +74,7 @@ PropertiesTable.Row = ({ label, children }: PropertiesTableRowProps) => (
 
 PropertiesTable.IdRow = ({ id, label = 'ID' }: { id?: string | null; label?: string }) => (
   <PropertiesTable.Row label={label}>
-    {id ? <Truncate text={id} maxLength={32} hasCopyButton /> : <EmptyCell />}
+    {id ? <Truncate text={id} maxLength={36} hasCopyButton /> : <EmptyCell />}
   </PropertiesTable.Row>
 )
 

--- a/app/ui/lib/PropertiesTable.tsx
+++ b/app/ui/lib/PropertiesTable.tsx
@@ -74,11 +74,7 @@ PropertiesTable.Row = ({ label, children }: PropertiesTableRowProps) => (
 
 PropertiesTable.IdRow = ({ id, label = 'ID' }: { id?: string | null; label?: string }) => (
   <PropertiesTable.Row label={label}>
-    {id ? (
-      <Truncate text={id} maxLength={32} hasCopyButton position="middle" />
-    ) : (
-      <EmptyCell />
-    )}
+    {id ? <Truncate text={id} maxLength={32} hasCopyButton /> : <EmptyCell />}
   </PropertiesTable.Row>
 )
 

--- a/app/ui/lib/PropertiesTable.tsx
+++ b/app/ui/lib/PropertiesTable.tsx
@@ -74,7 +74,7 @@ PropertiesTable.Row = ({ label, children }: PropertiesTableRowProps) => (
 
 PropertiesTable.IdRow = ({ id, label = 'ID' }: { id?: string | null; label?: string }) => (
   <PropertiesTable.Row label={label}>
-    {id ? <Truncate text={id} maxLength={36} hasCopyButton /> : <EmptyCell />}
+    {id ? <Truncate text={id} maxLength={32} hasCopyButton /> : <EmptyCell />}
   </PropertiesTable.Row>
 )
 

--- a/app/ui/lib/PropertiesTable.tsx
+++ b/app/ui/lib/PropertiesTable.tsx
@@ -13,6 +13,7 @@ import { EmptyCell } from '~/table/cells/EmptyCell'
 import { isOneOf } from '~/util/children'
 import { invariant } from '~/util/invariant'
 
+import { CopyToClipboard } from './CopyToClipboard'
 import { DateTime } from './DateTime'
 import { Truncate } from './Truncate'
 
@@ -33,6 +34,7 @@ export function PropertiesTable({
       PropertiesTable.IdRow,
       PropertiesTable.DescriptionRow,
       PropertiesTable.DateRow,
+      PropertiesTable.CopyableRow,
     ]),
     'PropertiesTable only accepts specific Row components as children'
   )
@@ -97,5 +99,12 @@ PropertiesTable.DateRow = ({
 }) => (
   <PropertiesTable.Row label={label}>
     <DateTime date={date} />
+  </PropertiesTable.Row>
+)
+
+PropertiesTable.CopyableRow = ({ label, text }: { label: string; text: string }) => (
+  <PropertiesTable.Row label={label}>
+    {text}
+    <CopyToClipboard className="ml-1" text={text} />
   </PropertiesTable.Row>
 )

--- a/app/ui/lib/Truncate.tsx
+++ b/app/ui/lib/Truncate.tsx
@@ -27,9 +27,10 @@ export const Truncate = ({
   tooltipDelay = 300,
 }: TruncateProps) => {
   // Only use the tooltip if the text is longer than maxLength
+  // "truncate" class used for CSS truncation when cell rendered narrowly
   const content =
     text.length <= maxLength ? (
-      <div>{text}</div>
+      <div className="truncate">{text}</div>
     ) : (
       <Tooltip content={text} delay={tooltipDelay}>
         <div aria-label={text} className="truncate">

--- a/app/ui/lib/Truncate.tsx
+++ b/app/ui/lib/Truncate.tsx
@@ -26,22 +26,27 @@ export const Truncate = ({
   hasCopyButton,
   tooltipDelay = 300,
 }: TruncateProps) => {
-  if (text.length <= maxLength) {
-    return <div>{text}</div>
-  }
-
   // Only use the tooltip if the text is longer than maxLength
-  return (
-    // overflow-hidden required to make inner truncate work
-    <div className="flex items-center gap-0.5 overflow-hidden">
+  const content =
+    text.length <= maxLength ? (
+      <div>{text}</div>
+    ) : (
       <Tooltip content={text} delay={tooltipDelay}>
         <div aria-label={text} className="truncate">
           {truncate(text, maxLength, position)}
         </div>
       </Tooltip>
-      <div className="flex items-center p-0.5">
-        {hasCopyButton && <CopyToClipboard text={text} />}
-      </div>
+    )
+
+  return (
+    // overflow-hidden required to make inner truncate work
+    <div className="flex items-center gap-0.5 overflow-hidden">
+      {content}
+      {hasCopyButton && (
+        <div className="flex items-center p-0.5">
+          <CopyToClipboard text={text} />
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
I was chatting with @sudomateo about a few improvements to the console, and one request was that we add the VPC ID to the header table, as it isn't currently available from the VPC page (and going back to the index page to grab it from the overflow menu is awkward). Second, as we get more IPv6 networking info into console, adding the IPv6 prefix to the header could be useful, and keeps the number of rows balanced. I am open to a different layout of the rows (are the timestamps useful? could remove?), but I think this works.

Before:
<img width="1184" height="237" alt="Screenshot 2026-06-23 at 4 00 43 PM" src="https://github.com/user-attachments/assets/f8cd13f8-4022-4e69-8e99-78c2a08e035b" />
After:
<img width="1186" height="282" alt="Screenshot 2026-06-23 at 3 30 09 PM" src="https://github.com/user-attachments/assets/e5a668df-5bfa-410f-b85e-277a736c2f17" />

In working on this I noticed that the logic we had in place for rows with a CopyToClipboard button had an early return that meant that the "copy" button would only show up when the truncation was in effect, even though it's a useful affordance even when the truncation isn't in play. So I fixed that so it shows up whenever the callsite includes the `hasCopyButton` prop set.