### PR TITLE
e2e flake: Freeze clock in instance metrics e2e tests

### DIFF
--- a/test/e2e/instance-metrics.e2e.ts
+++ b/test/e2e/instance-metrics.e2e.ts
@@ -12,6 +12,14 @@ import { OXQL_GROUP_BY_ERROR } from '~/api'
 
 import { expectConsoleMessage, expectNoConsoleMessage, getPageAsUser } from './utils'
 
+// Freeze the clock so the default "Last hour" range and the calendar's visible
+// month don't depend on when the tests run. Without this, runs near midnight
+// UTC flake: the range straddles the day boundary, and on a month boundary the
+// calendar opens on the previous month, so the "Today" cell isn't rendered.
+test.beforeEach(async ({ page }) => {
+  await page.clock.setFixedTime(new Date('2026-06-15T12:00:00.000Z'))
+})
+
 test('Click through instance metrics', async ({ page }) => {
   await page.goto('/projects/mock-project/instances/db1/metrics/cpu')
 
@@ -76,31 +84,19 @@ test('Date range picker: invalid range shows an error', async ({ page }) => {
   const today = page.getByRole('button', { name: /Today/ })
   await today.click()
   await today.click()
+  await expect(page.getByText('Date range is invalid')).toBeHidden()
 
-  // Set the times explicitly rather than relying on the times inherited from
-  // the default "Last hour" range. When the test runs shortly after midnight,
-  // that range straddles midnight (start ~23:00 the previous day, end ~00:00
-  // today), so collapsing both dates to today leaves start after end and the
-  // range reads as invalid before we've done anything. Start with a valid
-  // same-day range (01:00 before 23:00): no error.
+  // set the start time (23:00) after the end time (01:00) on that same day
   const hours = page.getByRole('spinbutton', { name: 'hour,' })
   const minutes = page.getByRole('spinbutton', { name: 'minute,' })
   await hours.first().click()
-  await page.keyboard.type('01')
+  await page.keyboard.type('23')
   await minutes.first().click()
   await page.keyboard.type('00')
   await hours.nth(1).click()
-  await page.keyboard.type('23')
+  await page.keyboard.type('01')
   await minutes.nth(1).click()
   await page.keyboard.type('00')
-  await expect(page.getByText('Date range is invalid')).toBeHidden()
-
-  // now flip the start time (23:00) to be after the end time (01:00) on that
-  // same day
-  await hours.first().click()
-  await page.keyboard.type('23')
-  await hours.nth(1).click()
-  await page.keyboard.type('01')
 
   await expect(page.getByText('Date range is invalid')).toBeVisible()
 })


### PR DESCRIPTION
The fix in #3269 was a hack. This is a better fix, and covers a second case I didn't learn about until an hour ago.

### 🤖 Summary

The metrics page defaults to a "Last hour" range derived from the wall clock, so what the tests see depends on when they run. Two failure modes:

- If the test runs **within an hour after midnight UTC,** the default range spans the day boundary (start `23:xx` yesterday, end `00:xx` today). The test collapses both dates to today, which keeps the inherited times, so start `23:xx` now lands after end `00:xx`, the range reads invalid before the test has done anything, and the "should be valid" assertion fails. This is what #3269 worked around by setting the times explicitly.
- If the test runs **within the first hour of a month UTC**, the range start (an hour before `00:xx` on the 1st = `23:xx` on the last day of the *previous* month) is in a different month than today. The calendar opens on the start's month, so today's cell isn't in the visible grid, `getByRole('button', { name: /Today/ })` finds nothing, and the click times out after 60s. This is what failed just now (June 30 → July 1): [Playwright (chrome)](https://github.com/oxidecomputer/console/actions/runs/28483772639/job/84425726642), all three browsers, tests running at 00:03 UTC.

No user impact either way — near midnight the calendar just opens on the start month, which is normal. The problem is just what the tests expect to see when that happens.

**Fix:** Freeze the clock to a fixed mid-month noon with `page.clock.setFixedTime` (same trick as the visual regression suite), so neither the range times nor the visible month depend on when CI runs. With that in place the #3269 time-juggling is no longer needed, so I reverted it back to the simpler form.