### PR TITLE
Add quota editing sidemodal to system utilization page

### DIFF
--- a/app/forms/silo-quotas-edit.tsx
+++ b/app/forms/silo-quotas-edit.tsx
@@ -1,0 +1,119 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
+ */
+import { useForm } from 'react-hook-form'
+import type { SetNonNullable } from 'type-fest'
+
+import {
+  api,
+  queryClient,
+  useApiMutation,
+  type SiloQuotasUpdate,
+  type VirtualResourceCounts,
+} from '@oxide/api'
+import { Cloud16Icon } from '@oxide/design-system/icons/react'
+
+import { NumberField } from '~/components/form/fields/NumberField'
+import { SideModalForm } from '~/components/form/SideModalForm'
+import { addToast } from '~/stores/toast'
+import { Message } from '~/ui/lib/Message'
+import { ResourceLabel } from '~/ui/lib/SideModal'
+import { links } from '~/util/links'
+import { bytesToGiB, GiB } from '~/util/units'
+
+type Props = {
+  /** Silo name, used as the path param on update */
+  silo: string
+  /** Current quotas, i.e., the `allocated` counts from silo utilization */
+  quotas: VirtualResourceCounts
+  onDismiss: () => void
+}
+
+export function EditQuotasSideModalForm({ silo, quotas, onDismiss }: Props) {
+  // required because we need to rule out undefined because NumberField hates that
+  const defaultValues: SetNonNullable<Required<SiloQuotasUpdate>> = {
+    cpus: quotas.cpus,
+    memory: bytesToGiB(quotas.memory),
+    storage: bytesToGiB(quotas.storage),
+  }
+
+  const form = useForm({ defaultValues })
+
+  const updateQuotas = useApiMutation(api.siloQuotasUpdate, {
+    onSuccess() {
+      queryClient.invalidateEndpoint('siloUtilizationView')
+      queryClient.invalidateEndpoint('siloUtilizationList')
+      addToast({ content: 'Quotas updated' })
+      onDismiss()
+    },
+  })
+
+  return (
+    <SideModalForm
+      form={form}
+      formType="edit"
+      resourceName="Quotas"
+      title="Edit quotas"
+      subtitle={
+        <ResourceLabel>
+          <Cloud16Icon /> {silo}
+        </ResourceLabel>
+      }
+      onDismiss={onDismiss}
+      onSubmit={({ cpus, memory, storage }) =>
+        updateQuotas.mutate({
+          body: {
+            cpus,
+            memory: memory * GiB,
+            // TODO: we use GiB on instance create but TiB on utilization. HM
+            storage: storage * GiB,
+          },
+          path: { silo },
+        })
+      }
+      loading={updateQuotas.isPending}
+      submitError={updateQuotas.error}
+    >
+      <Message content={<LearnMore />} variant="info" />
+
+      <NumberField name="cpus" label="CPU" units="vCPUs" required control={form.control} />
+      <NumberField
+        name="memory"
+        label="Memory"
+        units="GiB"
+        required
+        control={form.control}
+      />
+      <NumberField
+        name="storage"
+        label="Storage"
+        units="GiB"
+        required
+        control={form.control}
+      />
+    </SideModalForm>
+  )
+}
+
+function LearnMore() {
+  return (
+    <>
+      If a quota is set below the amount currently in use, users will not be able to
+      provision resources. Learn more about quotas in the{' '}
+      <a
+        href={links.siloQuotasDocs}
+        // don't need color and hover color because message text is already color-info anyway
+        className="underline"
+        target="_blank"
+        rel="noreferrer"
+      >
+        Silos
+      </a>{' '}
+      guide.
+    </>
+  )
+}

--- a/app/forms/silo-quotas-edit.tsx
+++ b/app/forms/silo-quotas-edit.tsx
@@ -99,7 +99,7 @@ export function EditQuotasSideModalForm({ silo, quotas, onDismiss }: Props) {
         required
         control={form.control}
       />
-      <SideModalFormDocs docs={[docLinks.siloQuotas]} />
+      <SideModalFormDocs docs={[docLinks.resourceManagement]} />
     </SideModalForm>
   )
 }

--- a/app/forms/silo-quotas-edit.tsx
+++ b/app/forms/silo-quotas-edit.tsx
@@ -88,7 +88,7 @@ export function EditQuotasSideModalForm({ silo, quotas, provisioned, onDismiss }
       submitError={updateQuotas.error}
     >
       <Message
-        content="If a quota is set below the amount currently in use, users will not be able to provision resources."
+        content="If a quota is set below the amount currently provisioned, users will not be able to provision new resources."
         variant="info"
       />
 

--- a/app/forms/silo-quotas-edit.tsx
+++ b/app/forms/silo-quotas-edit.tsx
@@ -20,6 +20,7 @@ import { Cloud16Icon } from '@oxide/design-system/icons/react'
 import { NumberField } from '~/components/form/fields/NumberField'
 import { SideModalForm } from '~/components/form/SideModalForm'
 import { addToast } from '~/stores/toast'
+import { BigNum } from '~/ui/lib/BigNum'
 import { Message } from '~/ui/lib/Message'
 import { SideModalFormDocs } from '~/ui/lib/ModalLinks'
 import { ResourceLabel } from '~/ui/lib/SideModal'
@@ -38,7 +39,7 @@ type Props = {
 
 const ProvisionedHint = ({ value, unit }: { value: number; unit: string }) => (
   <div className="text-sans-sm text-secondary mt-1">
-    Provisioned: {value} {unit}
+    Provisioned: <BigNum num={value} /> {unit}
   </div>
 )
 

--- a/app/forms/silo-quotas-edit.tsx
+++ b/app/forms/silo-quotas-edit.tsx
@@ -21,8 +21,9 @@ import { NumberField } from '~/components/form/fields/NumberField'
 import { SideModalForm } from '~/components/form/SideModalForm'
 import { addToast } from '~/stores/toast'
 import { Message } from '~/ui/lib/Message'
+import { SideModalFormDocs } from '~/ui/lib/ModalLinks'
 import { ResourceLabel } from '~/ui/lib/SideModal'
-import { links } from '~/util/links'
+import { docLinks } from '~/util/links'
 import { bytesToGiB, GiB } from '~/util/units'
 
 type Props = {
@@ -78,7 +79,10 @@ export function EditQuotasSideModalForm({ silo, quotas, onDismiss }: Props) {
       loading={updateQuotas.isPending}
       submitError={updateQuotas.error}
     >
-      <Message content={<LearnMore />} variant="info" />
+      <Message
+        content="If a quota is set below the amount currently in use, users will not be able to provision resources."
+        variant="info"
+      />
 
       <NumberField name="cpus" label="CPU" units="vCPUs" required control={form.control} />
       <NumberField
@@ -95,25 +99,7 @@ export function EditQuotasSideModalForm({ silo, quotas, onDismiss }: Props) {
         required
         control={form.control}
       />
+      <SideModalFormDocs docs={[docLinks.siloQuotas]} />
     </SideModalForm>
-  )
-}
-
-function LearnMore() {
-  return (
-    <>
-      If a quota is set below the amount currently in use, users will not be able to
-      provision resources. Learn more about quotas in the{' '}
-      <a
-        href={links.siloQuotasDocs}
-        // don't need color and hover color because message text is already color-info anyway
-        className="underline"
-        target="_blank"
-        rel="noreferrer"
-      >
-        Silos
-      </a>{' '}
-      guide.
-    </>
   )
 }

--- a/app/forms/silo-quotas-edit.tsx
+++ b/app/forms/silo-quotas-edit.tsx
@@ -38,7 +38,7 @@ type Props = {
 
 const ProvisionedHint = ({ value, unit }: { value: number; unit: string }) => (
   <div className="text-sans-sm text-secondary mt-1">
-    Currently provisioned: {value} {unit}
+    Provisioned: {value} {unit}
   </div>
 )
 

--- a/app/forms/silo-quotas-edit.tsx
+++ b/app/forms/silo-quotas-edit.tsx
@@ -31,10 +31,18 @@ type Props = {
   silo: string
   /** Current quotas, i.e., the `allocated` counts from silo utilization */
   quotas: VirtualResourceCounts
+  /** Currently provisioned amounts, shown under each input for context */
+  provisioned: VirtualResourceCounts
   onDismiss: () => void
 }
 
-export function EditQuotasSideModalForm({ silo, quotas, onDismiss }: Props) {
+const ProvisionedHint = ({ value, unit }: { value: number; unit: string }) => (
+  <div className="text-sans-sm text-secondary mt-1">
+    Currently provisioned: {value} {unit}
+  </div>
+)
+
+export function EditQuotasSideModalForm({ silo, quotas, provisioned, onDismiss }: Props) {
   // required because we need to rule out undefined because NumberField hates that
   const defaultValues: SetNonNullable<Required<SiloQuotasUpdate>> = {
     cpus: quotas.cpus,
@@ -84,21 +92,36 @@ export function EditQuotasSideModalForm({ silo, quotas, onDismiss }: Props) {
         variant="info"
       />
 
-      <NumberField name="cpus" label="CPU" units="vCPUs" required control={form.control} />
-      <NumberField
-        name="memory"
-        label="Memory"
-        units="GiB"
-        required
-        control={form.control}
-      />
-      <NumberField
-        name="storage"
-        label="Storage"
-        units="GiB"
-        required
-        control={form.control}
-      />
+      <div>
+        <NumberField
+          name="cpus"
+          label="CPU"
+          units="vCPUs"
+          required
+          control={form.control}
+        />
+        <ProvisionedHint value={provisioned.cpus} unit="vCPUs" />
+      </div>
+      <div>
+        <NumberField
+          name="memory"
+          label="Memory"
+          units="GiB"
+          required
+          control={form.control}
+        />
+        <ProvisionedHint value={bytesToGiB(provisioned.memory)} unit="GiB" />
+      </div>
+      <div>
+        <NumberField
+          name="storage"
+          label="Storage"
+          units="GiB"
+          required
+          control={form.control}
+        />
+        <ProvisionedHint value={bytesToGiB(provisioned.storage)} unit="GiB" />
+      </div>
       <SideModalFormDocs docs={[docLinks.resourceManagement]} />
     </SideModalForm>
   )

--- a/app/pages/system/UtilizationPage.tsx
+++ b/app/pages/system/UtilizationPage.tsx
@@ -16,6 +16,7 @@ import {
   queryClient,
   totalUtilization,
   usePrefetchedQuery,
+  type SiloUtilization,
 } from '@oxide/api'
 import { Metrics16Icon, Metrics24Icon } from '@oxide/design-system/icons/react'
 
@@ -25,6 +26,7 @@ import { useDateTimeRangePicker } from '~/components/form/fields/DateTimeRangePi
 import { QueryParamTabs } from '~/components/QueryParamTabs'
 import { useIntervalPicker } from '~/components/RefetchIntervalPicker'
 import { SystemMetric } from '~/components/SystemMetric'
+import { EditQuotasSideModalForm } from '~/forms/silo-quotas-edit'
 import { LinkCell } from '~/table/cells/LinkCell'
 import { RowActions } from '~/table/columns/action-col'
 import { Listbox } from '~/ui/lib/Listbox'
@@ -171,84 +173,105 @@ const MetricsTab = () => {
 function UsageTab() {
   const { data: siloUtilizations } = usePrefetchedQuery(siloUtilList.optionsFn())
 
+  // silo whose quotas are being edited, if any
+  const [editingSilo, setEditingSilo] = useState<SiloUtilization | null>(null)
+
   return (
-    <Table className="w-full">
-      <Table.Header>
-        <Table.HeaderRow>
-          <Table.HeadCell data-test-ignore></Table.HeadCell>
-          {/* data-test-ignore makes the row asserts work in the e2e tests */}
-          <Table.HeadCell colSpan={3} data-test-ignore>
-            Provisioned / Quota
-          </Table.HeadCell>
-          <Table.HeadCell colSpan={3} data-test-ignore>
-            Available
-          </Table.HeadCell>
-          <Table.HeadCell data-test-ignore></Table.HeadCell>
-        </Table.HeaderRow>
-        <Table.HeaderRow>
-          <Table.HeadCell>Silo</Table.HeadCell>
-          <Table.HeadCell>CPU</Table.HeadCell>
-          <Table.HeadCell>Memory</Table.HeadCell>
-          <Table.HeadCell>Storage</Table.HeadCell>
-          <Table.HeadCell>CPU</Table.HeadCell>
-          <Table.HeadCell>Memory</Table.HeadCell>
-          <Table.HeadCell>Storage</Table.HeadCell>
-          <Table.HeadCell data-test-ignore></Table.HeadCell>
-        </Table.HeaderRow>
-      </Table.Header>
-      <Table.Body>
-        {siloUtilizations.items.map((silo) => (
-          <Table.Row key={silo.siloName}>
-            <Table.Cell width="16%" height="large">
-              <LinkCell to={pb.silo({ silo: silo.siloName })}>{silo.siloName}</LinkCell>
-            </Table.Cell>
-            <Table.Cell width="14%" height="large">
-              <UsageCell
-                provisioned={silo.provisioned.cpus}
-                allocated={silo.allocated.cpus}
-              />
-            </Table.Cell>
-            <Table.Cell width="14%" height="large">
-              <UsageCell
-                provisioned={bytesToGiB(silo.provisioned.memory)}
-                allocated={bytesToGiB(silo.allocated.memory)}
-                unit="GiB"
-              />
-            </Table.Cell>
-            <Table.Cell width="14%" height="large">
-              <UsageCell
-                provisioned={bytesToTiB(silo.provisioned.storage)}
-                allocated={bytesToTiB(silo.allocated.storage)}
-                unit="TiB"
-              />
-            </Table.Cell>
-            <Table.Cell width="14%" className="relative" height="large">
-              <AvailableCell
-                provisioned={silo.provisioned.cpus}
-                allocated={silo.allocated.cpus}
-              />
-            </Table.Cell>
-            <Table.Cell width="14%" className="relative" height="large">
-              <AvailableCell
-                provisioned={bytesToGiB(silo.provisioned.memory)}
-                allocated={bytesToGiB(silo.allocated.memory)}
-                unit="GiB"
-              />
-            </Table.Cell>
-            <Table.Cell width="14%" className="relative" height="large">
-              <AvailableCell
-                provisioned={bytesToTiB(silo.provisioned.storage)}
-                allocated={bytesToTiB(silo.allocated.storage)}
-                unit="TiB"
-              />
-            </Table.Cell>
-            <Table.Cell className="action-col w-10 *:p-0" height="large">
-              <RowActions id={silo.siloId} copyIdLabel="Copy silo ID" />
-            </Table.Cell>
-          </Table.Row>
-        ))}
-      </Table.Body>
-    </Table>
+    <>
+      <Table className="w-full">
+        <Table.Header>
+          <Table.HeaderRow>
+            <Table.HeadCell data-test-ignore></Table.HeadCell>
+            {/* data-test-ignore makes the row asserts work in the e2e tests */}
+            <Table.HeadCell colSpan={3} data-test-ignore>
+              Provisioned / Quota
+            </Table.HeadCell>
+            <Table.HeadCell colSpan={3} data-test-ignore>
+              Available
+            </Table.HeadCell>
+            <Table.HeadCell data-test-ignore></Table.HeadCell>
+          </Table.HeaderRow>
+          <Table.HeaderRow>
+            <Table.HeadCell>Silo</Table.HeadCell>
+            <Table.HeadCell>CPU</Table.HeadCell>
+            <Table.HeadCell>Memory</Table.HeadCell>
+            <Table.HeadCell>Storage</Table.HeadCell>
+            <Table.HeadCell>CPU</Table.HeadCell>
+            <Table.HeadCell>Memory</Table.HeadCell>
+            <Table.HeadCell>Storage</Table.HeadCell>
+            <Table.HeadCell data-test-ignore></Table.HeadCell>
+          </Table.HeaderRow>
+        </Table.Header>
+        <Table.Body>
+          {siloUtilizations.items.map((silo) => (
+            <Table.Row key={silo.siloName}>
+              <Table.Cell width="16%" height="large">
+                <LinkCell to={pb.silo({ silo: silo.siloName })}>{silo.siloName}</LinkCell>
+              </Table.Cell>
+              <Table.Cell width="14%" height="large">
+                <UsageCell
+                  provisioned={silo.provisioned.cpus}
+                  allocated={silo.allocated.cpus}
+                />
+              </Table.Cell>
+              <Table.Cell width="14%" height="large">
+                <UsageCell
+                  provisioned={bytesToGiB(silo.provisioned.memory)}
+                  allocated={bytesToGiB(silo.allocated.memory)}
+                  unit="GiB"
+                />
+              </Table.Cell>
+              <Table.Cell width="14%" height="large">
+                <UsageCell
+                  provisioned={bytesToTiB(silo.provisioned.storage)}
+                  allocated={bytesToTiB(silo.allocated.storage)}
+                  unit="TiB"
+                />
+              </Table.Cell>
+              <Table.Cell width="14%" className="relative" height="large">
+                <AvailableCell
+                  provisioned={silo.provisioned.cpus}
+                  allocated={silo.allocated.cpus}
+                />
+              </Table.Cell>
+              <Table.Cell width="14%" className="relative" height="large">
+                <AvailableCell
+                  provisioned={bytesToGiB(silo.provisioned.memory)}
+                  allocated={bytesToGiB(silo.allocated.memory)}
+                  unit="GiB"
+                />
+              </Table.Cell>
+              <Table.Cell width="14%" className="relative" height="large">
+                <AvailableCell
+                  provisioned={bytesToTiB(silo.provisioned.storage)}
+                  allocated={bytesToTiB(silo.allocated.storage)}
+                  unit="TiB"
+                />
+              </Table.Cell>
+              <Table.Cell className="action-col w-10 *:p-0" height="large">
+                <RowActions
+                  id={silo.siloId}
+                  copyIdLabel="Copy silo ID"
+                  actions={[
+                    {
+                      label: 'Edit quotas',
+                      onActivate: () => setEditingSilo(silo),
+                    },
+                  ]}
+                />
+              </Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table>
+      {editingSilo && (
+        <EditQuotasSideModalForm
+          silo={editingSilo.siloName}
+          quotas={editingSilo.allocated}
+          onDismiss={() => setEditingSilo(null)}
+        />
+      )}
+    </>
   )
 }
 

--- a/app/pages/system/UtilizationPage.tsx
+++ b/app/pages/system/UtilizationPage.tsx
@@ -268,6 +268,7 @@ function UsageTab() {
         <EditQuotasSideModalForm
           silo={editingSilo.siloName}
           quotas={editingSilo.allocated}
+          provisioned={editingSilo.provisioned}
           onDismiss={() => setEditingSilo(null)}
         />
       )}

--- a/app/pages/system/silos/SiloQuotasTab.tsx
+++ b/app/pages/system/silos/SiloQuotasTab.tsx
@@ -7,30 +7,17 @@
  */
 
 import { useState } from 'react'
-import { useForm } from 'react-hook-form'
 import { type LoaderFunctionArgs } from 'react-router'
-import type { SetNonNullable } from 'type-fest'
 
-import {
-  api,
-  q,
-  queryClient,
-  useApiMutation,
-  usePrefetchedQuery,
-  type SiloQuotasUpdate,
-} from '~/api'
-import { NumberField } from '~/components/form/fields/NumberField'
-import { SideModalForm } from '~/components/form/SideModalForm'
+import { api, q, queryClient, usePrefetchedQuery } from '~/api'
+import { EditQuotasSideModalForm } from '~/forms/silo-quotas-edit'
 import { makeCrumb } from '~/hooks/use-crumbs'
 import { getSiloSelector, useSiloSelector } from '~/hooks/use-params'
-import { addToast } from '~/stores/toast'
 import { Button } from '~/ui/lib/Button'
-import { Message } from '~/ui/lib/Message'
 import { Table } from '~/ui/lib/Table'
 import { ValueUnit } from '~/ui/lib/ValueUnit'
-import { links } from '~/util/links'
 import type * as PP from '~/util/path-params'
-import { bytesToGiB, GiB } from '~/util/units'
+import { bytesToGiB } from '~/util/units'
 
 const siloUtil = ({ silo }: PP.Silo) => q(api.siloUtilizationView, { path: { silo } })
 
@@ -93,92 +80,15 @@ export default function SiloQuotasTab() {
           Edit quotas
         </Button>
       </div>
-      {editing && <EditQuotasForm onDismiss={() => setEditing(false)} />}
+      {editing && (
+        <EditQuotasSideModalForm
+          silo={silo}
+          quotas={quotas}
+          onDismiss={() => setEditing(false)}
+        />
+      )}
     </>
   )
 }
 
 export const handle = makeCrumb('Quotas')
-
-function EditQuotasForm({ onDismiss }: { onDismiss: () => void }) {
-  const { silo } = useSiloSelector()
-  const { data: utilization } = usePrefetchedQuery(siloUtil({ silo }))
-  const quotas = utilization.allocated
-
-  // required because we need to rule out undefined because NumberField hates that
-  const defaultValues: SetNonNullable<Required<SiloQuotasUpdate>> = {
-    cpus: quotas.cpus,
-    memory: bytesToGiB(quotas.memory),
-    storage: bytesToGiB(quotas.storage),
-  }
-
-  const form = useForm({ defaultValues })
-
-  const updateQuotas = useApiMutation(api.siloQuotasUpdate, {
-    onSuccess() {
-      queryClient.invalidateEndpoint('siloUtilizationView')
-      addToast({ content: 'Quotas updated' })
-      onDismiss()
-    },
-  })
-
-  return (
-    <SideModalForm
-      form={form}
-      formType="edit"
-      resourceName="Quotas"
-      title="Edit quotas"
-      onDismiss={onDismiss}
-      onSubmit={({ cpus, memory, storage }) =>
-        updateQuotas.mutate({
-          body: {
-            cpus,
-            memory: memory * GiB,
-            // TODO: we use GiB on instance create but TiB on utilization. HM
-            storage: storage * GiB,
-          },
-          path: { silo },
-        })
-      }
-      loading={updateQuotas.isPending}
-      submitError={updateQuotas.error}
-    >
-      <Message content={<LearnMore />} variant="info" />
-
-      <NumberField name="cpus" label="CPU" units="vCPUs" required control={form.control} />
-      <NumberField
-        name="memory"
-        label="Memory"
-        units="GiB"
-        required
-        control={form.control}
-      />
-      <NumberField
-        name="storage"
-        label="Storage"
-        units="GiB"
-        required
-        control={form.control}
-      />
-    </SideModalForm>
-  )
-}
-
-function LearnMore() {
-  return (
-    <>
-      If a quota is set below the amount currently in use, users will not be able to
-      provision resources. Learn more about quotas in the{' '}
-      <a
-        href={links.siloQuotasDocs}
-        // don't need color and hover color because message text is already color-info anyway
-        className="underline"
-        target="_blank"
-        rel="noreferrer"
-      >
-        Silos
-      </a>{' '}
-      guide.
-    </>
-  )
-}

--- a/app/pages/system/silos/SiloQuotasTab.tsx
+++ b/app/pages/system/silos/SiloQuotasTab.tsx
@@ -84,6 +84,7 @@ export default function SiloQuotasTab() {
         <EditQuotasSideModalForm
           silo={silo}
           quotas={quotas}
+          provisioned={provisioned}
           onDismiss={() => setEditing(false)}
         />
       )}

--- a/app/util/links.ts
+++ b/app/util/links.ts
@@ -22,8 +22,6 @@ export const links = {
   instanceBootDiskDocs: 'https://docs.oxide.computer/guides/deploying-workloads',
   oxqlSchemaDocs: (metric: string) =>
     `https://docs.oxide.computer/guides/metrics/timeseries-schemas#_${metric.replace(':', '')}`,
-  siloQuotasDocs:
-    'https://docs.oxide.computer/guides/operator/silo-management#_silo_resource_quota_management',
   siloTlsCertsDocs:
     'https://docs.oxide.computer/guides/system/system-setup#tls-certificate',
   transitIpsDocs:
@@ -110,6 +108,10 @@ export const docLinks = {
     href: remoteAccess,
     linkText: 'Remote Access',
   },
+  resourceManagement: {
+    href: 'https://docs.oxide.computer/guides/operator/resource-management',
+    linkText: 'Resource Management',
+  },
   scim: {
     href: 'https://docs.oxide.computer/guides/operator/identity-providers#_saml_authentication_scim_user_provisioning',
     linkText: 'SCIM',
@@ -164,10 +166,6 @@ export const docLinks = {
   },
   systemSilo: {
     href: 'https://docs.oxide.computer/guides/operator/silo-management',
-    linkText: 'Silos',
-  },
-  siloQuotas: {
-    href: links.siloQuotasDocs,
     linkText: 'Silos',
   },
   systemUpdate: {

--- a/app/util/links.ts
+++ b/app/util/links.ts
@@ -166,6 +166,10 @@ export const docLinks = {
     href: 'https://docs.oxide.computer/guides/operator/silo-management',
     linkText: 'Silos',
   },
+  siloQuotas: {
+    href: links.siloQuotasDocs,
+    linkText: 'Silos',
+  },
   systemUpdate: {
     href: 'https://docs.oxide.computer/guides/operator/system-update',
     linkText: 'System Update',

--- a/test/e2e/utilization.e2e.ts
+++ b/test/e2e/utilization.e2e.ts
@@ -56,6 +56,30 @@ test.describe('System utilization', () => {
     expect(await clipboardText(page)).toEqual('6d3a9c06-475e-4f75-b272-c0d0e3f980fa')
   })
 
+  test('can edit quotas', async ({ page }) => {
+    await page.goto('/system/utilization')
+
+    const table = page.getByRole('table')
+    // CPU here is the available column, i.e., quota (50) minus provisioned (30)
+    await expectRowVisible(table, { Silo: 'maze-war', CPU: '20' })
+
+    await clickRowAction(page, 'maze-war', 'Edit quotas')
+
+    const sideModal = page.getByRole('dialog', { name: 'Edit quotas' })
+    await expect(sideModal).toBeVisible()
+    await expect(sideModal.getByRole('heading', { name: 'maze-war' })).toBeVisible()
+
+    const cpus = sideModal.getByRole('textbox', { name: 'CPU' })
+    await expect(cpus).toHaveValue('50')
+    await cpus.fill('60')
+    await sideModal.getByRole('button', { name: 'Update quotas' }).click()
+
+    await expect(sideModal).toBeHidden()
+    await closeToast(page)
+
+    await expectRowVisible(table, { Silo: 'maze-war', CPU: '30' })
+  })
+
   test('does not appear for dev user', async ({ browser }) => {
     const page = await getPageAsUser(browser, 'Hans Jonas')
     await page.goto('/system/utilization')

--- a/test/e2e/utilization.e2e.ts
+++ b/test/e2e/utilization.e2e.ts
@@ -70,9 +70,9 @@ test.describe('System utilization', () => {
     await expect(sideModal.getByRole('heading', { name: 'maze-war' })).toBeVisible()
 
     // provisioned amounts show under each input
-    await expect(sideModal.getByText('Currently provisioned: 30 vCPUs')).toBeVisible()
-    await expect(sideModal.getByText('Currently provisioned: 234 GiB')).toBeVisible()
-    await expect(sideModal.getByText('Currently provisioned: 4403.2 GiB')).toBeVisible()
+    await expect(sideModal.getByText('Provisioned: 30 vCPUs')).toBeVisible()
+    await expect(sideModal.getByText('Provisioned: 234 GiB')).toBeVisible()
+    await expect(sideModal.getByText('Provisioned: 4403.2 GiB')).toBeVisible()
 
     await expect(
       sideModal.getByRole('link', { name: 'Resource Management' })

--- a/test/e2e/utilization.e2e.ts
+++ b/test/e2e/utilization.e2e.ts
@@ -69,6 +69,11 @@ test.describe('System utilization', () => {
     await expect(sideModal).toBeVisible()
     await expect(sideModal.getByRole('heading', { name: 'maze-war' })).toBeVisible()
 
+    // provisioned amounts show under each input
+    await expect(sideModal.getByText('Currently provisioned: 30 vCPUs')).toBeVisible()
+    await expect(sideModal.getByText('Currently provisioned: 234 GiB')).toBeVisible()
+    await expect(sideModal.getByText('Currently provisioned: 4403.2 GiB')).toBeVisible()
+
     await expect(
       sideModal.getByRole('link', { name: 'Resource Management' })
     ).toHaveAttribute(

--- a/test/e2e/utilization.e2e.ts
+++ b/test/e2e/utilization.e2e.ts
@@ -69,10 +69,11 @@ test.describe('System utilization', () => {
     await expect(sideModal).toBeVisible()
     await expect(sideModal.getByRole('heading', { name: 'maze-war' })).toBeVisible()
 
-    const docs = sideModal.getByRole('link', { name: 'Silos' })
-    await expect(docs).toHaveAttribute(
+    await expect(
+      sideModal.getByRole('link', { name: 'Resource Management' })
+    ).toHaveAttribute(
       'href',
-      'https://docs.oxide.computer/guides/operator/silo-management#_silo_resource_quota_management'
+      'https://docs.oxide.computer/guides/operator/resource-management'
     )
 
     const cpus = sideModal.getByRole('textbox', { name: 'CPU' })

--- a/test/e2e/utilization.e2e.ts
+++ b/test/e2e/utilization.e2e.ts
@@ -72,7 +72,7 @@ test.describe('System utilization', () => {
     // provisioned amounts show under each input
     await expect(sideModal.getByText('Provisioned: 30 vCPUs')).toBeVisible()
     await expect(sideModal.getByText('Provisioned: 234 GiB')).toBeVisible()
-    await expect(sideModal.getByText('Provisioned: 4403.2 GiB')).toBeVisible()
+    await expect(sideModal.getByText('Provisioned: 4,403.2 GiB')).toBeVisible()
 
     await expect(
       sideModal.getByRole('link', { name: 'Resource Management' })

--- a/test/e2e/utilization.e2e.ts
+++ b/test/e2e/utilization.e2e.ts
@@ -69,6 +69,12 @@ test.describe('System utilization', () => {
     await expect(sideModal).toBeVisible()
     await expect(sideModal.getByRole('heading', { name: 'maze-war' })).toBeVisible()
 
+    const docs = sideModal.getByRole('link', { name: 'Silos' })
+    await expect(docs).toHaveAttribute(
+      'href',
+      'https://docs.oxide.computer/guides/operator/silo-management#_silo_resource_quota_management'
+    )
+
     const cpus = sideModal.getByRole('textbox', { name: 'CPU' })
     await expect(cpus).toHaveValue('50')
     await cpus.fill('60')


### PR DESCRIPTION
This PR adds a sidemodal to the `/system/utilization` page, allowing the operator to edit quota values from that page. Before this change, quota updates have to be done from each silo's Quotas tab. (This PR doesn't remove that functionality; just adds it to the `/utilization` list page.)

Closes #2406

up-to-date screenshot:
<img width="1456" height="828" alt="Screenshot 2026-08-26 at 8 33 27 AM" src="https://github.com/user-attachments/assets/c6e10d9b-1683-4d82-b6df-09eb91646caa" />