### PR TITLE
Update IPv6 parsing

### DIFF
--- a/app/util/ip.spec.ts
+++ b/app/util/ip.spec.ts
@@ -206,6 +206,14 @@ const v6 = [
   '::ffff:255.255.255.255',
   'fe08::7:8',
   'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
+  // embedded IPv4 is allowed with :: in any position and in the full 6-group
+  // form, not just after ::ffff: (console#1939)
+  '2001:db8:3:4:5::192.0.2.33',
+  '1:2:3:4:5:6:192.0.2.33',
+  '::192.0.2.33',
+  '2001:db8::192.0.2.33',
+  '1:2:3:4::5:192.0.2.33',
+  'db8:db8:db8:db8:db8::192.0.2.33',
 ]
 
 test.each(v6)('parseIp catches invalid IPV4 / valid IPV6: %s', (s) => {
@@ -238,10 +246,17 @@ const invalid = [
   '::1:2:3:4:5:6:7:8',
   '1:2:3:4:5:6:7:8::',
   '1:2:3:4:5:6:7:88888',
-  '2001:db8:3:4:5::192.0.2.33', // std::new::Ipv6Net allows this one
+  '1:2:3:4:5:6:7:192.0.2.33', // one group too many before the dotted quad
+  '::1.2.3.4.5',
+  '1:2:3:4:5:6:7:8:1.2.3.4',
   'fe08::7:8%',
   'fe08::7:8i',
   'fe08::7:8interface',
+  // zone IDs are valid in some contexts but std::net::Ipv6Addr rejects them
+  'fe80::1%eth0',
+  'fe80::1%0',
+  'fe80::%eth0',
+  '::1%lo0',
 ]
 
 test.each(invalid)('parseIp catches invalid IP: %s', (s) => {

--- a/app/util/ip.spec.ts
+++ b/app/util/ip.spec.ts
@@ -10,7 +10,7 @@ import { describe, expect, test } from 'vitest'
 
 import type { ExternalIp, IpVersion, UnicastIpPool } from '~/api'
 
-import { getEphemeralIpSlots, parseIp, parseIpNet } from './ip'
+import { getEphemeralIpSlots, toUrlCheckableIpv6, parseIp, parseIpNet } from './ip'
 
 const makePool = (ipVersion: IpVersion, name = `pool-${ipVersion}`): UnicastIpPool => ({
   id: `id-${name}`,
@@ -182,6 +182,22 @@ describe('getEphemeralIpSlots', () => {
 // Small Rust project where we validate that the built-in Ipv4Addr and Ipv6Addr
 // and oxnet's Ipv4Net and Ipv6Net have the same validation behavior as our code.
 // https://github.com/oxidecomputer/test-ip-validation
+
+test.each([
+  ['2001:db8::1', '2001:db8::1'],
+  ['2001:db8:1:2::10.0.0.1', '2001:db8:1:2::0:0'],
+  ['1:2:3:4::10.0.0.1', '1:2:3:4::0:0'],
+  ['::ffff:255.255.255.255', '::ffff:0:0'],
+])('toUrlCheckableIpv6 converts %s to %s', (ip, expected) => {
+  expect(toUrlCheckableIpv6(ip)).toBe(expected)
+})
+
+test.each(['::ffff:1.2.3.04', '::251.240.044.17', '1::2:', '::1:', '1.2.3.4::', '1.2.3.4'])(
+  'toUrlCheckableIpv6 rejects %s',
+  (ip) => {
+    expect(toUrlCheckableIpv6(ip)).toBeNull()
+  }
+)
 
 const v4 = ['123.4.56.7', '1.2.3.4']
 

--- a/app/util/ip.spec.ts
+++ b/app/util/ip.spec.ts
@@ -257,6 +257,16 @@ const invalid = [
   'fe80::1%0',
   'fe80::%eth0',
   '::1%lo0',
+  // We validate v6 by handing the address to the URL parser as a bracketed
+  // host, so a `]` plus a URL continuation could otherwise parse as port, path,
+  // query, or fragment and come back valid. Zod's z.ipv6() has this bug.
+  '::1]:80',
+  '::1]:80/foo',
+  '::1]#x',
+  '::1]?q=1',
+  '::1]:0/../x',
+  '::1]@evil.com',
+  '::1]',
 ]
 
 test.each(invalid)('parseIp catches invalid IP: %s', (s) => {

--- a/app/util/ip.spec.ts
+++ b/app/util/ip.spec.ts
@@ -214,6 +214,10 @@ const v6 = [
   '2001:db8::192.0.2.33',
   '1:2:3:4::5:192.0.2.33',
   'db8:db8:db8:db8:db8::192.0.2.33',
+  // WebKit's URL parser wrongly rejects embedded IPv4 where :: expands to
+  // exactly two groups; isIpv6 validates the quad itself so these still pass
+  '2001:db8:1:2::10.0.0.1',
+  '1:2:3:4::10.0.0.1',
 ]
 
 test.each(v6)('parseIp catches invalid IPV4 / valid IPV6: %s', (s) => {
@@ -267,6 +271,12 @@ const invalid = [
   '::1]:0/../x',
   '::1]@evil.com',
   '::1]',
+  // engine quirks handled explicitly in isIpv6: Chrome's URL parser accepts
+  // leading-zero octets in the embedded quad; WebKit's accepts a trailing colon
+  '::ffff:1.2.3.04',
+  '::251.240.044.17',
+  '1::2:',
+  '::1:',
 ]
 
 test.each(invalid)('parseIp catches invalid IP: %s', (s) => {

--- a/app/util/ip.ts
+++ b/app/util/ip.ts
@@ -27,34 +27,41 @@ const IPV4_REGEX =
 
 const IPV6_CHARS_REGEX = /^[0-9a-f:.]+$/i
 
-function isIpv6(ip: string): boolean {
-  if (!ip.includes(':') || !IPV6_CHARS_REGEX.test(ip)) return false
+/**
+ * Convert an IPv6 candidate to a form all browsers' URL parsers judge
+ * correctly, or return null if it's invalid in a way we can detect up front.
+ * The result is only structurally equivalent to the input (an embedded IPv4
+ * quad becomes placeholder groups) — use it for validity checking only, never
+ * as an address.
+ */
+export function toUrlCheckableIpv6(ip: string): string | null {
+  if (!ip.includes(':') || !IPV6_CHARS_REGEX.test(ip)) return null
 
-  // Browser URL parsers deviate from the URL spec (and from std::net) on two
-  // constructs, so handle both before the string reaches new URL():
-  //
-  // 1. WebKit accepts a trailing single colon (`1::2:`), which std::net rejects.
-  if (/[^:]:$/.test(ip)) return false
+  // WebKit accepts a trailing single colon (`1::2:`), which std::net rejects.
+  if (/[^:]:$/.test(ip)) return null
 
-  // 2. Embedded IPv4: Chrome accepts leading-zero octets (`::ffff:1.2.3.04`)
-  //    and WebKit rejects valid addresses where `::` expands to exactly two
-  //    groups (`2001:db8:1:2::10.0.0.1`). Validate the dotted quad ourselves
-  //    with the same strict rules std::net uses, then stand in two hex groups
-  //    for it so the URL parser only sees hex, where all engines agree.
-  let hexOnly = ip
+  // URL parsers disagree on embedded IPv4, so validate the dotted quad and
+  // replace it with two placeholder groups before handing the address to URL.
   const lastColon = ip.lastIndexOf(':')
   const quad = ip.slice(lastColon + 1)
   if (quad.includes('.')) {
-    if (!IPV4_REGEX.test(quad)) return false
-    hexOnly = ip.slice(0, lastColon + 1) + '0:0' // a quad occupies two groups
+    if (!IPV4_REGEX.test(quad)) return null
+    return ip.slice(0, lastColon + 1) + '0:0'
   } else if (ip.includes('.')) {
-    return false // dots are only valid in a trailing IPv4 quad
+    return null // dots are only valid in a trailing IPv4 quad
   }
+
+  return ip
+}
+
+function isIpv6(ip: string): boolean {
+  const normalizedIp = toUrlCheckableIpv6(ip)
+  if (normalizedIp === null) return false
 
   try {
     // the brackets force the parser to treat the host as an IPv6 literal —
     // without them, non-addresses like domain names would parse fine
-    new URL(`http://[${hexOnly}]`)
+    new URL(`http://[${normalizedIp}]`)
     return true
   } catch {
     return false

--- a/app/util/ip.ts
+++ b/app/util/ip.ts
@@ -18,18 +18,30 @@ export const orderIps = (ips: ExternalIp[]) => R.sortBy(ips, (a) => IP_ORDER[a.k
 // Borrowed from Valibot. I tried some from Zod and an O'Reilly regex cookbook
 // but they didn't match results with std::net on simple test cases
 // https://github.com/fabian-hiller/valibot/blob/2554aea5/library/src/regex.ts#L43-L54
-
 const IPV4_REGEX =
   /^(?:(?:[1-9]|1\d|2[0-4])?\d|25[0-5])(?:\.(?:(?:[1-9]|1\d|2[0-4])?\d|25[0-5])){3}$/u
 
-const IPV6_REGEX =
-  /^(?:(?:[\da-f]{1,4}:){7}[\da-f]{1,4}|(?:[\da-f]{1,4}:){1,7}:|(?:[\da-f]{1,4}:){1,6}:[\da-f]{1,4}|(?:[\da-f]{1,4}:){1,5}(?::[\da-f]{1,4}){1,2}|(?:[\da-f]{1,4}:){1,4}(?::[\da-f]{1,4}){1,3}|(?:[\da-f]{1,4}:){1,3}(?::[\da-f]{1,4}){1,4}|(?:[\da-f]{1,4}:){1,2}(?::[\da-f]{1,4}){1,5}|[\da-f]{1,4}:(?::[\da-f]{1,4}){1,6}|:(?:(?::[\da-f]{1,4}){1,7}|:)|fe80:(?::[\da-f]{0,4}){0,4}%[\da-z]+|::(?:f{4}(?::0{1,4})?:)?(?:(?:25[0-5]|(?:2[0-4]|1?\d)?\d)\.){3}(?:25[0-5]|(?:2[0-4]|1?\d)?\d)|(?:[\da-f]{1,4}:){1,4}:(?:(?:25[0-5]|(?:2[0-4]|1?\d)?\d)\.){3}(?:25[0-5]|(?:2[0-4]|1?\d)?\d))$/iu
+// IPv6 is more complex; use the WHATWG URL parser rather than a regex to determine validity.
+// Restrict the charset first so the parser only ever sees a bare host: `]`, `/`,
+// `%`, and whitespace would otherwise let non-addresses through as port, path, or zone.
+
+const IPV6_CHARS_REGEX = /^[0-9a-f:.]+$/i
+
+function isIpv6(ip: string): boolean {
+  if (!ip.includes(':') || !IPV6_CHARS_REGEX.test(ip)) return false
+  try {
+    new URL(`http://[${ip}]`)
+    return true
+  } catch {
+    return false
+  }
+}
 
 type ParsedIp = { type: IpVersion; address: string } | { type: 'error'; message: string }
 
 export function parseIp(ip: string): ParsedIp {
   if (IPV4_REGEX.test(ip)) return { type: 'v4', address: ip }
-  if (IPV6_REGEX.test(ip)) return { type: 'v6', address: ip }
+  if (isIpv6(ip)) return { type: 'v6', address: ip }
   return { type: 'error', message: 'Not a valid IP address' }
 }
 

--- a/app/util/ip.ts
+++ b/app/util/ip.ts
@@ -29,8 +29,32 @@ const IPV6_CHARS_REGEX = /^[0-9a-f:.]+$/i
 
 function isIpv6(ip: string): boolean {
   if (!ip.includes(':') || !IPV6_CHARS_REGEX.test(ip)) return false
+
+  // Browser URL parsers deviate from the URL spec (and from std::net) on two
+  // constructs, so handle both before the string reaches new URL():
+  //
+  // 1. WebKit accepts a trailing single colon (`1::2:`), which std::net rejects.
+  if (/[^:]:$/.test(ip)) return false
+
+  // 2. Embedded IPv4: Chrome accepts leading-zero octets (`::ffff:1.2.3.04`)
+  //    and WebKit rejects valid addresses where `::` expands to exactly two
+  //    groups (`2001:db8:1:2::10.0.0.1`). Validate the dotted quad ourselves
+  //    with the same strict rules std::net uses, then stand in two hex groups
+  //    for it so the URL parser only sees hex, where all engines agree.
+  let hexOnly = ip
+  const lastColon = ip.lastIndexOf(':')
+  const quad = ip.slice(lastColon + 1)
+  if (quad.includes('.')) {
+    if (!IPV4_REGEX.test(quad)) return false
+    hexOnly = ip.slice(0, lastColon + 1) + '0:0' // a quad occupies two groups
+  } else if (ip.includes('.')) {
+    return false // dots are only valid in a trailing IPv4 quad
+  }
+
   try {
-    new URL(`http://[${ip}]`)
+    // the brackets force the parser to treat the host as an IPv6 literal —
+    // without them, non-addresses like domain names would parse fine
+    new URL(`http://[${hexOnly}]`)
     return true
   } catch {
     return false

--- a/vitest.browser.config.ts
+++ b/vitest.browser.config.ts
@@ -30,14 +30,14 @@ const pressComboboxKey: BrowserCommand<[label: string, key: string]> = async (
 
 export default defineConfig({
   optimizeDeps: {
-    entries: ['app/**/*.browser.spec.{ts,tsx}'],
+    entries: ['app/**/*.browser.spec.{ts,tsx}', 'app/util/ip.spec.ts'],
     include: ['react-router'],
   },
   plugins: [tailwindcss(), react()],
   resolve: { tsconfigPaths: true },
   test: {
     attachmentsDir: 'test-results/vitest/attachments',
-    include: ['app/**/*.browser.spec.{ts,tsx}'],
+    include: ['app/**/*.browser.spec.{ts,tsx}', 'app/util/ip.spec.ts'],
     name: 'browser',
     setupFiles: ['test/browser/setup.ts'],
     browser: {


### PR DESCRIPTION
This updates our parsing / validating of IPv6 addresses, to make them more compliant with `std::net::Ipv6Addr` parsing. Instead of a regex, it uses the `new URL()` function as part of the evaluation.

Closes #1939 