### PR TITLE
tests: scope MSW server and db reset to the one spec that uses them

### DIFF
--- a/app/api/__tests__/client.spec.ts
+++ b/app/api/__tests__/client.spec.ts
@@ -5,13 +5,24 @@
  *
  * Copyright Oxide Computer Company
  */
-import { describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 
 import { project } from '@oxide/api-mocks'
 
 import { api, q } from '..'
-import { overrideOnce } from '../../../test/unit/server'
+import { resetDb } from '../../../mock-api/msw/db'
+import { overrideOnce, server } from '../../../test/unit/server'
 import { processServerError } from '../errors'
+
+// These are the only unit tests that make requests, so the MSW server
+// lifecycle lives here rather than in the global setup file — resetDb clones
+// the whole mock db, which is too slow to run after every test suite-wide.
+beforeAll(() => server.listen())
+afterEach(() => {
+  resetDb()
+  server.resetHandlers()
+})
+afterAll(() => server.close())
 
 // useApiQuery and useApiMutation are almost entirely typed wrappers around React
 // Query's useQuery and useMutation, so they're exercised end-to-end by the

--- a/app/api/__tests__/safety.spec.ts
+++ b/app/api/__tests__/safety.spec.ts
@@ -67,13 +67,13 @@ it('mock-api is only referenced in test files', () => {
     [
       "AGENTS.md",
       "README.md",
+      "app/api/__tests__/client.spec.ts",
       "app/main.tsx",
       "app/msw-mock-api.ts",
       "docs/mock-api-differences.md",
       "package.json",
       "test/e2e/utils.ts",
       "test/unit/server.ts",
-      "test/unit/setup.ts",
       "tools/start_mock_api.ts",
       "tsconfig.json",
     ]

--- a/test/unit/setup.ts
+++ b/test/unit/setup.ts
@@ -12,10 +12,7 @@
  */
 import '@testing-library/jest-dom/vitest'
 import { cleanup } from '@testing-library/react'
-import { afterAll, afterEach, beforeAll, vi } from 'vitest'
-
-import { resetDb } from '../../mock-api/msw/db'
-import { server } from './server'
+import { afterEach, vi } from 'vitest'
 
 // xterm calls this when it's imported, so defining it here suppresses
 // an error that the method is not implemented
@@ -43,10 +40,4 @@ globalThis.ResizeObserver = class {
   disconnect() {}
 }
 
-beforeAll(() => server.listen())
-afterEach(() => {
-  resetDb()
-  cleanup()
-  server.resetHandlers()
-})
-afterAll(() => server.close())
+afterEach(() => cleanup())


### PR DESCRIPTION
We were curious why node tests would take longer than browser tests. Turns out we were setting up and tearing down the mock API and resetting the database after every unit test. This PR moves that out of global setup into the one file that actually needs it.

### Before

`npm test run -- ip`

<img width="492" height="91" alt="image" src="https://github.com/user-attachments/assets/3f6549f3-0a1a-4e67-b6ac-8483b60a5491" />

### After

`npm test run -- ip`

<img width="492" height="89" alt="image" src="https://github.com/user-attachments/assets/fe905db6-66b5-4c6e-9535-10cc6a9c0d7c" />
