### PR TITLE
prefetch VPCs/Subnets so networking tab loads without skeleton cells

### DIFF
--- a/app/pages/project/instances/NetworkingTab.tsx
+++ b/app/pages/project/instances/NetworkingTab.tsx
@@ -128,12 +128,29 @@ const staticSubnetCols = [
 export async function clientLoader({ params }: LoaderFunctionArgs) {
   const { project, instance } = getInstanceSelector(params)
   await Promise.all([
-    queryClient.fetchQuery(
-      q(api.instanceNetworkInterfaceList, {
-        // we want this to cover all NICs; TODO: determine actual limit?
-        query: { project, instance, limit: ALL_ISH },
-      })
-    ),
+    // Prefetch the by-ID VPC and subnet views the NIC table cells look up, so
+    // VpcNameFromId/SubnetNameFromId hit a warm cache instead of popping in
+    // after the table paints. IDs come from the NIC list, so chain off it; NICs
+    // usually share a VPC/subnet, so dedupe (≤8 NICs, typically 1 of each).
+    queryClient
+      .fetchQuery(
+        q(api.instanceNetworkInterfaceList, {
+          // we want this to cover all NICs; TODO: determine actual limit?
+          query: { project, instance, limit: ALL_ISH },
+        })
+      )
+      .then((nics) => {
+        const vpcIds = [...new Set(nics.items.map((n) => n.vpcId))]
+        const subnetIds = [...new Set(nics.items.map((n) => n.subnetId))]
+        return Promise.all([
+          ...vpcIds.map((vpc) =>
+            queryClient.prefetchQuery(q(api.vpcView, { path: { vpc } }))
+          ),
+          ...subnetIds.map((subnet) =>
+            queryClient.prefetchQuery(q(api.vpcSubnetView, { path: { subnet } }))
+          ),
+        ])
+      }),
     queryClient.fetchQuery(q(api.floatingIpList, { query: { project, limit: ALL_ISH } })),
     queryClient.fetchQuery(
       q(api.externalSubnetList, { query: { project, limit: ALL_ISH } })

--- a/app/pages/project/instances/NetworkingTab.tsx
+++ b/app/pages/project/instances/NetworkingTab.tsx
@@ -128,10 +128,10 @@ const staticSubnetCols = [
 export async function clientLoader({ params }: LoaderFunctionArgs) {
   const { project, instance } = getInstanceSelector(params)
   await Promise.all([
-    // Prefetch the by-ID VPC and subnet views the NIC table cells look up, so
-    // VpcNameFromId/SubnetNameFromId hit a warm cache instead of popping in
-    // after the table paints. IDs come from the NIC list, so chain off it; NICs
-    // usually share a VPC/subnet, so dedupe (≤8 NICs, typically 1 of each).
+    // Prefetch the by-ID subnet views the NIC table's subnet cells look up, so
+    // SubnetNameFromId hits a warm cache. subnetIds come from the NIC list, so
+    // chain off it; NICs usually share a subnet, so dedupe (≤8 NICs, typically 1).
+    // VPC cells are handled by seeding vpcView from the vpcList fetch below.
     queryClient
       .fetchQuery(
         q(api.instanceNetworkInterfaceList, {
@@ -140,16 +140,12 @@ export async function clientLoader({ params }: LoaderFunctionArgs) {
         })
       )
       .then((nics) => {
-        const vpcIds = [...new Set(nics.items.map((n) => n.vpcId))]
         const subnetIds = [...new Set(nics.items.map((n) => n.subnetId))]
-        return Promise.all([
-          ...vpcIds.map((vpc) =>
-            queryClient.prefetchQuery(q(api.vpcView, { path: { vpc } }))
-          ),
-          ...subnetIds.map((subnet) =>
+        return Promise.all(
+          subnetIds.map((subnet) =>
             queryClient.prefetchQuery(q(api.vpcSubnetView, { path: { subnet } }))
-          ),
-        ])
+          )
+        )
       }),
     queryClient.fetchQuery(q(api.floatingIpList, { query: { project, limit: ALL_ISH } })),
     queryClient.fetchQuery(
@@ -189,8 +185,15 @@ export async function clientLoader({ params }: LoaderFunctionArgs) {
           queryClient.setQueryData(queryKey, { type: 'success', data: pool })
         }
       }),
-    // Fetch VPCs for Add NIC form
-    queryClient.fetchQuery(q(api.vpcList, { query: { project, limit: ALL_ISH } })),
+    // Fetch VPCs for the Add NIC form, and seed vpcView-by-id so the NIC
+    // table's VPC cells (VpcNameFromId) render without a skeleton.
+    queryClient
+      .fetchQuery(q(api.vpcList, { query: { project, limit: ALL_ISH } }))
+      .then((vpcs) => {
+        for (const vpc of vpcs.items) {
+          queryClient.setQueryData(q(api.vpcView, { path: { vpc: vpc.id } }).queryKey, vpc)
+        }
+      }),
   ])
   return null
 }


### PR DESCRIPTION
Closes #1731 

Issue 1731 is pretty old, and not 100% an issue any more — some prefetching already happens, and the main benefits of this change are below the fold, so I doubt people would actually see the loading skeleton cell most of the time — but I saw the issue and figured it would be a quick one to knock out and we could decide whether to merge it or not.

Essentially, what this is doing: once the NICs have been loaded, use those values to prefetch the VPC and Subnet views, so their values can be entered into the table as it loads, sans skeleton cell.
* The primary VPC is already available to the table (unrelated to this PR), so the main VPC-related benefit here is in cases when an instance has secondary VPCs.
* The Subnet prefetching is easier to see the benefit of:

**Before:**

https://github.com/user-attachments/assets/8d7254bc-376b-484d-96e2-3dd74608359e

**After:**

https://github.com/user-attachments/assets/743202db-f7e5-4702-85ac-80efc6f0a1b0

But, again, this is generally below the fold of the page, so I think the revulsion Crespo felt with the earlier version of the Networking view is already somewhat softened.