### PR TITLE
Tell password managers to ignore first and last and client ID

### DIFF
--- a/app/components/form/fields/NameField.tsx
+++ b/app/components/form/fields/NameField.tsx
@@ -9,7 +9,7 @@ import type { FieldPath, FieldValues } from 'react-hook-form'
 
 import { capitalize } from '~/util/str'
 
-import { TextField, type TextFieldProps } from './TextField'
+import { noPasswordManager, TextField, type TextFieldProps } from './TextField'
 
 export function NameField<
   TFieldValues extends FieldValues,
@@ -30,11 +30,7 @@ export function NameField<
       required={required}
       label={label}
       name={name}
-      // https://www.stefanjudis.com/snippets/turn-off-password-managers/
-      data-1p-ignore
-      data-bwignore
-      data-lpignore="true"
-      data-form-type="other"
+      {...noPasswordManager}
       {...textFieldProps}
     />
   )

--- a/app/components/form/fields/TextField.tsx
+++ b/app/components/form/fields/TextField.tsx
@@ -27,6 +27,21 @@ import { capitalize } from '~/util/str'
 
 import { ErrorMessage } from './ErrorMessage'
 
+/**
+ * Spread onto a field to stop password managers (1Password, Bitwarden,
+ * LastPass) from showing their fill icon and offering autofill. Use for
+ * fields whose name/label a password manager might mistake for a credential
+ * or personal detail (e.g. `first`/`last`, which read as first/last name).
+ *
+ * https://www.stefanjudis.com/snippets/turn-off-password-managers/
+ */
+export const noPasswordManager = {
+  'data-1p-ignore': true,
+  'data-bwignore': true,
+  'data-lpignore': 'true',
+  'data-form-type': 'other',
+} as const
+
 export interface TextFieldProps<
   TFieldValues extends FieldValues,
   TName extends FieldPath<TFieldValues>,

--- a/app/forms/idp/create.tsx
+++ b/app/forms/idp/create.tsx
@@ -14,7 +14,7 @@ import { api, queryClient, useApiMutation } from '@oxide/api'
 import { DescriptionField } from '~/components/form/fields/DescriptionField'
 import { FileField } from '~/components/form/fields/FileField'
 import { NameField } from '~/components/form/fields/NameField'
-import { TextField } from '~/components/form/fields/TextField'
+import { noPasswordManager, TextField } from '~/components/form/fields/TextField'
 import { SideModalForm } from '~/components/form/SideModalForm'
 import { HL } from '~/components/HL'
 import { titleCrumb } from '~/hooks/use-crumbs'
@@ -168,6 +168,7 @@ export default function CreateIdpSideModalForm() {
         label="Technical contact email"
         required
         control={form.control}
+        {...noPasswordManager}
       />
 
       <FormDivider />
@@ -179,6 +180,7 @@ export default function CreateIdpSideModalForm() {
         label="Service provider client ID"
         required
         control={form.control}
+        {...noPasswordManager}
       />
       <div className="flex flex-col gap-2">
         <TextField

--- a/app/forms/ip-pool-range-add.tsx
+++ b/app/forms/ip-pool-range-add.tsx
@@ -18,7 +18,7 @@ import {
   type IpVersion,
 } from '@oxide/api'
 
-import { TextField } from '~/components/form/fields/TextField'
+import { noPasswordManager, TextField } from '~/components/form/fields/TextField'
 import { SideModalForm } from '~/components/form/SideModalForm'
 import { titleCrumb } from '~/hooks/use-crumbs'
 import { useIpPoolSelector } from '~/hooks/use-params'
@@ -84,6 +84,7 @@ export default function IpPoolAddRange() {
         control={form.control}
         required
         validate={(value) => validateAddress(value, poolData.ipVersion)}
+        {...noPasswordManager}
       />
       <TextField
         name="last"
@@ -91,6 +92,7 @@ export default function IpPoolAddRange() {
         control={form.control}
         required
         validate={(value) => validateAddress(value, poolData.ipVersion)}
+        {...noPasswordManager}
       />
       <SideModalFormDocs docs={[docLinks.systemIpPools]} />
     </SideModalForm>


### PR DESCRIPTION
This makes no sense!

<img width="499" height="403" alt="image" src="https://github.com/user-attachments/assets/77231601-c4fd-42cd-b7b9-cb864b39bddc" />
