### PR TITLE
Fix an e2e flake, maybe: use `fillNumberInput`

### DIFF
--- a/test/e2e/firewall-rules.e2e.ts
+++ b/test/e2e/firewall-rules.e2e.ts
@@ -11,6 +11,7 @@ import {
   expect,
   expectRowVisible,
   fillAndSelectComboboxOption,
+  fillNumberInput,
   selectOption,
   test,
   type Locator,
@@ -41,7 +42,7 @@ test('can create firewall rule', async ({ page }) => {
   await page.fill('input[name=name]', 'my-new-rule')
   await page.getByRole('radio', { name: 'Outbound' }).click()
 
-  await page.fill('role=textbox[name="Priority"]', '5')
+  await fillNumberInput(page.getByRole('textbox', { name: 'Priority' }), '5')
 
   // add targets with overlapping names and types to test delete
   const targets = page.getByRole('table', { name: 'Targets' })
@@ -583,7 +584,7 @@ test('name conflict error on edit', async ({ page }) => {
   await nameField.fill('allow-icmp')
 
   // changing a value _without_ changing the name is allowed
-  await page.getByRole('textbox', { name: 'Priority' }).fill('37')
+  await fillNumberInput(page.getByRole('textbox', { name: 'Priority' }), '37')
   await page.getByRole('button', { name: 'Update rule' }).click()
   await expect(error).toBeHidden()
   await expectRowVisible(page.getByRole('table'), { Name: 'allow-icmp', Priority: '37' })


### PR DESCRIPTION
Saw a flake in https://github.com/oxidecomputer/console/actions/runs/28251857097/job/83705140277, sicced the robot on it. Unfortunately it was not able to repro the flake locally, but it seems plausible anyway.

### 🤖 Summary

**Flake:** `firewall-rules.e2e.ts › can create firewall rule` (firefox)

**Root cause.** The test typed `5` into the Priority field, but the rule was created with `Priority: "0"` (the default) — failing all 3 retries with:

```
Expected: ...{"Priority": "5", ...}
Received: ...{"Priority": "0", ...}
```

The Priority field is a React Aria NumberInput, which can drop a value set via plain `page.fill()` when the form re-renders before the edit commits. The codebase already documents this exact race and has a helper for it: `fillNumberInput` (test/e2e/utils.ts:68), which clicks, fills, blurs, and polls until the value sticks.

The old call also used the deprecated legacy string-selector syntax (`'role=textbox[name="Priority"]'`) that CLAUDE.md discourages.

**Fix.** Swapped both raw Priority fills in the file to use `fillNumberInput`:
- line 44 (`can create firewall rule`, the one that flaked) — `'5'`
- line 586 (`name conflict error on edit`, same NumberInput risk) — `'37'`

**Verification.** The flake didn't reproduce locally in 15 runs (it needs CI's heavier parallel load), but the error is unambiguous and the fix matches the established pattern. After the change, both affected tests passed 20/20 on firefox; lint clean.

The fix is committed as its own rev (`b8c7d432`) on top of main for you to review/squash.