### PR TITLE
Fix time-of-day flake in date range picker e2e test

### DIFF
--- a/test/e2e/instance-metrics.e2e.ts
+++ b/test/e2e/instance-metrics.e2e.ts
@@ -76,19 +76,31 @@ test('Date range picker: invalid range shows an error', async ({ page }) => {
   const today = page.getByRole('button', { name: /Today/ })
   await today.click()
   await today.click()
-  await expect(page.getByText('Date range is invalid')).toBeHidden()
 
-  // set the start time (23:00) after the end time (01:00) on that same day
+  // Set the times explicitly rather than relying on the times inherited from
+  // the default "Last hour" range. When the test runs shortly after midnight,
+  // that range straddles midnight (start ~23:00 the previous day, end ~00:00
+  // today), so collapsing both dates to today leaves start after end and the
+  // range reads as invalid before we've done anything. Start with a valid
+  // same-day range (01:00 before 23:00): no error.
   const hours = page.getByRole('spinbutton', { name: 'hour,' })
   const minutes = page.getByRole('spinbutton', { name: 'minute,' })
   await hours.first().click()
-  await page.keyboard.type('23')
+  await page.keyboard.type('01')
   await minutes.first().click()
   await page.keyboard.type('00')
   await hours.nth(1).click()
-  await page.keyboard.type('01')
+  await page.keyboard.type('23')
   await minutes.nth(1).click()
   await page.keyboard.type('00')
+  await expect(page.getByText('Date range is invalid')).toBeHidden()
+
+  // now flip the start time (23:00) to be after the end time (01:00) on that
+  // same day
+  await hours.first().click()
+  await page.keyboard.type('23')
+  await hours.nth(1).click()
+  await page.keyboard.type('01')
 
   await expect(page.getByText('Date range is invalid')).toBeVisible()
 })


### PR DESCRIPTION
The "invalid range shows an error" test in instance-metrics.e2e.ts
collapsed the default "Last hour" range to a single day by clicking
Today twice, then asserted the range was valid. But the calendar keeps
the time components from the existing range, and when the test runs
shortly after midnight the "Last hour" range straddles midnight (start
~23:00 the previous day, end ~00:00 today). Collapsing both dates to
today then leaves the start time after the end time, so the range reads
as invalid and the precondition assertion fails. This is what broke CI
on main, which ran at 00:03 UTC.

Set the start and end times explicitly to a valid same-day order before
asserting the range is valid, then flip them to assert the invalid case,
so the test no longer depends on the time of day it runs.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017LT16CnNXBGhBHKk82cq9Z