### PR TITLE
Use ItemLabel in remaining silo and pool selectors

### DIFF
--- a/app/pages/system/networking/SubnetPoolPage.tsx
+++ b/app/pages/system/networking/SubnetPoolPage.tsx
@@ -49,10 +49,11 @@ import { useColsWithActions, type MenuAction } from '~/table/columns/action-col'
 import { Columns } from '~/table/columns/common'
 import { useQueryTable } from '~/table/QueryTable'
 import { UtilizationFraction } from '~/ui/lib/BigNum'
-import { toComboboxItems } from '~/ui/lib/Combobox'
+import type { ComboboxItem } from '~/ui/lib/Combobox'
 import { CreateButton, CreateLink } from '~/ui/lib/CreateButton'
 import * as Dropdown from '~/ui/lib/DropdownMenu'
 import { EmptyMessage } from '~/ui/lib/EmptyMessage'
+import { ItemLabel } from '~/ui/lib/ItemLabel'
 import { Message } from '~/ui/lib/Message'
 import { Modal } from '~/ui/lib/Modal'
 import { PageHeader, PageTitle } from '~/ui/lib/PageHeader'
@@ -458,6 +459,12 @@ type LinkSiloFormValues = {
 
 const defaultValues: LinkSiloFormValues = { silo: undefined, isDefault: false }
 
+const toSiloComboboxItem = ({ name, description }: Silo): ComboboxItem => ({
+  value: name,
+  selectedLabel: name,
+  label: <ItemLabel name={name}>{description}</ItemLabel>,
+})
+
 function LinkSiloModal({ onDismiss }: { onDismiss: () => void }) {
   const poolSelector = useSubnetPoolSelector()
   const { subnetPool } = poolSelector
@@ -508,7 +515,9 @@ function LinkSiloModal({ onDismiss }: { onDismiss: () => void }) {
   const unlinkedSiloItems = useMemo(
     () =>
       allSilos.data && linkedSiloIds
-        ? toComboboxItems(allSilos.data.items.filter((s) => !linkedSiloIds.has(s.id)))
+        ? allSilos.data.items
+            .filter((s) => !linkedSiloIds.has(s.id))
+            .map(toSiloComboboxItem)
         : [],
     [allSilos, linkedSiloIds]
   )

--- a/app/pages/system/silos/SiloIpPoolsTab.tsx
+++ b/app/pages/system/silos/SiloIpPoolsTab.tsx
@@ -43,6 +43,7 @@ import { useQueryTable } from '~/table/QueryTable'
 import type { ComboboxItem } from '~/ui/lib/Combobox'
 import { CreateButton } from '~/ui/lib/CreateButton'
 import { EmptyMessage } from '~/ui/lib/EmptyMessage'
+import { ItemLabel } from '~/ui/lib/ItemLabel'
 import { Message } from '~/ui/lib/Message'
 import { Modal } from '~/ui/lib/Modal'
 import { Tooltip } from '~/ui/lib/Tooltip'
@@ -55,11 +56,17 @@ function toIpPoolComboboxItem(p: IpPool): ComboboxItem {
     value: p.name,
     selectedLabel: p.name,
     label: (
-      <div className="flex items-center gap-1.5">
-        {p.name}
-        <IpVersionBadge ipVersion={p.ipVersion} />
-        <Badge color="neutral">{p.poolType}</Badge>
-      </div>
+      <ItemLabel
+        name={
+          <>
+            {p.name}
+            <IpVersionBadge ipVersion={p.ipVersion} />
+            <Badge color="neutral">{p.poolType}</Badge>
+          </>
+        }
+      >
+        {p.description}
+      </ItemLabel>
     ),
   }
 }

--- a/app/pages/system/silos/SiloSubnetPoolsTab.tsx
+++ b/app/pages/system/silos/SiloSubnetPoolsTab.tsx
@@ -43,6 +43,7 @@ import { useQueryTable } from '~/table/QueryTable'
 import type { ComboboxItem } from '~/ui/lib/Combobox'
 import { CreateButton } from '~/ui/lib/CreateButton'
 import { EmptyMessage } from '~/ui/lib/EmptyMessage'
+import { ItemLabel } from '~/ui/lib/ItemLabel'
 import { Message } from '~/ui/lib/Message'
 import { Modal } from '~/ui/lib/Modal'
 import { Tooltip } from '~/ui/lib/Tooltip'
@@ -55,10 +56,16 @@ function toSubnetPoolComboboxItem(p: SubnetPool): ComboboxItem {
     value: p.name,
     selectedLabel: p.name,
     label: (
-      <div className="flex items-center gap-1.5">
-        {p.name}
-        <IpVersionBadge ipVersion={p.ipVersion} />
-      </div>
+      <ItemLabel
+        name={
+          <>
+            {p.name}
+            <IpVersionBadge ipVersion={p.ipVersion} />
+          </>
+        }
+      >
+        {p.description}
+      </ItemLabel>
     ),
   }
 }


### PR DESCRIPTION
Robot found a couple more spots it would make sense to use the new `ItemLabel` component.

<img width="483" height="381" alt="image" src="https://github.com/user-attachments/assets/25cd05e0-53f3-4bf7-a969-6bdd2280b32a" />

The ones here are the obvious ones but there are actually ton more with descriptions we _could_ show if we wanted to:

🤖 Additional candidates include:

- Instances: anti-affinity membership, floating-IP attachment, external-subnet attachment, firewall rules, router routes
- Disks: attach disk, instance creation, snapshot creation
- Projects: image promotion/demotion
- VPCs and subnets: network-interface forms, firewall rules, router routes
- Internet gateways: router routes
- Anti-affinity groups: instance membership
- External subnets: attachment picker

Compact utilization/metrics filters should remain single-line even though their resources may have descriptions. `actorToItem` also stays unchanged because actors do not expose a resource description.