### PR TITLE
Use default names for mock VPCs and subnets

### DIFF
--- a/mock-api/vpc.ts
+++ b/mock-api/vpc.ts
@@ -21,9 +21,9 @@ const systemRouterId = 'b5af837b-b986-4a0a-b775-516d76c84ec3'
 
 export const vpc: Json<Vpc> = {
   id: '87774ff3-c6c1-475b-b920-ba2954f390fe',
-  name: 'mock-vpc',
+  name: 'default',
   description: 'a fake vpc',
-  dns_name: 'mock-vpc',
+  dns_name: 'default',
   project_id: project.id,
   system_router_id: systemRouterId,
   ipv6_prefix: 'fdf6:1818:b6e1::/48',
@@ -46,9 +46,9 @@ export const vpc2: Json<Vpc> = {
 // VPCs for test silos (IP pool configuration testing)
 export const vpcKosman: Json<Vpc> = {
   id: 'd1e2f3a4-b5c6-4890-abcd-ef1234567890',
-  name: 'kosman-vpc',
+  name: 'default',
   description: 'VPC in myriad silo',
-  dns_name: 'kosman-vpc',
+  dns_name: 'default',
   project_id: projectKosman.id,
   system_router_id: systemRouterId,
   ipv6_prefix: 'fdf6:1818:b6e3::/48',
@@ -58,9 +58,9 @@ export const vpcKosman: Json<Vpc> = {
 
 export const vpcAnscombe: Json<Vpc> = {
   id: 'e2f3a4b5-c6d7-4901-bcde-f12345678901',
-  name: 'anscombe-vpc',
+  name: 'default',
   description: 'VPC in thrax silo',
-  dns_name: 'anscombe-vpc',
+  dns_name: 'default',
   project_id: projectAnscombe.id,
   system_router_id: systemRouterId,
   ipv6_prefix: 'fdf6:1818:b6e4::/48',
@@ -70,9 +70,9 @@ export const vpcAnscombe: Json<Vpc> = {
 
 export const vpcAdorno: Json<Vpc> = {
   id: 'f3a4b5c6-d7e8-4012-8def-123456789012',
-  name: 'adorno-vpc',
+  name: 'default',
   description: 'VPC in pelerines silo',
-  dns_name: 'adorno-vpc',
+  dns_name: 'default',
   project_id: projectAdorno.id,
   system_router_id: systemRouterId,
   ipv6_prefix: 'fdf6:1818:b6e5::/48',
@@ -192,7 +192,7 @@ export const routerRoutes: Json<Array<RouterRoute>> = [
 export const vpcSubnet: Json<VpcSubnet> = {
   // this is supposed to be flattened into the top level. will fix in API
   id: 'd12bf934-d2bf-40e9-8596-bb42a7793749',
-  name: 'mock-subnet',
+  name: 'default',
   description: 'a fake subnet',
   time_created: new Date(2021, 0, 1).toISOString(),
   time_modified: new Date(2021, 0, 2).toISOString(),
@@ -214,7 +214,7 @@ export const vpcSubnet2: Json<VpcSubnet> = {
 // Subnets for test silos
 export const subnetKosman: Json<VpcSubnet> = {
   id: 'a1b2c3d4-e5f6-4890-9234-567890abcdef',
-  name: 'kosman-subnet',
+  name: 'default',
   description: 'subnet in myriad silo',
   time_created,
   time_modified,
@@ -225,7 +225,7 @@ export const subnetKosman: Json<VpcSubnet> = {
 
 export const subnetAnscombe: Json<VpcSubnet> = {
   id: 'b2c3d4e5-f6a7-4901-a345-67890abcdef1',
-  name: 'anscombe-subnet',
+  name: 'default',
   description: 'subnet in thrax silo',
   time_created,
   time_modified,
@@ -236,7 +236,7 @@ export const subnetAnscombe: Json<VpcSubnet> = {
 
 export const subnetAdorno: Json<VpcSubnet> = {
   id: 'c3d4e5f6-a7b8-4012-b456-7890abcdef12',
-  name: 'adorno-subnet',
+  name: 'default',
   description: 'subnet in pelerines silo',
   time_created,
   time_modified,

--- a/test/e2e/action-menu.e2e.ts
+++ b/test/e2e/action-menu.e2e.ts
@@ -112,13 +112,13 @@ test('router quick action "New route" hidden for system router, visible for cust
   page,
 }) => {
   // system router: action should not appear
-  await page.goto('/projects/mock-project/vpcs/mock-vpc/routers/mock-system-router')
+  await page.goto('/projects/mock-project/vpcs/default/routers/mock-system-router')
   await openActionMenu(page)
   await expect(page.getByRole('option', { name: 'New route' })).toBeHidden()
   await page.keyboard.press('Escape')
 
   // custom router: action should appear
-  await page.goto('/projects/mock-project/vpcs/mock-vpc/routers/mock-custom-router')
+  await page.goto('/projects/mock-project/vpcs/default/routers/mock-custom-router')
   await openActionMenu(page)
   await expect(page.getByRole('option', { name: 'New route' })).toBeVisible()
 })

--- a/test/e2e/combobox.e2e.ts
+++ b/test/e2e/combobox.e2e.ts
@@ -151,21 +151,22 @@ test('virtualized combobox filters and selects options outside the initial windo
 test('arbitrary-values combobox keeps typed values and resets submitted fields', async ({
   page,
 }) => {
-  await page.goto('/projects/mock-project/vpcs/mock-vpc/firewall-rules-new')
+  await page.goto('/projects/mock-project/vpcs/default/firewall-rules-new')
 
   const vpcInput = page.getByRole('combobox', { name: 'VPC name' }).first()
   await vpcInput.focus()
-  await expectComboboxOptions(page, ['mock-vpc'])
+  await expectComboboxOptions(page, ['default'])
 
-  await vpcInput.fill('d')
-  await expectComboboxOptions(page, ['Custom: d'])
+  // 'z' matches no VPC, so only the arbitrary-value option shows
+  await vpcInput.fill('z')
+  await expectComboboxOptions(page, ['Custom: z'])
 
   await vpcInput.blur()
   await page.getByRole('button', { name: 'Add target' }).click()
   await expect(vpcInput).toHaveValue('')
 
   await vpcInput.focus()
-  await expectComboboxOptions(page, ['mock-vpc'])
+  await expectComboboxOptions(page, ['default'])
 
   await selectOption(page, 'Target type', 'Instance')
   const instanceInput = page.getByRole('combobox', { name: 'Instance name' })
@@ -221,25 +222,26 @@ test('arbitrary-values combobox keeps typed values and resets submitted fields',
 })
 
 test('combobox Enter selects highlighted item, not raw query', async ({ page }) => {
-  await page.goto('/projects/mock-project/vpcs/mock-vpc/firewall-rules-new')
+  await page.goto('/projects/mock-project/vpcs/default/firewall-rules-new')
 
   const targets = page.getByRole('table', { name: 'Targets' })
   const vpcInput = page.getByRole('combobox', { name: 'VPC name' }).first()
 
-  await vpcInput.fill('mock')
-  await expect(page.getByRole('option', { name: 'mock-vpc' })).toBeVisible()
-  await expect(page.getByRole('option', { name: 'Custom: mock' })).toBeVisible()
+  // 'def' matches the default VPC as well as producing an arbitrary-value option
+  await vpcInput.fill('def')
+  await expect(page.getByRole('option', { name: 'default' })).toBeVisible()
+  await expect(page.getByRole('option', { name: 'Custom: def' })).toBeVisible()
 
   await page.keyboard.press('ArrowUp')
   await page.keyboard.press('Enter')
 
-  await expect(vpcInput).toHaveValue('mock-vpc')
+  await expect(vpcInput).toHaveValue('default')
   await page.getByRole('button', { name: 'Add target' }).click()
-  await expectRowVisible(targets, { Type: 'vpc', Value: 'mock-vpc' })
+  await expectRowVisible(targets, { Type: 'vpc', Value: 'default' })
 })
 
 test("Escape in combobox doesn't close the parent form", async ({ page }) => {
-  await page.goto('/projects/mock-project/vpcs/mock-vpc/firewall-rules-new')
+  await page.goto('/projects/mock-project/vpcs/default/firewall-rules-new')
 
   await page.getByRole('textbox', { name: 'Name' }).fill('a')
 
@@ -257,7 +259,7 @@ test("Escape in combobox doesn't close the parent form", async ({ page }) => {
   await input.focus()
 
   await expect(page.getByRole('option').first()).toBeVisible()
-  await expectComboboxOptions(page, ['mock-vpc'])
+  await expectComboboxOptions(page, ['default'])
 
   await page.keyboard.press('Escape')
   await expect(confirmModal).toBeHidden()

--- a/test/e2e/firewall-rules.e2e.ts
+++ b/test/e2e/firewall-rules.e2e.ts
@@ -20,7 +20,7 @@ import {
 const defaultRules = ['allow-internal-inbound', 'allow-ssh', 'allow-icmp']
 
 test('can create firewall rule', async ({ page }) => {
-  await page.goto('/projects/mock-project/vpcs/mock-vpc')
+  await page.goto('/projects/mock-project/vpcs/default')
   await page.getByRole('tab', { name: 'Firewall Rules' }).click()
 
   // default rules are all there
@@ -157,7 +157,7 @@ const deleteRowAndVerifyRowCount = async (table: Locator, expectedCount: number)
 }
 
 test('firewall rule form targets table', async ({ page }) => {
-  await page.goto('/projects/mock-project/vpcs/mock-vpc')
+  await page.goto('/projects/mock-project/vpcs/default')
   await page.getByRole('tab', { name: 'Firewall Rules' }).click()
 
   // open modal
@@ -177,23 +177,23 @@ test('firewall rule form targets table', async ({ page }) => {
   await addButton.click()
   await expectRowVisible(targets, { Type: 'vpc', Value: 'abc' })
 
-  // enter a VPC called 'mock-subnet', even if that doesn't make sense here, to test dropdown later
-  await fillAndSelectComboboxOption(targetVpcNameField, page, 'mock-subnet', 'mock-subnet')
+  // enter a VPC called 'default', even if that doesn't make sense here, to test dropdown later
+  await fillAndSelectComboboxOption(targetVpcNameField, page, 'default', 'default')
   await addButton.click()
-  await expectRowVisible(targets, { Type: 'vpc', Value: 'mock-subnet' })
+  await expectRowVisible(targets, { Type: 'vpc', Value: 'default' })
 
   // add VPC subnet targets
   const subnetNameField = page.getByRole('combobox', { name: 'Subnet name' })
 
-  // add a subnet by selecting from a dropdown; make sure 'mock-subnet' is present in the dropdown,
-  // even though VPC:'mock-subnet' has already been added
+  // add a subnet by selecting from a dropdown; make sure 'default' is present in the dropdown,
+  // even though VPC:'default' has already been added
   await selectOption(page, 'Target type', 'VPC subnet')
   // addButton should be disabled again, as type has changed but no value has been entered
   await expect(addButton).toBeDisabled()
-  await selectOption(page, subnetNameField, 'mock-subnet')
+  await selectOption(page, subnetNameField, 'default')
   await expect(addButton).toBeEnabled()
   await addButton.click()
-  await expectRowVisible(targets, { Type: 'subnet', Value: 'mock-subnet' })
+  await expectRowVisible(targets, { Type: 'subnet', Value: 'default' })
 
   // now add a subnet by entering text
   await selectOption(page, 'Target type', 'VPC subnet')
@@ -221,7 +221,7 @@ test('firewall rule form targets table', async ({ page }) => {
 })
 
 test('firewall rule form target validation', async ({ page }) => {
-  await page.goto('/projects/mock-project/vpcs/mock-vpc/firewall-rules-new')
+  await page.goto('/projects/mock-project/vpcs/default/firewall-rules-new')
 
   const addButton = page.getByRole('button', { name: 'Add target' })
   const targets = page.getByRole('table', { name: 'Targets' })
@@ -285,7 +285,7 @@ test('firewall rule form target validation', async ({ page }) => {
 // that code.
 
 test('firewall rule form host validation', async ({ page }) => {
-  await page.goto('/projects/mock-project/vpcs/mock-vpc/firewall-rules-new')
+  await page.goto('/projects/mock-project/vpcs/default/firewall-rules-new')
 
   const addButton = page.getByRole('button', { name: 'Add host filter' })
   const hosts = page.getByRole('table', { name: 'Host filters' })
@@ -350,7 +350,7 @@ test('firewall rule form host validation', async ({ page }) => {
 })
 
 test('firewall rule form hosts table', async ({ page }) => {
-  await page.goto('/projects/mock-project/vpcs/mock-vpc')
+  await page.goto('/projects/mock-project/vpcs/default')
   await page.getByRole('tab', { name: 'Firewall Rules' }).click()
 
   // open modal
@@ -371,9 +371,9 @@ test('firewall rule form hosts table', async ({ page }) => {
   await expectRowVisible(hosts, { Type: 'vpc', Value: 'def' })
 
   await selectOption(page, 'Host type', 'VPC subnet')
-  await selectOption(page, 'Subnet name', 'mock-subnet')
+  await selectOption(page, 'Subnet name', 'default')
   await addButton.click()
-  await expectRowVisible(hosts, { Type: 'subnet', Value: 'mock-subnet' })
+  await expectRowVisible(hosts, { Type: 'subnet', Value: 'default' })
 
   await selectOption(page, 'Host type', 'VPC subnet')
   const subnetNameField2 = page.getByRole('combobox', { name: 'Subnet name' })
@@ -398,7 +398,7 @@ test('firewall rule form hosts table', async ({ page }) => {
 })
 
 test('can update firewall rule', async ({ page }) => {
-  await page.goto('/projects/mock-project/vpcs/mock-vpc')
+  await page.goto('/projects/mock-project/vpcs/default')
   await page.getByRole('tab', { name: 'Firewall Rules' }).click()
 
   const rows = page.locator('tbody >> tr')
@@ -487,7 +487,7 @@ test('can update firewall rule', async ({ page }) => {
 })
 
 test('create from existing rule', async ({ page }) => {
-  const url = '/projects/mock-project/vpcs/mock-vpc/firewall-rules'
+  const url = '/projects/mock-project/vpcs/default/firewall-rules'
   await page.goto(url)
 
   const modal = page.getByRole('dialog', { name: 'Add firewall rule' })
@@ -536,7 +536,7 @@ test('create from existing rule', async ({ page }) => {
   await expect(targets.getByRole('row', { name: 'vpc default' })).toBeVisible()
 })
 
-const rulePath = '/projects/mock-project/vpcs/mock-vpc/firewall-rules/allow-icmp/edit'
+const rulePath = '/projects/mock-project/vpcs/default/firewall-rules/allow-icmp/edit'
 
 test('can edit rule directly by URL', async ({ page }) => {
   await page.goto(rulePath)
@@ -554,7 +554,7 @@ test('404s on edit non-existent rule', async ({ page }) => {
 // when creating a rule, giving it the same name as an existing rule is an
 // error. if you want to overwrite a rule, you need to edit it
 test('name conflict error on create', async ({ page }) => {
-  await page.goto('/projects/mock-project/vpcs/mock-vpc/firewall-rules-new')
+  await page.goto('/projects/mock-project/vpcs/default/firewall-rules-new')
 
   await page.getByRole('textbox', { name: 'Name', exact: true }).fill('allow-ssh')
 
@@ -568,7 +568,7 @@ test('name conflict error on create', async ({ page }) => {
 // when editing a rule, on the other hand, we only check for conflicts against rules
 // other than the one being edited, because of course its name can stay the same
 test('name conflict error on edit', async ({ page }) => {
-  await page.goto('/projects/mock-project/vpcs/mock-vpc/firewall-rules/allow-icmp/edit')
+  await page.goto('/projects/mock-project/vpcs/default/firewall-rules/allow-icmp/edit')
 
   // changing the name to one taken by another rule is an error
   const nameField = page.getByRole('textbox', { name: 'Name', exact: true })
@@ -597,7 +597,7 @@ test('name conflict error on edit', async ({ page }) => {
 })
 
 test('can add ICMPv4 and ICMPv6 protocol filters', async ({ page }) => {
-  await page.goto('/projects/mock-project/vpcs/mock-vpc/firewall-rules-new')
+  await page.goto('/projects/mock-project/vpcs/default/firewall-rules-new')
 
   const protocolTable = page.getByRole('table', { name: 'Protocol filters' })
   await expect(protocolTable).toBeHidden()

--- a/test/e2e/instance-create.e2e.ts
+++ b/test/e2e/instance-create.e2e.ts
@@ -121,8 +121,8 @@ test('can create an instance', async ({ page }) => {
   const table = page.getByRole('table', { name: 'Network interfaces' })
   await expectRowVisible(table, {
     name: 'defaultprimary',
-    vpc: 'mock-vpc',
-    subnet: 'mock-subnet',
+    vpc: 'default',
+    subnet: 'default',
   })
 })
 
@@ -822,9 +822,9 @@ test('create instance with custom IPv4-only NIC constrains ephemeral IP to IPv4'
 
   await modal.getByRole('textbox', { name: 'Name' }).fill('my-ipv4-nic')
   await modal.getByLabel('VPC', { exact: true }).click()
-  await page.getByRole('option', { name: 'mock-vpc' }).click()
+  await page.getByRole('option', { name: 'default' }).click()
   await modal.getByLabel('Subnet').click()
-  await page.getByRole('option', { name: 'mock-subnet', exact: true }).click()
+  await page.getByRole('option', { name: 'default', exact: true }).click()
 
   // Select IPv4-only IP configuration
   await modal.getByRole('radio', { name: 'IPv4', exact: true }).click()
@@ -898,9 +898,9 @@ test('create instance with custom IPv6-only NIC constrains ephemeral IP to IPv6'
 
   await modal.getByRole('textbox', { name: 'Name' }).fill('my-ipv6-nic')
   await modal.getByLabel('VPC', { exact: true }).click()
-  await page.getByRole('option', { name: 'mock-vpc' }).click()
+  await page.getByRole('option', { name: 'default' }).click()
   await modal.getByLabel('Subnet').click()
-  await page.getByRole('option', { name: 'mock-subnet', exact: true }).click()
+  await page.getByRole('option', { name: 'default', exact: true }).click()
 
   // Select IPv6-only IP configuration
   await modal.getByRole('radio', { name: 'IPv6', exact: true }).click()
@@ -974,9 +974,9 @@ test('create instance with custom dual-stack NIC allows both IPv4 and IPv6 ephem
 
   await modal.getByRole('textbox', { name: 'Name' }).fill('my-dual-stack-nic')
   await modal.getByLabel('VPC', { exact: true }).click()
-  await page.getByRole('option', { name: 'mock-vpc' }).click()
+  await page.getByRole('option', { name: 'default' }).click()
   await modal.getByLabel('Subnet').click()
-  await page.getByRole('option', { name: 'mock-subnet', exact: true }).click()
+  await page.getByRole('option', { name: 'default', exact: true }).click()
 
   // Select dual-stack IP configuration (should be default)
   await modal.getByRole('radio', { name: 'IPv4 & IPv6', exact: true }).click()
@@ -1104,9 +1104,9 @@ test('ephemeral IP checkbox disabled when no NICs configured', async ({ page }) 
   // Create an IPv4 NIC named "new-v4-nic"
   await modal.getByRole('textbox', { name: 'Name' }).fill('new-v4-nic')
   await modal.getByLabel('VPC', { exact: true }).click()
-  await page.getByRole('option', { name: 'mock-vpc' }).click()
+  await page.getByRole('option', { name: 'default' }).click()
   await modal.getByLabel('Subnet').click()
-  await page.getByRole('option', { name: 'mock-subnet', exact: true }).click()
+  await page.getByRole('option', { name: 'default', exact: true }).click()
 
   // Select IPv4 IP configuration
   await modal.getByRole('radio', { name: 'IPv4', exact: true }).click()

--- a/test/e2e/instance-networking.e2e.ts
+++ b/test/e2e/instance-networking.e2e.ts
@@ -23,10 +23,10 @@ const selectASiloImage = async (page: Page, name: string) => {
 }
 
 test('Instance networking tab — firewall rules card', async ({ page }) => {
-  // db1 has a primary NIC in mock-vpc, so the card names that VPC
+  // db1 has a primary NIC in default, so the card names that VPC
   await page.goto('/projects/mock-project/instances/db1/networking')
   await expect(
-    page.getByText('Manage firewall rules affecting this instance in VPC mock-vpc')
+    page.getByText('Manage firewall rules affecting this instance in VPC default')
   ).toBeVisible()
 
   // you-fail has no NICs, so there's no primary VPC and we show the fallback copy
@@ -45,7 +45,7 @@ test('Instance networking tab — NIC table', async ({ page }) => {
   await page.goto('/projects/mock-project/instances/db1')
 
   // links to VPC and external IPs appear in table
-  await expect(page.getByRole('link', { name: 'mock-vpc' })).toBeVisible()
+  await expect(page.getByRole('link', { name: 'default' })).toBeVisible()
   await expect(page.getByRole('link', { name: '123.4.56.0' })).toBeVisible()
 
   // Instance networking tab
@@ -56,9 +56,9 @@ test('Instance networking tab — NIC table', async ({ page }) => {
   await expectRowVisible(nicTable, { name: 'my-nicprimary' })
 
   // check VPC link in table points to the right page
-  await expect(nicTable.getByRole('link', { name: 'mock-vpc' })).toHaveAttribute(
+  await expect(nicTable.getByRole('link', { name: 'default' })).toHaveAttribute(
     'href',
-    '/projects/mock-project/vpcs/mock-vpc/firewall-rules'
+    '/projects/mock-project/vpcs/default/firewall-rules'
   )
 
   const addNicButton = page.getByRole('button', { name: 'Add network interface' })
@@ -83,9 +83,9 @@ test('Instance networking tab — NIC table', async ({ page }) => {
 
   await page.getByRole('textbox', { name: 'Name' }).fill('nic-2')
   await page.getByLabel('VPC', { exact: true }).click()
-  await page.getByRole('option', { name: 'mock-vpc' }).click()
+  await page.getByRole('option', { name: 'default' }).click()
   await page.getByRole('dialog').getByLabel('Subnet').click()
-  await page.getByRole('option', { name: 'mock-subnet', exact: true }).click()
+  await page.getByRole('option', { name: 'default', exact: true }).click()
   await page
     .getByRole('dialog')
     .getByRole('button', { name: 'Add network interface' })

--- a/test/e2e/network-interface-create.e2e.ts
+++ b/test/e2e/network-interface-create.e2e.ts
@@ -19,9 +19,9 @@ test('can create a NIC with a specified IP address', async ({ page }) => {
   // fill out the form
   await page.getByLabel('Name').fill('nic-1')
   // VPC is preselected because the project has exactly one
-  await expect(page.getByLabel('VPC', { exact: true })).toContainText('mock-vpc')
+  await expect(page.getByLabel('VPC', { exact: true })).toContainText('default')
   await page.getByRole('dialog').getByRole('button', { name: 'VPC subnet' }).click()
-  await page.getByRole('option', { name: 'mock-subnet', exact: true }).click()
+  await page.getByRole('option', { name: 'default', exact: true }).click()
 
   // Select IPv4 only
   await page.getByRole('radio', { name: 'IPv4', exact: true }).click()
@@ -46,9 +46,9 @@ test('can create a NIC with a blank IP address', async ({ page }) => {
   // fill out the form
   await page.getByLabel('Name').fill('nic-2')
   await page.getByLabel('VPC', { exact: true }).click()
-  await page.getByRole('option', { name: 'mock-vpc' }).click()
+  await page.getByRole('option', { name: 'default' }).click()
   await page.getByRole('dialog').getByRole('button', { name: 'VPC subnet' }).click()
-  await page.getByRole('option', { name: 'mock-subnet', exact: true }).click()
+  await page.getByRole('option', { name: 'default', exact: true }).click()
 
   // Dual-stack is selected by default, so both fields should be visible
   // make sure the IPv4 address field has a non-conforming bit of text in it
@@ -84,9 +84,9 @@ test('can create a NIC with IPv6 only', async ({ page }) => {
 
   await page.getByLabel('Name').fill('nic-3')
   await page.getByLabel('VPC', { exact: true }).click()
-  await page.getByRole('option', { name: 'mock-vpc' }).click()
+  await page.getByRole('option', { name: 'default' }).click()
   await page.getByRole('dialog').getByRole('button', { name: 'VPC subnet' }).click()
-  await page.getByRole('option', { name: 'mock-subnet', exact: true }).click()
+  await page.getByRole('option', { name: 'default', exact: true }).click()
 
   // Select IPv6 only
   await page.getByRole('radio', { name: 'IPv6', exact: true }).click()
@@ -107,9 +107,9 @@ test('can create a NIC with dual-stack and explicit IPs', async ({ page }) => {
 
   await page.getByLabel('Name').fill('nic-4')
   await page.getByLabel('VPC', { exact: true }).click()
-  await page.getByRole('option', { name: 'mock-vpc' }).click()
+  await page.getByRole('option', { name: 'default' }).click()
   await page.getByRole('dialog').getByRole('button', { name: 'VPC subnet' }).click()
-  await page.getByRole('option', { name: 'mock-subnet', exact: true }).click()
+  await page.getByRole('option', { name: 'default', exact: true }).click()
 
   // Dual-stack is selected by default
   await page.getByLabel('IPv4 address').fill('10.0.0.5')

--- a/test/e2e/networking.e2e.ts
+++ b/test/e2e/networking.e2e.ts
@@ -17,8 +17,8 @@ test('Create and edit VPC', async ({ page }) => {
 
   const table = page.getByRole('table')
   await expectRowVisible(table, {
-    name: 'mock-vpc',
-    'DNS name': 'mock-vpc',
+    name: 'default',
+    'DNS name': 'default',
     description: 'a fake vpc',
     'Firewall Rules': '3',
   })
@@ -52,7 +52,7 @@ test('Create and edit VPC', async ({ page }) => {
   })
 
   // Edit VPC form
-  await clickRowAction(page, 'mock-vpc', 'Edit')
+  await clickRowAction(page, 'default', 'Edit')
   await expectVisible(page, [
     'role=textbox[name="Name"]',
     'role=textbox[name="Description"]',
@@ -69,11 +69,11 @@ test('Create and edit VPC', async ({ page }) => {
 })
 
 test('Create and edit subnet', async ({ page }) => {
-  await page.goto('/projects/mock-project/vpcs/mock-vpc')
+  await page.goto('/projects/mock-project/vpcs/default')
 
   // VPC detail, subnets tab
   await expectVisible(page, [
-    'role=heading[name*="mock-vpc"]',
+    'role=heading[name*="default"]',
     'role=tab[name="Firewall Rules"]',
     'role=cell[name="allow-icmp"]',
   ])

--- a/test/e2e/row-select.e2e.ts
+++ b/test/e2e/row-select.e2e.ts
@@ -41,7 +41,7 @@ test.skip('Row multiselect works as expected', async ({ page }) => {
 
   // ACTUAL TEST
 
-  await page.goto('/projects/mock-project/vpcs/mock-vpc?tab=firewall-rules')
+  await page.goto('/projects/mock-project/vpcs/default?tab=firewall-rules')
 
   // baseline empty state
   await expect(headCheckbox).toHaveCount(1)

--- a/test/e2e/vpcs.e2e.ts
+++ b/test/e2e/vpcs.e2e.ts
@@ -17,38 +17,38 @@ test('can nav to VpcPage from /', async ({ page }) => {
   await page.waitForURL('**/vpcs**')
 
   await expectRowVisible(page.getByRole('table'), {
-    name: 'mock-vpc',
-    'DNS name': 'mock-vpc',
+    name: 'default',
+    'DNS name': 'default',
     description: 'a fake vpc',
     'Firewall Rules': '3',
   })
 
   // click the vpc name cell to go there
-  await page.getByRole('link', { name: 'mock-vpc' }).click()
+  await page.getByRole('link', { name: 'default' }).click()
 
-  await expect(page.getByRole('heading', { name: 'mock-vpc' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'default' })).toBeVisible()
   await expect(page.getByRole('tab', { name: 'Firewall rules' })).toBeVisible()
   await expect(page.getByRole('cell', { name: 'allow-icmp' })).toBeVisible()
-  await expect(page).toHaveURL('/projects/mock-project/vpcs/mock-vpc/firewall-rules')
+  await expect(page).toHaveURL('/projects/mock-project/vpcs/default/firewall-rules')
   await expect(page).toHaveTitle(
-    'Firewall Rules / mock-vpc / VPCs / mock-project / Projects / Oxide Console'
+    'Firewall Rules / default / VPCs / mock-project / Projects / Oxide Console'
   )
 
   // we can also click the firewall rules cell to get to the VPC detail
   await page.goBack()
-  await expect(page.getByRole('heading', { name: 'mock-vpc' })).toBeHidden()
+  await expect(page.getByRole('heading', { name: 'default' })).toBeHidden()
   await expect(page.getByRole('cell', { name: 'allow-icmp' })).toBeHidden()
   await page.getByRole('link', { name: '3' }).click()
-  await expect(page.getByRole('heading', { name: 'mock-vpc' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'default' })).toBeVisible()
   await expect(page.getByRole('cell', { name: 'allow-icmp' })).toBeVisible()
 })
 
 test('can edit VPC', async ({ page }) => {
   // update the VPC name, starting from the VPCs list page
   await page.goto('/projects/mock-project/vpcs')
-  await expectRowVisible(page.getByRole('table'), { name: 'mock-vpc' })
-  await clickRowAction(page, 'mock-vpc', 'Edit')
-  await expect(page).toHaveURL('/projects/mock-project/vpcs/mock-vpc/edit')
+  await expectRowVisible(page.getByRole('table'), { name: 'default' })
+  await clickRowAction(page, 'default', 'Edit')
+  await expect(page).toHaveURL('/projects/mock-project/vpcs/default/edit')
   await page.getByRole('textbox', { name: 'Name' }).first().fill('mock-vpc-2')
   await page.getByRole('button', { name: 'Update VPC' }).click()
   await expect(page).toHaveURL('/projects/mock-project/vpcs/mock-vpc-2/firewall-rules')
@@ -69,21 +69,21 @@ test('can edit VPC', async ({ page }) => {
   await expect(page.getByRole('table').locator('tbody >> tr')).toHaveCount(1)
   await expectRowVisible(page.getByRole('table'), {
     name: 'mock-vpc-2',
-    'DNS name': 'mock-vpc',
+    'DNS name': 'default',
     description: 'updated description',
   })
 })
 
 test('can create and delete subnet', async ({ page }) => {
-  await page.goto('/projects/mock-project/vpcs/mock-vpc')
+  await page.goto('/projects/mock-project/vpcs/default')
   await page.getByRole('tab', { name: 'VPC Subnets' }).click()
-  // two rows in table: mock-subnet and mock-subnet-2
+  // two rows in table: default and mock-subnet-2
   const table = page.getByRole('table')
   const rows = page.getByRole('table').getByRole('row')
   await expect(rows).toHaveCount(3)
 
   await expectRowVisible(table, {
-    name: 'mock-subnet',
+    name: 'default',
     'Custom Router': '—',
     'IP Block': expect.stringContaining('10.1.1.1/24'),
   })
@@ -94,7 +94,7 @@ test('can create and delete subnet', async ({ page }) => {
   const dialog = page.getByRole('dialog', { name: 'Create VPC subnet' })
   await expect(dialog).toBeVisible()
 
-  await dialog.getByRole('textbox', { name: 'Name' }).fill('mock-subnet-3')
+  await dialog.getByRole('textbox', { name: 'Name' }).fill('default-3')
   await dialog.getByRole('textbox', { name: 'IPv4 block' }).fill('10.1.1.3/24')
 
   // little hack to catch a bug where we weren't handling empty input here properly
@@ -107,25 +107,25 @@ test('can create and delete subnet', async ({ page }) => {
   await expect(rows).toHaveCount(4)
 
   await expectRowVisible(table, {
-    name: 'mock-subnet',
+    name: 'default',
     'Custom Router': '—',
     'IP Block': expect.stringContaining('10.1.1.1/24'),
   })
   await expectRowVisible(table, {
-    name: 'mock-subnet-3',
+    name: 'default-3',
     'Custom Router': '—',
     'IP Block': expect.stringContaining('10.1.1.3/24'),
   })
 
   // click more button on row to get menu, then click Delete
-  await clickRowAction(page, 'mock-subnet-3', 'Delete')
+  await clickRowAction(page, 'default-3', 'Delete')
   await page.getByRole('button', { name: 'Confirm' }).click()
 
   await expect(rows).toHaveCount(3)
 })
 
 test('can create and update subnets with a custom router', async ({ page }) => {
-  await page.goto('/projects/mock-project/vpcs/mock-vpc/subnets')
+  await page.goto('/projects/mock-project/vpcs/default/subnets')
 
   // Check initial table state before opening the dialog — once it's open the
   // table is aria-hidden and role-based locators won't find it.
@@ -133,7 +133,7 @@ test('can create and update subnets with a custom router', async ({ page }) => {
   const rows = table.getByRole('row')
   await expect(rows).toHaveCount(3)
   await expectRowVisible(table, {
-    name: 'mock-subnet',
+    name: 'default',
     'Custom Router': '—',
     'IP Block': expect.stringContaining('10.1.1.1/24'),
   })
@@ -142,7 +142,7 @@ test('can create and update subnets with a custom router', async ({ page }) => {
   const dialog = page.getByRole('dialog', { name: 'Create VPC subnet' })
   await expect(dialog).toBeVisible()
 
-  await page.getByRole('textbox', { name: 'Name' }).fill('mock-subnet-3')
+  await page.getByRole('textbox', { name: 'Name' }).fill('default-3')
   await page.getByRole('textbox', { name: 'IPv4 block' }).fill('10.1.1.3/24')
 
   await page.getByRole('button', { name: 'Custom router' }).click()
@@ -153,27 +153,27 @@ test('can create and update subnets with a custom router', async ({ page }) => {
 
   await expect(rows).toHaveCount(4)
   await expectRowVisible(table, {
-    name: 'mock-subnet-3',
+    name: 'default-3',
     'Custom Router': 'mock-custom-router',
     'IP Block': expect.stringContaining('10.1.1.3/24'),
   })
 
   // now remove the router
-  await page.getByRole('link', { name: 'mock-subnet-3' }).click()
+  await page.getByRole('link', { name: 'default-3' }).click()
   await page.getByRole('button', { name: 'Custom router' }).click()
   await page.getByRole('option', { name: 'None' }).click()
   await page.getByRole('button', { name: 'Update VPC subnet' }).click()
   await expect(dialog).toBeHidden()
 
   await expectRowVisible(table, {
-    name: 'mock-subnet-3',
+    name: 'default-3',
     'Custom Router': '—',
   })
 })
 
 test('can create, update, and delete Router', async ({ page }) => {
-  // load the VPC page for mock-vpc, to the firewall-rules tab
-  await page.goto('/projects/mock-project/vpcs/mock-vpc')
+  // load the VPC page for default, to the firewall-rules tab
+  await page.goto('/projects/mock-project/vpcs/default')
   await page.getByRole('tab', { name: 'Routers' }).click()
 
   // expect to see the list of routers, including mock-system-router and mock-custom-router
@@ -200,13 +200,13 @@ test('can create, update, and delete Router', async ({ page }) => {
   // click on mock-system-router to go to the router detail page
   await page.getByText('mock-system-router').click()
   await expect(page).toHaveURL(
-    '/projects/mock-project/vpcs/mock-vpc/routers/mock-system-router'
+    '/projects/mock-project/vpcs/default/routers/mock-system-router'
   )
 })
 
 test('can’t create or delete Routes on system routers', async ({ page }) => {
   // load the router
-  await page.goto('/projects/mock-project/vpcs/mock-vpc/routers/mock-system-router')
+  await page.goto('/projects/mock-project/vpcs/default/routers/mock-system-router')
 
   // verify that the "new route" link isn't present, since users can't add routes to system routers
   await expect(page.getByRole('link', { name: 'New route' })).toBeHidden()
@@ -224,7 +224,7 @@ test('can’t create or delete Routes on system routers', async ({ page }) => {
 })
 
 test('create router route', async ({ page }) => {
-  await page.goto('/projects/mock-project/vpcs/mock-vpc/routers/mock-custom-router')
+  await page.goto('/projects/mock-project/vpcs/default/routers/mock-custom-router')
 
   // Selectors
   const form = page.getByRole('dialog', { name: 'Create route' })
@@ -281,7 +281,7 @@ test('create router route', async ({ page }) => {
 })
 
 test('edit and delete router route', async ({ page }) => {
-  await page.goto('/projects/mock-project/vpcs/mock-vpc/routers/mock-custom-router')
+  await page.goto('/projects/mock-project/vpcs/default/routers/mock-custom-router')
 
   const table = page.getByRole('table')
   await expect(table.locator('tbody >> tr')).toHaveCount(2)
@@ -308,14 +308,14 @@ test('edit and delete router route', async ({ page }) => {
 
   // Change destination to subnet
   await selectOption(page, 'Destination type', 'Subnet')
-  await selectOption(page, 'Destination value', 'mock-subnet')
+  await selectOption(page, 'Destination value', 'default')
 
   await submitButton.click()
   await expect(form).toBeHidden()
 
   await expectRowVisible(table, {
     Name: 'new-name',
-    Destination: 'VPC subnetmock-subnet',
+    Destination: 'VPC subnetdefault',
     Target: 'IP10.0.0.2',
   })
 
@@ -327,7 +327,7 @@ test('edit and delete router route', async ({ page }) => {
 })
 
 test('can view internet gateways', async ({ page }) => {
-  await page.goto('/projects/mock-project/vpcs/mock-vpc')
+  await page.goto('/projects/mock-project/vpcs/default')
   await page.getByRole('tab', { name: 'Internet Gateways' }).click()
 
   const table = page.getByRole('table')
@@ -351,7 +351,7 @@ test('can view internet gateways', async ({ page }) => {
 
   await page.getByRole('link', { name: 'internet-gateway-1' }).click()
   await expect(page).toHaveURL(
-    '/projects/mock-project/vpcs/mock-vpc/internet-gateways/internet-gateway-1'
+    '/projects/mock-project/vpcs/default/internet-gateways/internet-gateway-1'
   )
   // Use getByRole instead of getByLabel to avoid matching truncated descriptions
   const sidemodal = page.getByRole('dialog', { name: 'Internet gateway' })
@@ -369,7 +369,7 @@ test('can view internet gateways', async ({ page }) => {
 test('internet gateway shows proper list of routes targeting it', async ({ page }) => {
   // open up the internet gateway detail page for internet-gateway-1
   await page.goto(
-    '/projects/mock-project/vpcs/mock-vpc/internet-gateways/internet-gateway-1'
+    '/projects/mock-project/vpcs/default/internet-gateways/internet-gateway-1'
   )
   // verify that it has a table with the row showing "mock-custom-router" and "dc2"
   const sidemodal = page.getByRole('dialog', { name: 'Internet Gateway' })
@@ -388,7 +388,7 @@ test('internet gateway shows proper list of routes targeting it', async ({ page 
   await page.getByRole('link', { name: 'mock-custom-router' }).click()
   // expect to be on the view page
   await expect(page).toHaveURL(
-    '/projects/mock-project/vpcs/mock-vpc/routers/mock-custom-router'
+    '/projects/mock-project/vpcs/default/routers/mock-custom-router'
   )
 
   await page.getByRole('link', { name: 'mock-custom-router' }).click()
@@ -400,8 +400,8 @@ test('internet gateway shows proper list of routes targeting it', async ({ page 
   await selectOption(page, 'Target value', 'internet-gateway-1')
   await page.getByRole('button', { name: 'Create route' }).click()
 
-  // go back to the mock-vpc page by clicking on the link in the header
-  await page.getByRole('link', { name: 'mock-vpc' }).click()
+  // go back to the default page by clicking on the link in the header
+  await page.getByRole('link', { name: 'default' }).click()
   // click on the internet gateways tab and then the internet-gateway-1 link to go to the detail page
   await page.getByRole('tab', { name: 'Internet Gateways' }).click()
   // verify that the route count is now 2: click on the link to go to the edit gateway sidemodal
@@ -416,7 +416,7 @@ test('internet gateway shows proper list of routes targeting it', async ({ page 
   await sidemodal.getByRole('link', { name: 'mock-custom-router' }).first().click()
   // expect to be on the view page
   await expect(page).toHaveURL(
-    '/projects/mock-project/vpcs/mock-vpc/routers/mock-custom-router'
+    '/projects/mock-project/vpcs/default/routers/mock-custom-router'
   )
 })
 

--- a/test/e2e/z-index.e2e.ts
+++ b/test/e2e/z-index.e2e.ts
@@ -22,9 +22,9 @@ test('Dropdown content in SidebarModal shows on screen', async ({ page }) => {
   // select the VPC and subnet via the dropdowns. The fact that the options are
   // clickable means they are not obscured due to having a too-low z-index
   await page.getByLabel('VPC', { exact: true }).click()
-  await page.getByRole('option', { name: 'mock-vpc' }).click()
+  await page.getByRole('option', { name: 'default' }).click()
   await page.getByRole('dialog').getByRole('button', { name: 'Subnet' }).click()
-  await page.getByRole('option', { name: 'mock-subnet', exact: true }).click()
+  await page.getByRole('option', { name: 'default', exact: true }).click()
 
   const sidebar = page.getByRole('dialog', { name: 'Add network interface' })
 

--- a/test/visual/regression.e2e.ts
+++ b/test/visual/regression.e2e.ts
@@ -89,19 +89,19 @@ const pages = [
   { name: 'vpcs list', url: `${p}/vpcs`, heading: 'VPCs' },
   {
     name: 'vpc firewall rules',
-    url: `${p}/vpcs/mock-vpc/firewall-rules`,
-    heading: 'mock-vpc',
+    url: `${p}/vpcs/default/firewall-rules`,
+    heading: 'default',
   },
-  { name: 'vpc subnets', url: `${p}/vpcs/mock-vpc/subnets`, heading: 'mock-vpc' },
-  { name: 'vpc routers', url: `${p}/vpcs/mock-vpc/routers`, heading: 'mock-vpc' },
+  { name: 'vpc subnets', url: `${p}/vpcs/default/subnets`, heading: 'default' },
+  { name: 'vpc routers', url: `${p}/vpcs/default/routers`, heading: 'default' },
   {
     name: 'vpc internet gateways',
-    url: `${p}/vpcs/mock-vpc/internet-gateways`,
-    heading: 'mock-vpc',
+    url: `${p}/vpcs/default/internet-gateways`,
+    heading: 'default',
   },
   {
     name: 'vpc router detail',
-    url: `${p}/vpcs/mock-vpc/routers/mock-custom-router`,
+    url: `${p}/vpcs/default/routers/mock-custom-router`,
     heading: 'mock-custom-router',
   },
 


### PR DESCRIPTION
This is prep for an actual fix on how we handle non-default VPC names in the instance create form. This changes all the names for the VPC in the mock data (except for one that we keep around for testing a non-default VPC) and updates the tests accordingly. Just noise. Real fix will be on top.