### PR TITLE
Fix active tab hover background color

### DIFF
--- a/app/ui/styles/components/Tabs.css
+++ b/app/ui/styles/components/Tabs.css
@@ -35,6 +35,10 @@
   @apply bg-hover;
 }
 
+.ox-tabs-list .ox-tab[data-active]:hover > * {
+  @apply bg-accent-hover;
+}
+
 /* Active states */
 .ox-tab[data-active] {
   @apply text-accent border-accent light:border-green-800 light:text-raise;


### PR DESCRIPTION
Closes #3341 

Seems it was accidentally deleted here: https://github.com/oxidecomputer/console/pull/3061/changes#diff-57ea12aef20e3ff5f985b4755178e4fa2c5fe0bcd362c4a38d9c0b00cc7110c1R40

<img width="266" height="80" alt="image" src="https://github.com/user-attachments/assets/7ee096aa-4f43-473e-947c-bc3a354dcab7" />
