### PR TITLE
Fix CSP warning in preview from Zod

### DIFF
--- a/app/msw-mock-api.ts
+++ b/app/msw-mock-api.ts
@@ -70,6 +70,10 @@ async function streamBootLog(socket: WebSocket, text: string) {
 
 export async function startMockAPI() {
   // dynamic imports to make extremely sure none of this code ends up in the prod bundle
+  const { z } = await import('zod/v4')
+  // Configure Zod before importing the handlers, which create schemas during module evaluation.
+  // https://github.com/colinhacks/zod/issues/4461#issuecomment-2900137130
+  z.config({ jitless: true })
   const { handlers } = await import('../mock-api/msw/handlers')
   const { http, HttpResponse, ws } = await import('msw')
   const { setupWorker } = await import('msw/browser')

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "tunnel-rat": "^0.1.2",
         "use-debounce": "^10.0.4",
         "uuid": "^14.0.0",
-        "zod": "^4.0.17",
+        "zod": "^4.4.3",
         "zustand": "^5.0.3"
       },
       "devDependencies": {
@@ -12521,9 +12521,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.17.tgz",
-      "integrity": "sha512-1PHjlYRevNxxdy2JZ8JcNAw7rX8V9P1AKkP+x/xZfxB0K5FYfuV+Ug6P/6NVSR2jHQ+FzDDoDHS04nYUsOIyLQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6524,9 +6524,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6597,9 +6597,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -8174,9 +8174,9 @@
       "peer": true
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -8663,9 +8663,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "tunnel-rat": "^0.1.2",
     "use-debounce": "^10.0.4",
     "uuid": "^14.0.0",
-    "zod": "^4.0.17",
+    "zod": "^4.4.3",
     "zustand": "^5.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Not very interesting and not breaking anything, but might as well fix it. Zod does something at initialization to check what browser capabilities are available to it, and falls back to something else. But it warns when it fails, so we can just skip the thing that fails and avoid the warning.

> When set, Zod will not attempt to call `new Function()`, which triggers this.

https://github.com/colinhacks/zod/issues/4461#issuecomment-2900137130