### PR TITLE
Fix submit button loading state race

### DIFF
--- a/app/ui/lib/Button.tsx
+++ b/app/ui/lib/Button.tsx
@@ -125,7 +125,7 @@ export const Button = ({
         )}
         <span
           className={cn(
-            'flex items-center transition-[opacity,translate] duration-300 ease-(--button-loading-easing) motion-reduce:transition-none',
+            'button-content flex items-center',
             loading ? 'translate-y-[25px] opacity-0' : 'translate-y-0 opacity-100',
             innerClassName
           )}

--- a/app/ui/lib/Button.tsx
+++ b/app/ui/lib/Button.tsx
@@ -6,7 +6,6 @@
  * Copyright Oxide Computer Company
  */
 import cn from 'classnames'
-import * as m from 'motion/react-m'
 import { type MouseEventHandler, type ReactNode } from 'react'
 
 import { type BadgeColor } from '@oxide/design-system/ui'
@@ -120,25 +119,19 @@ export const Button = ({
         {...rest}
       >
         {loading && (
-          <m.span
-            animate={{ opacity: 1, y: '-50%', x: '-50%' }}
-            initial={{ opacity: 0, y: 'calc(-50% - 25px)', x: '-50%' }}
-            transition={{ type: 'spring', duration: 0.3, bounce: 0 }}
-            className="absolute top-1/2 left-1/2 flex items-center justify-center"
-          >
+          <span className="button-spinner-in absolute top-1/2 left-1/2 flex -translate-x-1/2 -translate-y-1/2 items-center justify-center">
             <Spinner variant={variantToBadgeColorMap[variant || 'primary']} />
-          </m.span>
+          </span>
         )}
-        <m.span
-          className={cn('flex items-center', innerClassName)}
-          animate={{
-            opacity: loading ? 0 : 1,
-            y: loading ? 25 : 0,
-          }}
-          transition={{ type: 'spring', duration: 0.3, bounce: 0 }}
+        <span
+          className={cn(
+            'flex items-center transition-[opacity,translate] duration-300 ease-(--button-loading-easing) motion-reduce:transition-none',
+            loading ? 'translate-y-[25px] opacity-0' : 'translate-y-0 opacity-100',
+            innerClassName
+          )}
         >
           {children}
-        </m.span>
+        </span>
       </button>
     </Wrap>
   )

--- a/app/ui/styles/components/button.css
+++ b/app/ui/styles/components/button.css
@@ -8,6 +8,8 @@
 
 .ox-button {
   @apply relative;
+  /* Approximates Motion's { type: 'spring', duration: 0.3, bounce: 0 }. */
+  --button-loading-easing: cubic-bezier(0.35, 0.98, 0.35, 1);
 
   &:after {
     content: '';
@@ -71,4 +73,21 @@
 
 .active-clicked:active:not(.visually-disabled) {
   @apply motion-safe:translate-y-px;
+}
+
+@keyframes button-spinner-in {
+  from {
+    opacity: 0;
+    transform: translateY(-25px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .button-spinner-in {
+    animation: button-spinner-in 0.3s var(--button-loading-easing);
+  }
 }

--- a/app/ui/styles/components/button.css
+++ b/app/ui/styles/components/button.css
@@ -8,7 +8,10 @@
 
 .ox-button {
   @apply relative;
-  /* Approximates Motion's { type: 'spring', duration: 0.3, bounce: 0 }. */
+  /*
+   * Shared by the spinner keyframes and the .button-content transition below.
+   * Approximates Motion's { type: 'spring', duration: 0.3, bounce: 0 }.
+   */
   --button-loading-easing: cubic-bezier(0.35, 0.98, 0.35, 1);
 
   &:after {
@@ -75,6 +78,9 @@
   @apply motion-safe:translate-y-px;
 }
 
+/* Animating transform is deliberate: the spinner's centering utilities set the
+ * separate translate property, which composes with transform instead of being
+ * overridden by it. */
 @keyframes button-spinner-in {
   from {
     opacity: 0;
@@ -87,7 +93,15 @@
 }
 
 @media (prefers-reduced-motion: no-preference) {
-  .button-spinner-in {
+  .ox-button .button-spinner-in {
     animation: button-spinner-in 0.3s var(--button-loading-easing);
+  }
+
+  /* Button label; swaps out as the spinner drops in. Loading state is toggled
+   * with utility classes in Button.tsx. */
+  .ox-button .button-content {
+    transition:
+      opacity 0.3s var(--button-loading-easing),
+      translate 0.3s var(--button-loading-easing);
   }
 }


### PR DESCRIPTION
Closes #3340 by switching from Motion to a CSS animation. The problem was that state internal to Motion was getting messed up when it got spammed with input. I had Codex figure out a Bezier easing that matches Motion's spring animation.

https://github.com/user-attachments/assets/8c2356d8-728b-4dd0-b276-5ca6e9726243

