### PR TITLE
minor: fix extra space at the bottom of combobox options

### DIFF
--- a/app/ui/lib/Combobox.tsx
+++ b/app/ui/lib/Combobox.tsx
@@ -33,8 +33,11 @@ const NO_MATCH_ITEM: ComboboxItem = {
 }
 const isNoMatch = (item: ComboboxItem | null) => item === NO_MATCH_ITEM
 
-// HUI's virtualizer needs the scroll container to have a non-zero height
-const ITEM_HEIGHT = 40
+// HUI's virtualizer needs the scroll container to have a non-zero height.
+// Must match the actual rendered row height (.ox-menu-item: text-sans-md +
+// py-2 + 1px border ≈ 34px) or the panel min-height overshoots the content
+// and leaves empty space at the bottom.
+const ITEM_HEIGHT = 34
 const MAX_PANEL_HEIGHT = 280
 
 /** Convert an array of items with a `name` attribute to an array of ComboboxItems


### PR DESCRIPTION
Get rid of that little space at the bottom of the list. The hard-coded item height was slightly off.

<img width="475" height="427" alt="image" src="https://github.com/user-attachments/assets/8f8219e5-4a37-4cd2-83d1-2a520190f3ce" />
