### PR TITLE
Don't scroll page to top when opening or closing a side modal

### DIFF
--- a/app/hooks/use-crumbs.ts
+++ b/app/hooks/use-crumbs.ts
@@ -5,7 +5,7 @@
  *
  * Copyright Oxide Computer Company
  */
-import { useMatches, type Params, type UIMatch } from 'react-router'
+import { useLocation, useMatches, type Params, type UIMatch } from 'react-router'
 
 import { invariant } from '~/util/invariant'
 
@@ -80,3 +80,15 @@ export const useCrumbs = () => matchesToCrumbs(useMatches())
  * this one is true.
  */
 export const useIsSideModalRoute = () => useCrumbs().some((c) => c.titleOnly)
+
+/**
+ * Path of the page the current location displays, i.e., where its nav
+ * breadcrumbs point. For a side modal route this is the parent page it renders
+ * on top of — side modals are marked `titleOnly` precisely because the page
+ * underneath doesn't change. Falls back to the pathname for crumbless routes.
+ */
+export function usePagePath() {
+  const { pathname } = useLocation()
+  const pageCrumb = useCrumbs().findLast((c) => !c.titleOnly)
+  return pageCrumb?.path ?? pathname
+}

--- a/app/hooks/use-scroll-restoration.ts
+++ b/app/hooks/use-scroll-restoration.ts
@@ -46,15 +46,22 @@ export function useScrollRestoration() {
   useEffect(() => {
     // opt out of native scroll restoration, it conflicts with ours
     window.history.scrollRestoration = 'manual'
+
+    // idle + new key = we just landed somewhere (or this is the initial render)
+    const landed = state === 'idle' && prev.current?.key !== key
+
+    // underlying page didn't change, which either means the nav was opening
+    // or closing a side modal, a query param tab change, or clicking the
+    // breadcrumb for the page you're already on
+    const samePage = prev.current?.page === page
+
     if (state === 'loading') {
       // nav in flight: save current scroll under the outgoing location's key
       setScrollPosition(key, window.scrollY)
-    } else if (state === 'idle' && prev.current?.key !== key) {
-      // we've landed on a page
-      if (prev.current?.page === page) {
-        // underlying page didn't change, which means the nav was opening or
-        // closing a side modal. leave scroll alone, record under the new key
-        // so it can be restored on forward/back
+    } else if (landed) {
+      if (samePage) {
+        // leave scroll alone, record under the new key so it can be restored
+        // on forward/back
         setScrollPosition(key, window.scrollY)
       } else {
         // landed on a new page: restore its saved scroll, or 0 if none saved

--- a/app/hooks/use-scroll-restoration.ts
+++ b/app/hooks/use-scroll-restoration.ts
@@ -5,8 +5,10 @@
  *
  * Copyright Oxide Computer Company
  */
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { useLocation, useNavigation } from 'react-router'
+
+import { usePagePath } from './use-crumbs'
 
 function getScrollPosition(key: string) {
   const pos = window.sessionStorage.getItem(key)
@@ -33,15 +35,36 @@ function setScrollPosition(key: string, pos: number) {
 export function useScrollRestoration() {
   const key = `scroll-position-${useLocation().key}`
   const { state } = useNavigation()
+  // The page on screen at this location: a side modal route renders its parent
+  // page underneath, so it counts as that page. Navigating within the same
+  // page (opening or closing a side modal over it) shouldn't move the scroll.
+  const page = usePagePath()
+  // last committed location, tracked at idle. We can't track this in the
+  // loading state because a navigation whose loader data is already cached
+  // can complete without ever rendering with state === 'loading'.
+  const prev = useRef<{ key: string; page: string } | null>(null)
   useEffect(() => {
     // opt out of the browser's native scroll restoration so it doesn't jump
     // the still-visible old page to the new page's saved position on POP,
     // before the new route's loader resolves. We restore manually below.
     window.history.scrollRestoration = 'manual'
     if (state === 'loading') {
+      // during a navigation, location still reflects the old route
       setScrollPosition(key, window.scrollY)
-    } else if (state === 'idle') {
-      window.scrollTo(0, getScrollPosition(key))
+    } else if (state === 'idle' && prev.current?.key !== key) {
+      // both checks are needed: key changes on every nav, including same-page
+      // ones like opening a side modal, so key says we just landed on a new
+      // location (or this is the initial render) and page decides whether the
+      // nav stayed within the same page
+      if (prev.current?.page === page) {
+        // same page, new location (opened a side modal): leave the scroll alone
+        // and record it under the new location's key so back/forward to it
+        // restores correctly
+        setScrollPosition(key, window.scrollY)
+      } else {
+        window.scrollTo(0, getScrollPosition(key))
+      }
     }
-  }, [key, state])
+    if (state === 'idle') prev.current = { key, page }
+  }, [key, state, page])
 }

--- a/app/hooks/use-scroll-restoration.ts
+++ b/app/hooks/use-scroll-restoration.ts
@@ -35,33 +35,29 @@ function setScrollPosition(key: string, pos: number) {
 export function useScrollRestoration() {
   const key = `scroll-position-${useLocation().key}`
   const { state } = useNavigation()
-  // The page on screen at this location: a side modal route renders its parent
-  // page underneath, so it counts as that page. Navigating within the same
-  // page (opening or closing a side modal over it) shouldn't move the scroll.
+  // page path looks at the page under a side modal, which we use to distinguish
+  // modal open/close (which shouldn't reset scroll) from full page navs (which
+  // should)
   const page = usePagePath()
-  // last committed location, tracked at idle. We can't track this in the
-  // loading state because a navigation whose loader data is already cached
-  // can complete without ever rendering with state === 'loading'.
+  // last committed location, tracked at idle. We can't track it during
+  // 'loading' because a nav with cached loader data can complete without ever
+  // hitting state === 'loading'.
   const prev = useRef<{ key: string; page: string } | null>(null)
   useEffect(() => {
-    // opt out of the browser's native scroll restoration so it doesn't jump
-    // the still-visible old page to the new page's saved position on POP,
-    // before the new route's loader resolves. We restore manually below.
+    // opt out of native scroll restoration, it conflicts with ours
     window.history.scrollRestoration = 'manual'
     if (state === 'loading') {
-      // during a navigation, location still reflects the old route
+      // nav in flight: save current scroll under the outgoing location's key
       setScrollPosition(key, window.scrollY)
     } else if (state === 'idle' && prev.current?.key !== key) {
-      // both checks are needed: key changes on every nav, including same-page
-      // ones like opening a side modal, so key says we just landed on a new
-      // location (or this is the initial render) and page decides whether the
-      // nav stayed within the same page
+      // we've landed on a page
       if (prev.current?.page === page) {
-        // same page, new location (opened a side modal): leave the scroll alone
-        // and record it under the new location's key so back/forward to it
-        // restores correctly
+        // underlying page didn't change, which means the nav was opening or
+        // closing a side modal. leave scroll alone, record under the new key
+        // so it can be restored on forward/back
         setScrollPosition(key, window.scrollY)
       } else {
+        // landed on a new page: restore its saved scroll, or 0 if none saved
         window.scrollTo(0, getScrollPosition(key))
       }
     }

--- a/app/routes.tsx
+++ b/app/routes.tsx
@@ -446,7 +446,14 @@ export const routes = createRoutesFromElements(
                     element={null}
                     handle={{ crumb: 'Firewall Rules' }}
                   />
-                  <Route element={null} handle={{ crumb: 'Firewall Rules' }}>
+                  <Route
+                    element={null}
+                    // path makes crumb link straight to the tab instead of
+                    // bouncing through the redirect at the VPC root
+                    handle={makeCrumb('Firewall Rules', (p) =>
+                      pb.vpcFirewallRules(getVpcSelector(p))
+                    )}
+                  >
                     <Route
                       path="firewall-rules-new/:rule?"
                       lazy={() => import('./forms/firewall-rules-create').then(convert)}

--- a/app/util/__snapshots__/path-builder.spec.ts.snap
+++ b/app/util/__snapshots__/path-builder.spec.ts.snap
@@ -960,7 +960,7 @@ exports[`breadcrumbs 2`] = `
     },
     {
       "label": "Firewall Rules",
-      "path": "/projects/p/vpcs/v/",
+      "path": "/projects/p/vpcs/v/firewall-rules",
     },
   ],
   "vpcFirewallRuleEdit (/projects/p/vpcs/v/firewall-rules/fr/edit)": [
@@ -982,7 +982,7 @@ exports[`breadcrumbs 2`] = `
     },
     {
       "label": "Firewall Rules",
-      "path": "/projects/p/vpcs/v/",
+      "path": "/projects/p/vpcs/v/firewall-rules",
     },
   ],
   "vpcFirewallRules (/projects/p/vpcs/v/firewall-rules)": [
@@ -1026,7 +1026,7 @@ exports[`breadcrumbs 2`] = `
     },
     {
       "label": "Firewall Rules",
-      "path": "/projects/p/vpcs/v/",
+      "path": "/projects/p/vpcs/v/firewall-rules",
     },
   ],
   "vpcInternetGateway (/projects/p/vpcs/v/internet-gateways/g)": [

--- a/test/e2e/route-announcer.e2e.ts
+++ b/test/e2e/route-announcer.e2e.ts
@@ -15,7 +15,7 @@ const announcements = (page: Page) =>
 
 test('route announcer', async ({ page }) => {
   await page.goto('/projects')
-  await page.getByRole('heading', { name: 'Projects' }).waitFor()
+  await expect(page.getByRole('heading', { name: 'Projects' })).toBeVisible()
 
   // nothing on first load — the browser already announced the page
   await expect(announcements(page)).toHaveCount(0)

--- a/test/e2e/scroll-restore.e2e.ts
+++ b/test/e2e/scroll-restore.e2e.ts
@@ -50,3 +50,77 @@ test('scroll restore', async ({ page }) => {
   await expect(page).toHaveURL('/projects/mock-project/snapshots')
   await expectScrollTop(page, 0)
 })
+
+// https://github.com/oxidecomputer/console/issues/3321
+test('opening and closing side modal preserves scroll', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 500 })
+
+  await page.goto('/projects/mock-project/disks')
+  await page.getByRole('heading', { name: 'Disks' }).waitFor()
+
+  // click the last disk in the table. clicking auto-scrolls it into view, so
+  // read the resulting scroll position as the baseline rather than setting one
+  const lastDisk = page
+    .locator('table')
+    .getByRole('link', { name: /^disk-/ })
+    .last()
+  await lastDisk.scrollIntoViewIfNeeded()
+  const baseline = await page.evaluate(() => window.scrollY)
+  expect(baseline).toBeGreaterThan(0)
+
+  // opening the detail side modal doesn't scroll the page underneath
+  await lastDisk.click()
+  await expect(page.getByRole('dialog')).toBeVisible()
+  await expectScrollTop(page, baseline)
+
+  // closing it doesn't either
+  await page.keyboard.press('Escape')
+  await expect(page.getByRole('dialog')).toBeHidden()
+  await expectScrollTop(page, baseline)
+})
+
+// this modal route is trickier than the others: it hangs off a pathless crumb
+// wrapper route rather than being a direct child of the page route
+test('opening firewall rule modal preserves scroll', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 300 })
+
+  await page.goto('/projects/mock-project/vpcs/default/firewall-rules')
+  await page.getByRole('tab', { name: 'Firewall Rules' }).waitFor()
+  await scrollTo(page, 100)
+  await expectScrollTop(page, 100)
+
+  // clicking auto-scrolls the link into view, so read the resulting scroll
+  // position as the baseline rather than assuming it stays at 100
+  const newRuleLink = page.getByRole('link', { name: 'New rule' })
+  await newRuleLink.scrollIntoViewIfNeeded()
+  const baseline = await page.evaluate(() => window.scrollY)
+  expect(baseline).toBeGreaterThan(0)
+
+  await newRuleLink.click()
+  await expect(page.getByRole('dialog', { name: 'Add firewall rule' })).toBeVisible()
+  await expectScrollTop(page, baseline)
+
+  await page.keyboard.press('Escape')
+  await expect(page.getByRole('dialog')).toBeHidden()
+  await expectScrollTop(page, baseline)
+})
+
+test('navigating from a side modal to a new page resets scroll', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 300 })
+
+  await page.goto('/projects/mock-project/vpcs')
+  await page.getByRole('heading', { name: 'VPCs' }).waitFor()
+  await scrollTo(page, 100)
+  await expectScrollTop(page, 100)
+
+  await page.getByRole('link', { name: 'New VPC' }).click()
+  await expect(page.getByRole('dialog', { name: 'Create VPC' })).toBeVisible()
+  await expectScrollTop(page, 100)
+
+  await page.getByRole('textbox', { name: 'Name', exact: true }).fill('scroll-test-vpc')
+  await page.getByRole('textbox', { name: 'DNS name' }).fill('scroll-test-vpc')
+  await page.getByRole('button', { name: 'Create VPC' }).click()
+
+  await expect(page.getByRole('heading', { name: 'scroll-test-vpc' })).toBeVisible()
+  await expectScrollTop(page, 0)
+})

--- a/test/e2e/scroll-restore.e2e.ts
+++ b/test/e2e/scroll-restore.e2e.ts
@@ -58,6 +58,14 @@ test('opening and closing side modal preserves scroll', async ({ page }) => {
   await page.goto('/projects/mock-project/disks')
   await expect(page.getByRole('heading', { name: 'Disks' })).toBeVisible()
 
+  // visit snapshots and come back so its data is cached: the later nav to it
+  // can then complete without rendering a loading state, which would otherwise
+  // save the scroll position and mask a failure to record it at modal close
+  await page.getByRole('link', { name: 'Snapshots' }).click()
+  await expect(page.getByRole('heading', { name: 'Snapshots' })).toBeVisible()
+  await page.getByRole('link', { name: 'Disks' }).click()
+  await expect(page.getByRole('heading', { name: 'Disks' })).toBeVisible()
+
   // click the last disk in the table. clicking auto-scrolls it into view, so
   // read the resulting scroll position as the baseline rather than setting one
   const lastDisk = page
@@ -76,6 +84,13 @@ test('opening and closing side modal preserves scroll', async ({ page }) => {
   // closing it doesn't either
   await page.keyboard.press('Escape')
   await expect(page.getByRole('dialog')).toBeHidden()
+  await expectScrollTop(page, baseline)
+
+  // nav away and back: the scroll recorded at modal close is restored
+  await page.getByRole('link', { name: 'Snapshots' }).click()
+  await expectScrollTop(page, 0)
+  await page.goBack()
+  await expect(page).toHaveURL('/projects/mock-project/disks')
   await expectScrollTop(page, baseline)
 })
 
@@ -123,4 +138,9 @@ test('navigating from a side modal to a new page resets scroll', async ({ page }
 
   await expect(page.getByRole('heading', { name: 'scroll-test-vpc' })).toBeVisible()
   await expectScrollTop(page, 0)
+
+  // going back reopens the modal with the underlying page's scroll restored
+  await page.goBack()
+  await expect(page.getByRole('dialog', { name: 'Create VPC' })).toBeVisible()
+  await expectScrollTop(page, 100)
 })

--- a/test/e2e/scroll-restore.e2e.ts
+++ b/test/e2e/scroll-restore.e2e.ts
@@ -16,7 +16,7 @@ test('scroll restore', async ({ page }) => {
   // nav to disks and scroll it
   await page.goto('/projects/mock-project/disks')
   // wait for content to render so the page is tall enough to scroll
-  await page.getByRole('heading', { name: 'Disks' }).waitFor()
+  await expect(page.getByRole('heading', { name: 'Disks' })).toBeVisible()
   await expectScrollTop(page, 0)
   await scrollTo(page, 143)
 
@@ -56,7 +56,7 @@ test('opening and closing side modal preserves scroll', async ({ page }) => {
   await page.setViewportSize({ width: 1280, height: 500 })
 
   await page.goto('/projects/mock-project/disks')
-  await page.getByRole('heading', { name: 'Disks' }).waitFor()
+  await expect(page.getByRole('heading', { name: 'Disks' })).toBeVisible()
 
   // click the last disk in the table. clicking auto-scrolls it into view, so
   // read the resulting scroll position as the baseline rather than setting one
@@ -85,7 +85,7 @@ test('opening firewall rule modal preserves scroll', async ({ page }) => {
   await page.setViewportSize({ width: 1280, height: 300 })
 
   await page.goto('/projects/mock-project/vpcs/default/firewall-rules')
-  await page.getByRole('tab', { name: 'Firewall Rules' }).waitFor()
+  await expect(page.getByRole('tab', { name: 'Firewall Rules' })).toBeVisible()
   await scrollTo(page, 100)
   await expectScrollTop(page, 100)
 
@@ -109,7 +109,7 @@ test('navigating from a side modal to a new page resets scroll', async ({ page }
   await page.setViewportSize({ width: 1280, height: 300 })
 
   await page.goto('/projects/mock-project/vpcs')
-  await page.getByRole('heading', { name: 'VPCs' }).waitFor()
+  await expect(page.getByRole('heading', { name: 'VPCs' })).toBeVisible()
   await scrollTo(page, 100)
   await expectScrollTop(page, 100)
 


### PR DESCRIPTION
Closes #3321

Because side modals get their own routes, and the scroll height cache is keyed (in part) by route, opening a side modal counts as a new page with no saved scroll height, so it scrolls the document to top. The fix is to handle the modal scenario specially by opting out of resetting scroll when we switch to a new location that has the same underlying page path as the previous one. 


https://github.com/user-attachments/assets/af40dae5-7065-4599-be55-a9dd7ae7299e



### Example flows

Each of these scenarios is covered by e2e tests.

The underlying "page path" for a location is the path of the last non-`titleOnly` crumb, i.e., where the nav breadcrumbs point: a regular page's own path, or for a side modal, the path of the page under it. When a nav starts, we save the current scroll under the outgoing location's key. When it completes, if the page path changed we scroll to the new location's cached position (0 if none); if it didn't (side modal open/close), we leave the scroll alone and just record it under the new key so back/forward still works. 

#### Normal page → page nav (`…/disks` → `…/snapshots`, then back)

| Step                                                  | Location           | Page path     | Cache          | Scroll  |
| ----------------------------------------------------- | ------------------ | ------------- | -------------- | ------- |
| Scroll the disks page                                 | `…/disks` (k1)     | `…/disks`     |                | 143     |
| Click Snapshots: nav starts                           | `…/disks` (k1)     | `…/disks`     | k1: 143        | 143     |
| Nav completes: page changed → scroll to cached (none) | `…/snapshots` (k2) | `…/snapshots` | k1: 143        | 0       |
| Back: nav starts                                      | `…/snapshots` (k2) | `…/snapshots` | k1: 143, k2: 0 | 0       |
| Nav completes: page changed → scroll to cached        | `…/disks` (k1)     | `…/disks`     | k1: 143, k2: 0 | **143** |

#### Page → modal → page (open the New disk form, then dismiss it)

| Step                                                          | Location           | Page path | Cache                     | Scroll  |
| ------------------------------------------------------------- | ------------------ | --------- | ------------------------- | ------- |
| Scroll the disks page                                         | `…/disks` (k1)     | `…/disks` |                           | 143     |
| Click New disk: nav starts                                    | `…/disks` (k1)     | `…/disks` | k1: 143                   | 143     |
| Nav completes: same page → leave scroll, record under new key | `…/disks-new` (k2) | `…/disks` | k1: 143, k2: 143          | **143** |
| Dismiss: nav starts                                           | `…/disks-new` (k2) | `…/disks` | k1: 143, k2: 143          | 143     |
| Nav completes: same page → leave scroll, record under new key | `…/disks` (k3)     | `…/disks` | k1: 143, k2: 143, k3: 143 | **143** |

#### Modal submit → new page (create a VPC, land on VPC detail page)

| Step                                                  | Location             | Page path       | Cache            | Scroll |
| ----------------------------------------------------- | -------------------- | --------------- | ---------------- | ------ |
| Modal open over scrolled VPCs page                    | `…/vpcs-new` (k2)    | `…/vpcs`        | k1: 143, k2: 143 | 143    |
| Submit: nav starts                                    | `…/vpcs-new` (k2)    | `…/vpcs`        | k1: 143, k2: 143 | 143    |
| Nav completes: page changed → scroll to cached (none) | `…/vpcs/my-vpc` (k3) | `…/vpcs/my-vpc` | k1: 143, k2: 143 | **0**  |