### PR TITLE
Set target `es2024` in TS and Vite, drop browserslist

### DIFF
--- a/app/api/__tests__/safety.spec.ts
+++ b/app/api/__tests__/safety.spec.ts
@@ -11,6 +11,8 @@ import path from 'path'
 
 import { expect, it } from 'vitest'
 
+import viteConfigFn from '../../../vite.config'
+
 it('Generated API client version matches API version specified for deployment', () => {
   const generatedVersion = fs
     .readFileSync(path.resolve(__dirname, '../__generated__/OMICRON_VERSION'), 'utf8')
@@ -38,6 +40,20 @@ it('API_VERSION file matches apiVersion in generated client', () => {
   const match = apiTs.match(/^\s*apiVersion = '(.+)'$/m)
 
   expect(match?.[1]).toEqual(apiVersionFile)
+})
+
+// tsc is the only thing preventing use of JS APIs missing from our supported
+// browsers: Vite's build neither polyfills nor warns about calls to unsupported
+// APIs, it only transpiles syntax. So we want to make sure vite and tsc have
+// the same target.
+it('vite build target matches tsconfig target', () => {
+  const tsconfig = JSON.parse(
+    fs.readFileSync(path.resolve(__dirname, '../../../tsconfig.json'), 'utf8')
+  )
+  const viteConfig = viteConfigFn({ mode: 'production', command: 'build' })
+  // guard against an undefined === undefined pass if both are removed
+  expect(tsconfig.compilerOptions.target).toMatch(/^es\d{4}$/)
+  expect(viteConfig.build?.target).toEqual(tsconfig.compilerOptions.target)
 })
 
 const grepFiles = (s: string) =>

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,6 @@
         "@vitejs/plugin-basic-ssl": "^2.3.0",
         "@vitejs/plugin-react": "^6.0.2",
         "@vitest/browser-playwright": "^4.1.11",
-        "autoprefixer": "^10.4.20",
         "eslint-plugin-playwright": "^2.10.4",
         "eslint-plugin-react-hook-form": "^0.3.1",
         "husky": "^9.1.7",
@@ -6059,44 +6058,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/autoprefixer": {
-      "version": "10.4.20",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
-      "integrity": "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.23.3",
-        "caniuse-lite": "^1.0.30001646",
-        "fraction.js": "^4.3.7",
-        "normalize-range": "^0.1.2",
-        "picocolors": "^1.0.1",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "bin": {
-        "autoprefixer": "bin/autoprefixer"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -6208,39 +6169,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/browserslist": {
-      "version": "4.24.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
-      "integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "caniuse-lite": "^1.0.30001669",
-        "electron-to-chromium": "^1.5.41",
-        "node-releases": "^2.0.18",
-        "update-browserslist-db": "^1.1.1"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -6317,27 +6245,6 @@
       "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/caniuse-lite": {
-      "version": "1.0.30001769",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001769.tgz",
-      "integrity": "sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "CC-BY-4.0"
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -6828,13 +6735,6 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/electron-to-chromium": {
-      "version": "1.5.68",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.68.tgz",
-      "integrity": "sha512-FgMdJlma0OzUYlbrtZ4AeXjKxKPk6KT8WOP8BjcqxWtlg8qyJQjRzPJzUtUn5GBg1oQ26hFs7HOOHJMYiJRnvQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -7381,20 +7281,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/fraction.js": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
-      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "type": "patreon",
-        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/framer-motion": {
@@ -8870,23 +8756,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/node-releases": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
-      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/normalize-range": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -9487,13 +9356,6 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
-    },
-    "node_modules/postcss-value-parser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -10931,37 +10793,6 @@
       "peer": true,
       "engines": {
         "node": ">=8.11"
-      }
-    },
-    "node_modules/update-browserslist-db": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
-      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "escalade": "^3.2.0",
-        "picocolors": "^1.1.0"
-      },
-      "bin": {
-        "update-browserslist-db": "cli.js"
-      },
-      "peerDependencies": {
-        "browserslist": ">= 4.21.0"
       }
     },
     "node_modules/uplot": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "@vitejs/plugin-basic-ssl": "^2.3.0",
     "@vitejs/plugin-react": "^6.0.2",
     "@vitest/browser-playwright": "^4.1.11",
-    "autoprefixer": "^10.4.20",
     "eslint-plugin-playwright": "^2.10.4",
     "eslint-plugin-react-hook-form": "^0.3.1",
     "husky": "^9.1.7",
@@ -113,9 +112,6 @@
     "vitest": "^4.1.11",
     "vitest-browser-react": "^2.2.0"
   },
-  "browserslist": [
-    "defaults"
-  ],
   "msw": {
     "workerDirectory": [
       ""

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
       "@oxide/api-mocks": ["./mock-api/index.ts"]
     },
     "skipLibCheck": true,
-    "target": "es2023",
+    "target": "es2024",
     "types": ["node", "vite/client", "vitest/importMeta"]
   },
   "exclude": ["tools/deno"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -96,6 +96,12 @@ const devHeaders = {
 // see https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
   build: {
+    // Must match `target` in tsconfig.json: tsc only checks against lib types
+    // and nothing polyfills missing APIs, so the browser floor and the type
+    // ceiling have to move together. Vite maps this to the oldest browsers
+    // with full ES2024 support. We pin it because the default
+    // (baseline-widely-available) drifts across Vite versions.
+    target: 'es2024',
     outDir: resolve(__dirname, 'dist'),
     emptyOutDir: true,
     sourcemap: true,


### PR DESCRIPTION
Spun off from #3354, where I wanted `Promise.withResolvers` in a test but tsc wouldn't let me. Then I found out our browserslist list setting is not being used by anything — autoprefixer went away with Tailwind v4. 

### Changes

- `target` in tsconfig: es2023 → es2024, so tsc accepts ES2024 builtins like `Promise.withResolvers`
- Set `build.target: 'es2024'` in the Vite config to match. Vite's default target is [`'baseline-widely-available'`](https://vite.dev/config/build-options.html#build-target), a browser list regenerated for each Vite major (currently Chrome 111 / Firefox 114 / Safari 16.4)
- Add a safety test asserting the two targets stay equal
- Remove the browserslist key and the autoprefixer dep 

### Argument

`target` in tsconfig can control two things: what syntax tsc emits and the default `lib` declarations for typechecking. We use `noEmit` because we compile with Vite, so we only care about `lib`: it determines which builtin APIs the typechecker allows (`Promise.withResolvers`, `Object.groupBy`, etc.).

Vite has its own target concept, and it [only affects syntax](https://oxc.rs/docs/guide/usage/transformer/lowering#warnings): it rewrites newer syntax for older browsers, but if you call a too-new API, it doesn't polyfill or warn about it. 🤖 confirmed this by building `Promise.withResolvers()` with target `safari16.4`: clean build, the call ships as-is, TypeError at runtime. That means tsc's `lib` is the only thing keeping unsupported APIs out of the code, so the tsconfig target has to line up with the browsers we actually support. This PR sets `build.target: 'es2024'`, which Vite maps to the oldest browsers with full ES2024 support (Chrome 119, Safari 17.4, Firefox 145, per https://caniuse.com/sr-es15), and adds a safety test asserting the two targets are the same.

The potential downside is that we are moving our target to browsers that might be too new. The worst one is Firefox, where full ES2024 support means 145 (Nov 2025). But that version requirement comes from a single feature that we're never going to call: [per MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/waitAsync#browser_compatibility), `Atomics.waitAsync` appeared in Firefox 145, while every other ES2024 feature was in by Firefox 128 (July 2024), and the ones we'd actually use (`groupBy`, `withResolvers`, `isWellFormed`) by 121 (Dec 2023).

### Alternatives

* Do nothing (but still remove useless browserslist), i.e., leave `es2023` for TS and `baseline-widely-available` for Vite. Fine, but `es2024` has fun APIs we could use.
* `es2024` for TS but leave Vite on the default. Also most likely fine in practice, but feels bad.