### PR TITLE
Make tooltips accessible to screen readers via persistent aria-describedby

### DIFF
--- a/app/ui/lib/Tooltip.tsx
+++ b/app/ui/lib/Tooltip.tsx
@@ -24,7 +24,7 @@ import {
   type Placement,
 } from '@floating-ui/react'
 import cn from 'classnames'
-import { Children, cloneElement, useRef, useState, type ReactElement } from 'react'
+import { Children, cloneElement, useId, useRef, useState, type ReactElement } from 'react'
 
 import { usePopoverZIndex } from './SideModal'
 
@@ -36,7 +36,10 @@ export interface TooltipProps {
   // the corner at (0,0).
 
   /** The target the tooltip hovers near; can not be a raw string. */
-  children?: ReactElement<{ ref?: React.Ref<HTMLButtonElement> }>
+  children?: ReactElement<{
+    ref?: React.Ref<HTMLButtonElement>
+    'aria-describedby'?: string
+  }>
   /** The text to appear on hover/focus */
   content?: string | React.ReactNode
   /**
@@ -78,9 +81,20 @@ export const Tooltip = ({ delay = 250, children, content, placement }: TooltipPr
     useRole(context, { role: 'tooltip' }),
   ])
 
+  const descriptionId = useId()
+
   const onlyChild = Children.only(children)!
+  const describedBy = content
+    ? `${onlyChild.props['aria-describedby'] ?? ''} ${descriptionId}`.trim()
+    : onlyChild.props['aria-describedby']
   const child = cloneElement(onlyChild, {
     ...getReferenceProps(),
+    // Point at a visually hidden copy of the content that is always rendered,
+    // overriding the aria-describedby that useRole sets only while the tooltip
+    // is open. Open state requires hover or DOM focus, and a screen reader
+    // cursor is neither, so a description that only exists while open is
+    // unreachable for exactly the users who need it.
+    'aria-describedby': describedBy,
     // merge with whatever ref is already on the button
     ref: useMergeRefs([refs.setReference, onlyChild.props.ref]),
   })
@@ -93,6 +107,15 @@ export const Tooltip = ({ delay = 250, children, content, placement }: TooltipPr
     <>
       {child}
       <FloatingPortal>
+        {/* Keep the persistent description separate from the conditionally
+            rendered tooltip. Floating UI's autoUpdate lifecycle assumes the
+            floating element unmounts while closed. aria-hidden keeps this copy
+            out of the reading order, but description computation still follows
+            the aria-describedby reference into hidden nodes.
+            https://floating-ui.com/docs/react#anchoring */}
+        <div id={descriptionId} className="sr-only" aria-hidden>
+          {content}
+        </div>
         {open && (
           <div
             ref={refs.setFloating}

--- a/test/e2e/external-subnets.e2e.ts
+++ b/test/e2e/external-subnets.e2e.ts
@@ -201,7 +201,7 @@ test('cannot delete an attached external subnet', async ({ page }) => {
   const deleteButton = page.getByRole('menuitem', { name: 'Delete' })
   await expect(deleteButton).toBeDisabled()
   await deleteButton.hover()
-  await expect(page.getByText('must be detached')).toBeVisible()
+  await expect(page.getByRole('tooltip').getByText('must be detached')).toBeVisible()
 })
 
 test('can detach and reattach an external subnet from the list page', async ({ page }) => {

--- a/test/e2e/fleet-access.e2e.ts
+++ b/test/e2e/fleet-access.e2e.ts
@@ -168,7 +168,9 @@ test('Cross-silo user shows UUID with tooltip', async ({ page }) => {
   await expect(userCell).toBeVisible()
   await userCell.getByRole('button', { name: 'Tip' }).hover()
   await expect(
-    page.getByText("Can't resolve name because user is not in your silo")
+    page
+      .getByRole('tooltip')
+      .getByText("Can't resolve name because user is not in your silo")
   ).toBeVisible()
 
   // dismiss the first tooltip before checking the group's
@@ -179,7 +181,9 @@ test('Cross-silo user shows UUID with tooltip', async ({ page }) => {
   await expect(groupCell).toBeVisible()
   await groupCell.getByRole('button', { name: 'Tip' }).hover()
   await expect(
-    page.getByText("Can't resolve name because group is not in your silo")
+    page
+      .getByRole('tooltip')
+      .getByText("Can't resolve name because group is not in your silo")
   ).toBeVisible()
 })
 

--- a/test/e2e/instance-create.e2e.ts
+++ b/test/e2e/instance-create.e2e.ts
@@ -155,8 +155,12 @@ test('ephemeral pool selection tracks network interface IP version', async ({ pa
 
   // Verify disabled v4 checkbox shows tooltip
   await v4Checkbox.hover()
-  await expect(page.getByText('Add an IPv4 network interface')).toBeVisible()
-  await expect(page.getByText('to attach an ephemeral IPv4 address')).toBeVisible()
+  await expect(
+    page.getByRole('tooltip').getByText('Add an IPv4 network interface')
+  ).toBeVisible()
+  await expect(
+    page.getByRole('tooltip').getByText('to attach an ephemeral IPv4 address')
+  ).toBeVisible()
 
   // Change to IPv4-only NIC - v6 checkbox should become disabled and unchecked
   await selectOption(page, page.getByRole('button', { name: 'IPv6', exact: true }), 'IPv4')
@@ -169,8 +173,12 @@ test('ephemeral pool selection tracks network interface IP version', async ({ pa
 
   // Verify disabled v6 checkbox shows tooltip
   await v6Checkbox.hover()
-  await expect(page.getByText('Add an IPv6 network interface')).toBeVisible()
-  await expect(page.getByText('to attach an ephemeral IPv6 address')).toBeVisible()
+  await expect(
+    page.getByRole('tooltip').getByText('Add an IPv6 network interface')
+  ).toBeVisible()
+  await expect(
+    page.getByRole('tooltip').getByText('to attach an ephemeral IPv6 address')
+  ).toBeVisible()
 })
 
 test('duplicate instance name produces visible error', async ({ page }) => {
@@ -1073,13 +1081,21 @@ test('ephemeral IP checkbox disabled when no NICs configured', async ({ page }) 
 
   // Verify tooltip shows disabled reason for IPv4
   await v4Checkbox.hover()
-  await expect(page.getByText('Add an IPv4 network interface')).toBeVisible()
-  await expect(page.getByText('to attach an ephemeral IPv4 address')).toBeVisible()
+  await expect(
+    page.getByRole('tooltip').getByText('Add an IPv4 network interface')
+  ).toBeVisible()
+  await expect(
+    page.getByRole('tooltip').getByText('to attach an ephemeral IPv4 address')
+  ).toBeVisible()
 
   // Verify tooltip shows disabled reason for IPv6
   await v6Checkbox.hover()
-  await expect(page.getByText('Add an IPv6 network interface')).toBeVisible()
-  await expect(page.getByText('to attach an ephemeral IPv6 address')).toBeVisible()
+  await expect(
+    page.getByRole('tooltip').getByText('Add an IPv6 network interface')
+  ).toBeVisible()
+  await expect(
+    page.getByRole('tooltip').getByText('to attach an ephemeral IPv6 address')
+  ).toBeVisible()
 
   // Select "Custom" radio → verify ephemeral IP checkboxes are still disabled and unchecked
   await customRadio.click()
@@ -1092,8 +1108,12 @@ test('ephemeral IP checkbox disabled when no NICs configured', async ({ page }) 
 
   // Verify tooltip still shows disabled reason when in Custom mode with no NICs
   await v4Checkbox.hover()
-  await expect(page.getByText('Add an IPv4 network interface')).toBeVisible()
-  await expect(page.getByText('to attach an ephemeral IPv4 address')).toBeVisible()
+  await expect(
+    page.getByRole('tooltip').getByText('Add an IPv4 network interface')
+  ).toBeVisible()
+  await expect(
+    page.getByRole('tooltip').getByText('to attach an ephemeral IPv4 address')
+  ).toBeVisible()
 
   // Click "Add network interface" button to open modal
   await page.getByRole('button', { name: 'Add network interface' }).click()
@@ -1265,8 +1285,10 @@ test('floating IPs are filtered by NIC IP version', async ({ page }) => {
 
   // Verify the disabled reason tooltip
   await attachFloatingIpButton.hover()
-  await expect(page.getByText('A network interface is required')).toBeVisible()
-  await expect(page.getByText('to attach a floating IP')).toBeVisible()
+  await expect(
+    page.getByRole('tooltip').getByText('A network interface is required')
+  ).toBeVisible()
+  await expect(page.getByRole('tooltip').getByText('to attach a floating IP')).toBeVisible()
 })
 
 test('can create instance with read-only boot disk', async ({ page }) => {

--- a/test/e2e/instance-disks.e2e.ts
+++ b/test/e2e/instance-disks.e2e.ts
@@ -31,6 +31,15 @@ test('Disk detail side modal', async ({ page }) => {
 test('Disabled actions', async ({ page }) => {
   await page.goto('/projects/mock-project/instances/db1')
 
+  // the disabled reason is exposed to screen readers as an accessible
+  // description even with no hover or focus to pop the tooltip
+  await expect(
+    page.getByRole('button', { name: 'Attach existing disk' })
+  ).toHaveAccessibleDescription('Instance must be stopped to attach a disk')
+  await expect(
+    page.getByRole('button', { name: 'Create disk' })
+  ).toHaveAccessibleDescription('Instance must be stopped to create and attach a disk')
+
   const bootDiskRow = page.getByRole('row', { name: 'disk-1', exact: false })
   await expect(bootDiskRow).toBeVisible()
 

--- a/test/e2e/instance-disks.e2e.ts
+++ b/test/e2e/instance-disks.e2e.ts
@@ -53,13 +53,15 @@ test('Disabled actions', async ({ page }) => {
   await expect(unsetButton).toBeDisabled()
   await page.getByRole('menuitem', { name: 'Unset' }).hover()
   await expect(
-    page.getByText('Instance must be stopped before boot disk can be changed')
+    page
+      .getByRole('tooltip')
+      .getByText('Instance must be stopped before boot disk can be changed')
   ).toBeVisible()
 
   await expect(detachButton).toBeDisabled()
   await detachButton.hover()
   await expect(
-    page.getByText('Boot disk must be unset before it can be detached')
+    page.getByRole('tooltip').getByText('Boot disk must be unset before it can be detached')
   ).toBeVisible()
   await page.keyboard.press('Escape') // close menu
 
@@ -72,13 +74,17 @@ test('Disabled actions', async ({ page }) => {
   await expect(setButton).toBeDisabled()
   await setButton.hover()
   await expect(
-    page.getByText('Instance must be stopped before boot disk can be changed')
+    page
+      .getByRole('tooltip')
+      .getByText('Instance must be stopped before boot disk can be changed')
   ).toBeVisible()
 
   await expect(detachButton).toBeDisabled()
   await detachButton.hover()
   await expect(
-    page.getByText('Instance must be stopped before disk can be detached')
+    page
+      .getByRole('tooltip')
+      .getByText('Instance must be stopped before disk can be detached')
   ).toBeVisible()
   await page.keyboard.press('Escape') // close menu
 

--- a/test/e2e/instance-networking.e2e.ts
+++ b/test/e2e/instance-networking.e2e.ts
@@ -110,7 +110,9 @@ test('Instance networking tab — NIC table', async ({ page }) => {
   const deleteButton = page.getByRole('menuitem', { name: 'Delete' })
   await expect(deleteButton).toBeDisabled()
   await deleteButton.hover()
-  await expect(page.getByText('The primary interface can’t')).toBeVisible()
+  await expect(
+    page.getByRole('tooltip').getByText('The primary interface can’t')
+  ).toBeVisible()
 
   // close the menu for nic-3, without the next line fails in FF and Safari (but not Chrome)
   await clickRowActions(page, 'nic-3')

--- a/test/e2e/instance.e2e.ts
+++ b/test/e2e/instance.e2e.ts
@@ -78,7 +78,7 @@ test('can start a failed instance', async ({ page }) => {
   await clickRowActions(page, 'db1')
   await page.getByRole('menuitem', { name: 'Start' }).hover()
   await expect(
-    page.getByText('Only stopped or failed instances can be started')
+    page.getByRole('tooltip').getByText('Only stopped or failed instances can be started')
   ).toBeVisible()
   await page.keyboard.press('Escape') // get out of the menu
 

--- a/test/e2e/instance.e2e.ts
+++ b/test/e2e/instance.e2e.ts
@@ -54,8 +54,9 @@ test('shows external IPs on the instances table', async ({ page }) => {
   ).toHaveCount(1)
   // hovering the +1 reveals the other external IP in a tooltip
   await table.getByRole('row', { name: 'db1' }).getByText('+1').hover()
-  await expect(page.getByText('Other external IPs')).toBeVisible()
-  await expect(page.getByText('123.4.56.0')).toBeVisible()
+  const tooltip = page.getByRole('tooltip')
+  await expect(tooltip.getByText('Other external IPs')).toBeVisible()
+  await expect(tooltip.getByText('123.4.56.0')).toBeVisible()
 
   // not-there-yet has three ephemeral IPs, so it shows the first plus a +2 overflow
   await expect(

--- a/test/e2e/ip-pool-silo-config.e2e.ts
+++ b/test/e2e/ip-pool-silo-config.e2e.ts
@@ -52,7 +52,9 @@ test.describe('IP pool configuration: myriad silo (v4-only default)', () => {
     await expect(v6Checkbox).not.toBeChecked()
     await expect(v6Checkbox).toBeDisabled()
     await v6Checkbox.hover()
-    await expect(page.getByText('No IPv6 pools available')).toBeVisible()
+    await expect(
+      page.getByRole('tooltip').getByText('No IPv6 pools available')
+    ).toBeVisible()
 
     // IPv4 pool dropdown should be visible with default pool preselected
     const v4PoolDropdown = page.getByLabel('IPv4 pool')
@@ -230,7 +232,9 @@ test.describe('IP pool configuration: thrax silo (v6-only default)', () => {
     await expect(v4Checkbox).not.toBeChecked()
     await expect(v4Checkbox).toBeDisabled()
     await v4Checkbox.hover()
-    await expect(page.getByText('No IPv4 pools available')).toBeVisible()
+    await expect(
+      page.getByRole('tooltip').getByText('No IPv4 pools available')
+    ).toBeVisible()
     await expect(v6Checkbox).toBeVisible()
     await expect(v6Checkbox).toBeChecked()
 

--- a/test/e2e/system-update.e2e.ts
+++ b/test/e2e/system-update.e2e.ts
@@ -54,7 +54,7 @@ test('Set target release', async ({ page }) => {
   const disabledItem = page.getByRole('menuitem', { name: 'Set as target release' })
   await expect(disabledItem).toBeDisabled()
   await disabledItem.hover()
-  await expect(page.getByText('Already set as target')).toBeVisible()
+  await expect(page.getByRole('tooltip').getByText('Already set as target')).toBeVisible()
   await page.keyboard.press('Escape')
 
   // Upgrade to 18.0.0
@@ -87,7 +87,9 @@ test('Set target release', async ({ page }) => {
   const setTargetItem = page.getByRole('menuitem', { name: 'Set as target release' })
   await expect(setTargetItem).toBeDisabled()
   await setTargetItem.hover()
-  await expect(page.getByText('Cannot set older release as target')).toBeVisible()
+  await expect(
+    page.getByRole('tooltip').getByText('Cannot set older release as target')
+  ).toBeVisible()
 })
 
 test('Cannot downgrade to older release', async ({ page }) => {
@@ -104,7 +106,9 @@ test('Cannot downgrade to older release', async ({ page }) => {
   const setTargetItem = page.getByRole('menuitem', { name: 'Set as target release' })
   await expect(setTargetItem).toBeDisabled()
   await setTargetItem.hover()
-  await expect(page.getByText('Cannot set older release as target')).toBeVisible()
+  await expect(
+    page.getByRole('tooltip').getByText('Cannot set older release as target')
+  ).toBeVisible()
 
   // Verify the target release has NOT changed - still 17.0.0
   await expect(page.getByLabel('Properties table')).toContainText('17.0.0')

--- a/vitest.browser.config.ts
+++ b/vitest.browser.config.ts
@@ -37,6 +37,8 @@ export default defineConfig({
   resolve: { tsconfigPaths: true },
   test: {
     attachmentsDir: 'test-results/vitest/attachments',
+    // Concurrent Playwright contexts make focus-sensitive Firefox interactions flaky.
+    fileParallelism: false,
     include: ['app/**/*.browser.spec.{ts,tsx}'],
     name: 'browser',
     setupFiles: ['test/browser/setup.ts'],


### PR DESCRIPTION
While testing #3332 with VO in Safari I noticed that there is no way to get a screen reader to read a tooltip on a button. It appears this is because they only appear in the a11y tree when the tooltip is open (it appears visually but not to the screen reader for some reason). So instead we add a permanent describedby to the button. It works!

I considered having it reuse the tooltip div as the `sr-only` description when the tooltip is closed to avoid having two copies of the description in the DOM, but basically it seems like Floating UI wants you to do conditional rendering. In order to keep the div around and _not_ conditionally render it, we would instead end up doing kinda gnarly stuff like this:

```tsx
<div
  ref={open ? refs.setFloating : undefined}
  className={open ? 'ox-tooltip …' : 'sr-only'}
  aria-hidden={open ? undefined : true}
>
  {content}
</div>
```

It can work, but it requires a more complicated integration with Floating UI lifecycle stuff. Seems fine to duplicate the div instead and keep the tooltip rendering on the simple happy path.

- https://floating-ui.com/docs/react#anchoring
- https://floating-ui.com/docs/usefloating#whileelementsmounted