### PR TITLE
Mobile layout

### DIFF
--- a/app/components/DocsPopover.tsx
+++ b/app/components/DocsPopover.tsx
@@ -55,7 +55,7 @@ export const DocsPopover = ({ heading, icon, summary, links }: DocsPopoverProps)
       <PopoverPanel
         // popover-panel needed for enter animation
         className="popover-panel bg-raise light:bg-default shadow-menu z-10 w-96 rounded-lg"
-        anchor={{ to: 'bottom end', gap: 12 }}
+        anchor={{ to: 'bottom end', gap: 12, padding: 16 }}
       >
         <div className="px-4">
           <h2 className="text-sans-md mt-4 flex items-center gap-1">

--- a/app/components/ErrorPage.tsx
+++ b/app/components/ErrorPage.tsx
@@ -40,7 +40,7 @@ export function ErrorPage({ children }: Props) {
         </Link>
         <SignOutButton className="mt-4 mr-6" />
       </div>
-      <div className="bg-raise! shadow-modal absolute top-1/2 left-1/2 flex w-96 -translate-x-1/2 -translate-y-1/2 flex-col items-center justify-center space-y-4 rounded-lg p-8">
+      <div className="bg-raise! shadow-modal max-1000:w-[calc(100%-var(--content-gutter)*2)] absolute top-1/2 left-1/2 flex w-96 -translate-x-1/2 -translate-y-1/2 flex-col items-center justify-center space-y-4 rounded-lg p-8">
         <div className="my-2 flex h-12 w-12 items-center justify-center">
           <div className="bg-destructive-inverse absolute h-10 w-10 rounded-full opacity-40 motion-safe:animate-[ping_2s_cubic-bezier(0,0,0.2,1)_infinite]" />
           <Error12Icon className="text-error light:text-error-secondary relative h-8 w-8" />

--- a/app/components/PageSkeleton.tsx
+++ b/app/components/PageSkeleton.tsx
@@ -13,6 +13,7 @@ import {
   ContentPane,
   PageContainer,
   sidebarWrapperClass,
+  topBarHomeCellClass,
   topBarWrapperClass,
 } from '~/layouts/helpers'
 import { classed } from '~/util/classed'
@@ -31,7 +32,7 @@ export function PageSkeleton({ skipPaths }: { skipPaths?: RegExp[] }) {
     <PageContainer>
       {/* TopBar */}
       <div className={topBarWrapperClass}>
-        <div className="border-secondary flex items-center gap-2 border-r p-3">
+        <div className={cn(topBarHomeCellClass, 'gap-2 p-3')}>
           <Block className="h-8 w-8" />
           <Block className="h-4 w-24" />
         </div>
@@ -44,7 +45,8 @@ export function PageSkeleton({ skipPaths }: { skipPaths?: RegExp[] }) {
         </div>
       </div>
       {/* Sidebar */}
-      <div className={cn(sidebarWrapperClass, 'p-4')}>
+      {/* on mobile the sidebar is an overlay, closed (translated off-screen) by default */}
+      <div className={cn(sidebarWrapperClass, 'p-4 max-1000:-translate-x-full')}>
         <Block className="mb-10 h-4 w-full" />
         <div className="mb-6 space-y-2">
           <Block className="h-4 w-32" />

--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -20,7 +20,7 @@ import { Truncate } from '~/ui/lib/Truncate'
 
 const linkStyles = (isActive = false) =>
   cn(
-    'flex h-7 items-center rounded-md px-2 text-sans-md [&>svg]:mr-2',
+    'flex h-7 items-center rounded-md px-2 text-sans-md pointer-coarse:h-8 [&>svg]:mr-2',
     isActive
       ? 'text-accent bg-accent hover:bg-accent-hover [&>svg]:text-accent-tertiary'
       : 'hover:bg-hover [&>svg]:text-quaternary text-default'

--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -6,6 +6,7 @@
  * Copyright Oxide Computer Company
  */
 import cn from 'classnames'
+import { useEffect } from 'react'
 import { Link, useLocation } from 'react-router'
 
 import { Action16Icon, Document16Icon } from '@oxide/design-system/icons/react'
@@ -13,6 +14,7 @@ import { Action16Icon, Document16Icon } from '@oxide/design-system/icons/react'
 import { useIsActivePath } from '~/hooks/use-is-active-path'
 import { openQuickActions } from '~/hooks/use-quick-actions'
 import { sidebarWrapperClass } from '~/layouts/helpers'
+import { closeMobileNav, useMobileNavStore } from '~/stores/mobile-nav'
 import { Button } from '~/ui/lib/Button'
 import { Truncate } from '~/ui/lib/Truncate'
 
@@ -62,18 +64,37 @@ const JumpToButton = () => {
 }
 
 export function Sidebar({ children }: { children: React.ReactNode }) {
+  const mobileNavOpen = useMobileNavStore((state) => state.isOpen)
+  const { pathname } = useLocation()
+
+  // close the mobile nav overlay on any navigation, including ones triggered
+  // outside the sidebar (breadcrumbs, quick actions)
+  useEffect(() => closeMobileNav(), [pathname])
+
   return (
-    <div
-      className={cn(
-        sidebarWrapperClass,
-        'text-sans-md text-raise flex flex-col overflow-y-auto overscroll-none'
+    <>
+      {/* scrim behind the mobile nav overlay. covers everything below the top
+          bar so the toggle button in the top bar stays clickable */}
+      {mobileNavOpen && (
+        <div
+          aria-hidden
+          onClick={closeMobileNav}
+          className="bg-scrim 1000:hidden fixed inset-0 top-[calc(var(--top-bar-height)+var(--preview-banner-height))] z-(--z-side-modal-overlay)"
+        />
       )}
-    >
-      <div className="mx-3 mt-4">
-        <JumpToButton />
+      <div
+        className={cn(
+          sidebarWrapperClass,
+          'text-sans-md text-raise flex flex-col overflow-y-auto overscroll-none',
+          !mobileNavOpen && 'max-1000:-translate-x-full'
+        )}
+      >
+        <div className="mx-3 mt-4">
+          <JumpToButton />
+        </div>
+        {children}
       </div>
-      {children}
-    </div>
+    </>
   )
 }
 

--- a/app/components/Terminal.tsx
+++ b/app/components/Terminal.tsx
@@ -126,10 +126,10 @@ export function Terminal({ ws }: TerminalProps) {
     <>
       <div
         role="application"
-        className="text-mono-code h-full w-[calc(100%-3rem)]"
+        className="text-mono-code 1000:w-[calc(100%-3rem)] h-full w-full"
         ref={terminalRef}
       />
-      <div className="text-default absolute top-0 right-0 space-y-2">
+      <div className="text-default max-1000:hidden absolute top-0 right-0 space-y-2">
         <ScrollButton onClick={() => term?.scrollToTop()} aria-label="Scroll to top">
           <DirectionUpIcon aria-hidden />
         </ScrollButton>

--- a/app/components/TopBar.tsx
+++ b/app/components/TopBar.tsx
@@ -43,7 +43,7 @@ export function TopBar({ systemOrSilo }: { systemOrSilo: 'system' | 'silo' }) {
         <HomeButton level={systemOrSilo} />
       </div>
       <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-4 px-3">
-        <div className="flex min-w-0 flex-1 items-center gap-2.5">
+        <div className="flex min-w-0 flex-1 items-center gap-3">
           <MobileNavToggle />
           <Breadcrumbs />
         </div>
@@ -60,15 +60,19 @@ function MobileNavToggle() {
   const isOpen = useMobileNavStore((state) => state.isOpen)
   const Icon = isOpen ? MenuClose12Icon : MenuOpen12Icon
   return (
-    <button
-      type="button"
-      onClick={toggleMobileNav}
-      aria-label="Toggle sidebar"
-      aria-expanded={isOpen}
-      className="hover:bg-hover 1000:hidden -ml-2 flex h-10 w-10 shrink-0 items-center justify-center rounded-md"
-    >
-      <Icon className="text-secondary" />
-    </button>
+    // full-height cell with a right border so the toggle reads as its own
+    // region, mirroring the desktop home button cell
+    <div className="border-secondary 1000:hidden -ml-3 flex h-(--top-bar-height) shrink-0 items-center border-r px-1.5">
+      <button
+        type="button"
+        onClick={toggleMobileNav}
+        aria-label="Toggle sidebar"
+        aria-expanded={isOpen}
+        className="hover:bg-hover flex h-10 w-10 items-center justify-center rounded-md"
+      >
+        <Icon className="text-secondary" />
+      </button>
+    </div>
   )
 }
 

--- a/app/components/TopBar.tsx
+++ b/app/components/TopBar.tsx
@@ -15,6 +15,7 @@ import {
   MenuOpen12Icon,
   Monitor12Icon,
   Moon12Icon,
+  More12Icon,
   Organization16Icon,
   Profile16Icon,
   SelectArrows6Icon,
@@ -66,11 +67,7 @@ function MobileNavToggle() {
       aria-expanded={isOpen}
       className="hover:bg-hover 1000:hidden -ml-2 flex h-10 w-10 shrink-0 items-center justify-center rounded-md"
     >
-      {/* the menu glyphs only ship at 12px, so scale up for legibility.
-          the half-pixel lift splits the difference between engines: WebKit
-          seats the adjacent breadcrumb text ~1px higher in its line box
-          than Blink, so a nudge that's exact on one is off on the other */}
-      <Icon className="text-secondary h-4 w-4 -translate-y-[0.5px]" />
+      <Icon className="text-secondary" />
     </button>
   )
 }
@@ -130,7 +127,10 @@ function Breadcrumbs() {
   return (
     <nav
       ref={navRef}
-      className="text-sans-md relative flex min-w-0 flex-1 items-center gap-0.5 overflow-clip"
+      // x-only clip: it exists to keep the measurement copies and long crumbs from
+      // causing page overflow, and y must stay visible so the overflow trigger's
+      // expanded hit target (before:-inset-4) isn't clipped to the 18px nav height
+      className="text-sans-md relative flex min-w-0 flex-1 items-center gap-0.5 overflow-x-clip"
       aria-label="Breadcrumbs"
     >
       {hasHiddenCrumbs && (
@@ -138,11 +138,9 @@ function Breadcrumbs() {
           <DropdownMenu.Root>
             <DropdownMenu.Trigger
               aria-label="Show full breadcrumb path"
-              className="text-secondary hover:bg-hover flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-lg leading-none"
+              className="text-secondary hover:text-default relative flex shrink-0 items-center before:absolute before:-inset-4 before:content-['']"
             >
-              <span aria-hidden className="-translate-y-0.5">
-                …
-              </span>
+              <More12Icon className="translate-y-0.5 rotate-90" />
             </DropdownMenu.Trigger>
             <DropdownMenu.Content
               anchor="bottom start"
@@ -193,7 +191,7 @@ function Breadcrumbs() {
         aria-hidden
         className="invisible absolute top-0 left-0 flex w-max items-center gap-0.5 whitespace-nowrap"
       >
-        <span data-breadcrumb-ellipsis className="block h-8 w-8 shrink-0" />
+        <span data-breadcrumb-ellipsis className="block h-3 w-3 shrink-0" />
         <Slash className="breadcrumb-measure-slash shrink-0" />
         {crumbs.map(({ label, path }) => (
           <span data-breadcrumb-crumb key={`${label}|${path}`}>

--- a/app/components/TopBar.tsx
+++ b/app/components/TopBar.tsx
@@ -10,6 +10,8 @@ import { Link } from 'react-router'
 
 import { api, navToLogin, useApiMutation } from '@oxide/api'
 import {
+  MenuClose12Icon,
+  MenuOpen12Icon,
   Monitor12Icon,
   Moon12Icon,
   Organization16Icon,
@@ -22,7 +24,8 @@ import {
 
 import { useCrumbs } from '~/hooks/use-crumbs'
 import { useCurrentUser } from '~/hooks/use-current-user'
-import { topBarWrapperClass } from '~/layouts/helpers'
+import { topBarHomeCellClass, topBarWrapperClass } from '~/layouts/helpers'
+import { toggleMobileNav, useMobileNavStore } from '~/stores/mobile-nav'
 import { useThemeStore, type Theme } from '~/stores/theme'
 import { buttonStyle } from '~/ui/lib/Button'
 import * as DropdownMenu from '~/ui/lib/DropdownMenu'
@@ -35,19 +38,40 @@ export function TopBar({ systemOrSilo }: { systemOrSilo: 'system' | 'silo' }) {
   const { me } = useCurrentUser()
   return (
     <div className={topBarWrapperClass}>
-      <div className="border-secondary flex items-center border-r px-2">
+      <div className={cn(topBarHomeCellClass, 'px-2')}>
         <HomeButton level={systemOrSilo} />
       </div>
-      <div className="flex items-center justify-between gap-4 px-3">
-        <div className="flex flex-1 gap-2.5">
+      <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-4 px-3">
+        <div className="flex min-w-0 flex-1 items-center gap-2.5">
+          <MobileNavToggle />
           <Breadcrumbs />
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex shrink-0 items-center gap-2">
           {me.fleetViewer && <SiloSystemPicker level={systemOrSilo} />}
           <UserMenu />
         </div>
       </div>
     </div>
+  )
+}
+
+function MobileNavToggle() {
+  const isOpen = useMobileNavStore((state) => state.isOpen)
+  const Icon = isOpen ? MenuClose12Icon : MenuOpen12Icon
+  return (
+    <button
+      type="button"
+      onClick={toggleMobileNav}
+      aria-label="Toggle sidebar"
+      aria-expanded={isOpen}
+      className="hover:bg-hover 1000:hidden -ml-2 flex h-10 w-10 shrink-0 items-center justify-center rounded-md"
+    >
+      {/* the menu glyphs only ship at 12px, so scale up for legibility.
+          the half-pixel lift splits the difference between engines: WebKit
+          seats the adjacent breadcrumb text ~1px higher in its line box
+          than Blink, so a nudge that's exact on one is off on the other */}
+      <Icon className="text-secondary h-4 w-4 -translate-y-[0.5px]" />
+    </button>
   )
 }
 
@@ -138,15 +162,23 @@ function UserMenu() {
           )}
         >
           <Profile16Icon className="text-tertiary" />
-          <span className="text-sans-md text-default normal-case">
+          <span className="text-sans-md text-default max-1000:hidden normal-case">
             {me.displayName || 'User'}
           </span>
         </div>
       </DropdownMenu.Trigger>
       <DropdownMenu.Content gap={8} zIndex="topBar">
-        <DropdownMenu.LinkItem to={pb.profile()}>Settings</DropdownMenu.LinkItem>
-        <ThemeSubmenu />
-        <DropdownMenu.Item onSelect={() => logout.mutate({})} label="Sign out" />
+        <DropdownMenu.Group>
+          <DropdownMenu.GroupLabel className="border-secondary 1000:hidden border-b px-3 py-2">
+            <div className="text-mono-xs text-tertiary">User</div>
+            <div className="text-sans-md text-default mt-0.5">
+              {me.displayName || 'User'}
+            </div>
+          </DropdownMenu.GroupLabel>
+          <DropdownMenu.LinkItem to={pb.profile()}>Settings</DropdownMenu.LinkItem>
+          <ThemeSubmenu />
+          <DropdownMenu.Item onSelect={() => logout.mutate({})} label="Sign out" />
+        </DropdownMenu.Group>
       </DropdownMenu.Content>
     </DropdownMenu.Root>
   )

--- a/app/components/TopBar.tsx
+++ b/app/components/TopBar.tsx
@@ -6,6 +6,7 @@
  * Copyright Oxide Computer Company
  */
 import cn from 'classnames'
+import { Fragment, useLayoutEffect, useRef, useState } from 'react'
 import { Link } from 'react-router'
 
 import { api, navToLogin, useApiMutation } from '@oxide/api'
@@ -31,7 +32,6 @@ import { buttonStyle } from '~/ui/lib/Button'
 import * as DropdownMenu from '~/ui/lib/DropdownMenu'
 import { Identicon } from '~/ui/lib/Identicon'
 import { Slash } from '~/ui/lib/Slash'
-import { intersperse } from '~/util/array'
 import { pb } from '~/util/path-builder'
 
 export function TopBar({ systemOrSilo }: { systemOrSilo: 'system' | 'silo' }) {
@@ -122,28 +122,160 @@ function HomeButton({ level }: { level: 'system' | 'silo' }) {
 
 function Breadcrumbs() {
   const crumbs = useCrumbs().filter((c) => !c.titleOnly)
+  const lastCrumb = crumbs.length - 1
+  const { firstVisibleCrumb, measurementRef, navRef } = useBreadcrumbOverflow(crumbs)
+  const hasHiddenCrumbs = firstVisibleCrumb > 0
+  const visibleCrumbs = crumbs.slice(firstVisibleCrumb)
+
   return (
     <nav
-      className="text-sans-md flex items-center gap-0.5 overflow-clip"
+      ref={navRef}
+      className="text-sans-md relative flex min-w-0 flex-1 items-center gap-0.5 overflow-clip"
       aria-label="Breadcrumbs"
     >
-      {intersperse(
-        crumbs.map(({ label, path }, i) => (
-          <Link
-            to={path}
-            className={cn(
-              'text-sans-md whitespace-nowrap',
-              i === crumbs.length - 1 ? 'text-raise' : 'text-secondary hover:text-default'
-            )}
-            key={`${label}|${path}`}
-          >
-            {label}
-          </Link>
-        )),
-        <Slash />
+      {hasHiddenCrumbs && (
+        <>
+          <DropdownMenu.Root>
+            <DropdownMenu.Trigger
+              aria-label="Show full breadcrumb path"
+              className="text-secondary hover:bg-hover flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-lg leading-none"
+            >
+              <span aria-hidden className="-translate-y-0.5">
+                …
+              </span>
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Content
+              anchor="bottom start"
+              className="max-w-[calc(100vw-2rem)]"
+              gap={8}
+              zIndex="topBar"
+            >
+              {crumbs.map(({ label, path }, i) => (
+                <DropdownMenu.LinkItem
+                  key={`${label}|${path}`}
+                  to={path}
+                  className={cn(
+                    'wrap-break-word whitespace-normal',
+                    i === lastCrumb && 'is-selected'
+                  )}
+                >
+                  {label}
+                </DropdownMenu.LinkItem>
+              ))}
+            </DropdownMenu.Content>
+          </DropdownMenu.Root>
+          <Slash className="shrink-0" />
+        </>
       )}
+      {visibleCrumbs.map(({ label, path }, visibleIndex) => {
+        const crumbIndex = firstVisibleCrumb + visibleIndex
+        return (
+          <Fragment key={`${label}|${path}`}>
+            {visibleIndex > 0 && <Slash className="shrink-0" />}
+            <Link
+              to={path}
+              aria-current={crumbIndex === lastCrumb ? 'page' : undefined}
+              className={cn(
+                'text-sans-md whitespace-nowrap',
+                crumbIndex === lastCrumb
+                  ? 'text-raise min-w-0 overflow-hidden text-ellipsis'
+                  : 'text-secondary hover:text-default shrink-0'
+              )}
+            >
+              {label}
+            </Link>
+          </Fragment>
+        )
+      })}
+      {/* Keep natural-width copies available after their interactive counterparts collapse. */}
+      <div
+        ref={measurementRef}
+        aria-hidden
+        className="invisible absolute top-0 left-0 flex w-max items-center gap-0.5 whitespace-nowrap"
+      >
+        <span data-breadcrumb-ellipsis className="block h-8 w-8 shrink-0" />
+        <Slash className="breadcrumb-measure-slash shrink-0" />
+        {crumbs.map(({ label, path }) => (
+          <span data-breadcrumb-crumb key={`${label}|${path}`}>
+            {label}
+          </span>
+        ))}
+      </div>
     </nav>
   )
+}
+
+type Breadcrumb = ReturnType<typeof useCrumbs>[number]
+
+function useBreadcrumbOverflow(crumbs: Breadcrumb[]) {
+  const navRef = useRef<HTMLElement>(null)
+  const measurementRef = useRef<HTMLDivElement>(null)
+  const [firstVisibleCrumb, setFirstVisibleCrumb] = useState(() =>
+    Math.max(0, crumbs.length - 1)
+  )
+  const crumbLabels = crumbs.map(({ label }) => label).join('\0')
+
+  useLayoutEffect(() => {
+    const nav = navRef.current
+    const measurement = measurementRef.current
+    if (!nav || !measurement || crumbs.length === 0) return
+
+    const update = () => {
+      const crumbElements = Array.from(
+        measurement.querySelectorAll<HTMLElement>('[data-breadcrumb-crumb]')
+      )
+      const ellipsis = measurement.querySelector<HTMLElement>('[data-breadcrumb-ellipsis]')
+      const slash = measurement.querySelector<HTMLElement>('.breadcrumb-measure-slash')
+      if (crumbElements.length !== crumbs.length || !ellipsis || !slash) return
+
+      const style = getComputedStyle(measurement)
+      const gap = Number.parseFloat(style.columnGap) || 0
+      const slashStyle = getComputedStyle(slash)
+      const slashWidth =
+        slash.getBoundingClientRect().width +
+        (Number.parseFloat(slashStyle.marginLeft) || 0) +
+        (Number.parseFloat(slashStyle.marginRight) || 0)
+      const ellipsisWidth = ellipsis.getBoundingClientRect().width
+      const crumbWidths = crumbElements.map(
+        (element) => element.getBoundingClientRect().width
+      )
+      const lastCrumbIndex = crumbs.length - 1
+
+      // Prefer the longest complete suffix that fits. The current crumb remains when no
+      // suffix fits and its CSS ellipsis becomes the final fallback.
+      let nextFirstVisible = lastCrumbIndex
+      for (let candidate = 0; candidate <= lastCrumbIndex; candidate++) {
+        const visibleCount = crumbs.length - candidate
+        const visibleCrumbWidth = crumbWidths
+          .slice(candidate)
+          .reduce((total, width) => total + width, 0)
+        const separatorWidth = (visibleCount - 1) * (slashWidth + gap * 2)
+        const collapsedPrefixWidth =
+          candidate > 0 ? ellipsisWidth + slashWidth + gap * 2 : 0
+
+        if (visibleCrumbWidth + separatorWidth + collapsedPrefixWidth <= nav.clientWidth) {
+          nextFirstVisible = candidate
+          break
+        }
+      }
+
+      setFirstVisibleCrumb((current) =>
+        current === nextFirstVisible ? current : nextFirstVisible
+      )
+    }
+
+    update()
+    const observer = new ResizeObserver(update)
+    observer.observe(nav)
+    observer.observe(measurement)
+    return () => observer.disconnect()
+  }, [crumbLabels, crumbs.length])
+
+  return {
+    firstVisibleCrumb: Math.min(firstVisibleCrumb, Math.max(0, crumbs.length - 1)),
+    measurementRef,
+    navRef,
+  }
 }
 
 function UserMenu() {

--- a/app/components/form/fields/DateTimeRangePicker.tsx
+++ b/app/components/form/fields/DateTimeRangePicker.tsx
@@ -127,9 +127,9 @@ export function DateTimeRangePicker({
   items,
 }: DateTimeRangePickerProps) {
   return (
-    <div className="flex">
+    <div className="max-1000:w-full flex">
       <Listbox
-        className="z-10 w-40 [&_button]:rounded-r-none! [&_button]:border-r-0!"
+        className="max-1000:flex-grow z-10 w-40 [&_button]:rounded-r-none! [&_button]:border-r-0!"
         name="preset"
         selected={preset}
         aria-label="Choose a time range preset"

--- a/app/components/form/fields/DisksTableField.tsx
+++ b/app/components/form/fields/DisksTableField.tsx
@@ -75,13 +75,19 @@ export function DisksTableField({
           emptyState={{ title: 'No disks', body: 'Add a disk to see it here' }}
         />
 
-        <div className="space-x-3">
-          <Button size="sm" onClick={() => setShowDiskCreate(true)} disabled={disabled}>
+        <div className="max-1000:flex-col flex gap-3">
+          <Button
+            size="sm"
+            className="max-1000:w-full"
+            onClick={() => setShowDiskCreate(true)}
+            disabled={disabled}
+          >
             Create new disk
           </Button>
           <Button
             variant="secondary"
             size="sm"
+            className="max-1000:w-full"
             onClick={() => setShowDiskAttach(true)}
             disabled={disabled}
           >

--- a/app/layouts/helpers.tsx
+++ b/app/layouts/helpers.tsx
@@ -16,14 +16,20 @@ export const PageContainer = classed.div`min-h-full pt-[calc(var(--top-bar-heigh
 
 // shared with PageSkeleton so the skeleton doesn't drift from the real layout
 export const topBarWrapperClass =
-  'bg-default border-secondary fixed top-(--preview-banner-height) right-0 left-0 z-(--z-top-bar) grid h-(--top-bar-height) grid-cols-[var(--sidebar-width)_1fr] border-b'
+  'bg-default border-secondary fixed top-(--preview-banner-height) right-0 left-0 z-(--z-top-bar) grid h-(--top-bar-height) grid-cols-[1fr] 1000:grid-cols-[var(--sidebar-width)_1fr] border-b'
+// home button cell only exists at desktop width — on mobile the sidebar is an
+// overlay toggled from the top bar, so the top bar is a single cell
+export const topBarHomeCellClass = 'border-secondary hidden items-center border-r 1000:flex'
+// below the 1000px breakpoint the sidebar becomes an overlay whose visibility
+// is controlled by translate-x classes in Sidebar (and PageSkeleton, which
+// always renders it closed)
 export const sidebarWrapperClass =
-  'border-secondary fixed top-[calc(var(--top-bar-height)+var(--preview-banner-height))] bottom-0 left-0 w-(--sidebar-width) border-r'
+  'bg-default border-secondary fixed top-[calc(var(--top-bar-height)+var(--preview-banner-height))] bottom-0 left-0 w-(--sidebar-width) border-r max-1000:z-(--z-side-modal) max-1000:transition-transform max-1000:duration-200 max-1000:ease-out motion-reduce:max-1000:transition-none'
 
 export function ContentPane() {
   useScrollRestoration()
   return (
-    <div className="light:bg-raise ml-(--sidebar-width) flex min-h-[calc(100vh-var(--top-bar-height)-var(--preview-banner-height))] flex-col">
+    <div className="light:bg-raise 1000:ml-(--sidebar-width) flex min-h-[calc(100vh-var(--top-bar-height)-var(--preview-banner-height))] flex-col">
       <div className="flex grow flex-col pb-8">
         {/* id/tabIndex make this the skip link target and where useRouteAnnouncer
             puts focus after a nav. It has to be a real element in the a11y tree
@@ -47,7 +53,7 @@ export function ContentPane() {
  * `<div>` because we don't need it.
  */
 export const SerialConsoleContentPane = () => (
-  <div className="ml-(--sidebar-width) flex h-[calc(100vh-var(--top-bar-height)-var(--preview-banner-height))] flex-col overflow-hidden">
+  <div className="1000:ml-(--sidebar-width) flex h-[calc(100vh-var(--top-bar-height)-var(--preview-banner-height))] flex-col overflow-hidden">
     <main id="content" tabIndex={-1} className="*:gutter h-full outline-none">
       <Outlet />
     </main>

--- a/app/pages/project/instances/SerialConsolePage.tsx
+++ b/app/pages/project/instances/SerialConsolePage.tsx
@@ -157,7 +157,7 @@ export default function SerialConsolePage() {
         {ws.current && <Terminal ws={ws.current} />}
       </div>
       <div className="bg-default border-secondary shrink-0 justify-between overflow-hidden border-t empty:border-t-0">
-        <div className="gutter flex h-20 items-center justify-between">
+        <div className="gutter 1000:h-20 max-1000:py-4 flex items-center justify-between">
           <div>
             <EquivalentCliCommand project={project} instance={instance} />
           </div>

--- a/app/stores/mobile-nav.ts
+++ b/app/stores/mobile-nav.ts
@@ -1,0 +1,20 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
+ */
+
+import { create } from 'zustand'
+
+/**
+ * Whether the sidebar nav is open as an overlay on small screens. Above the
+ * mobile breakpoint the sidebar is always visible and this state is ignored.
+ */
+export const useMobileNavStore = create<{ isOpen: boolean }>(() => ({ isOpen: false }))
+
+export const closeMobileNav = () => useMobileNavStore.setState({ isOpen: false })
+
+export const toggleMobileNav = () =>
+  useMobileNavStore.setState(({ isOpen }) => ({ isOpen: !isOpen }))

--- a/app/ui/lib/CardBlock.tsx
+++ b/app/ui/lib/CardBlock.tsx
@@ -53,7 +53,7 @@ CardBlock.Header = ({ title, description, children, titleId }: HeaderProps) => (
       {description && <div className="text-secondary">{description}</div>}
     </div>
 
-    <div className="space-x-2">{children}</div>
+    <div className="max-1000:flex-col flex gap-2">{children}</div>
   </header>
 )
 

--- a/app/ui/lib/DropdownMenu.tsx
+++ b/app/ui/lib/DropdownMenu.tsx
@@ -72,7 +72,8 @@ export function Content({
   anchor = 'bottom end',
   gap,
   zIndex = 'dropdown',
-  collisionPadding,
+  // keep menus off the viewport edge, mainly for small screens
+  collisionPadding = 12,
 }: ContentProps) {
   const { side, align, sideOffset, alignOffset } = parseAnchor(anchor, gap)
   return (

--- a/app/ui/lib/DropdownMenu.tsx
+++ b/app/ui/lib/DropdownMenu.tsx
@@ -158,6 +158,8 @@ export const Item = ({ className, onSelect, label, disabled, ref }: ItemProps) =
 
 export const Submenu = Menu.SubmenuRoot
 export const SubmenuTrigger = Menu.SubmenuTrigger
+export const Group = Menu.Group
+export const GroupLabel = Menu.GroupLabel
 export const RadioGroup = Menu.RadioGroup
 export const RadioItem = Menu.RadioItem
 export const Separator = Menu.Separator

--- a/app/ui/lib/Modal.tsx
+++ b/app/ui/lib/Modal.tsx
@@ -20,10 +20,12 @@ import { ModalContext } from './modal-context'
 
 type Width = 'narrow' | 'medium' | 'free'
 
+// the 100vw terms keep modals from going edge-to-edge on small screens
 const widthClass: Record<Width, string> = {
-  narrow: 'w-full max-w-[24rem]',
-  medium: 'w-full max-w-md',
-  free: 'min-w-[24rem] max-w-3xl', // give it a big max just to be safe
+  narrow: 'w-full max-w-[min(24rem,calc(100vw-2rem))]',
+  medium: 'w-full max-w-[min(28rem,calc(100vw-2rem))]',
+  // give it a big max just to be safe
+  free: 'min-w-[min(24rem,calc(100vw-2rem))] max-w-[min(48rem,calc(100vw-2rem))]',
 }
 
 export type ModalProps = {

--- a/app/ui/lib/PageHeader.tsx
+++ b/app/ui/lib/PageHeader.tsx
@@ -9,7 +9,7 @@ import type { ReactElement } from 'react'
 
 import { classed } from '~/util/classed'
 
-export const PageHeader = classed.header`mb-16 mt-12 flex items-center justify-between`
+export const PageHeader = classed.header`mb-16 mt-12 flex items-center justify-between max-1000:mt-8`
 
 interface PageTitleProps {
   icon?: ReactElement

--- a/app/ui/lib/Radio.tsx
+++ b/app/ui/lib/Radio.tsx
@@ -66,9 +66,11 @@ export function RadioCard({ children, className, ...inputProps }: RadioProps) {
   // HACK: This forces the focus states for storybook stories
   const focus = className?.includes(':focus') ? ':focus' : ''
   return (
-    <label className="inline-flex items-center">
+    <label className="max-1000:w-full inline-flex items-center">
       <input className={cn(focus, 'peer sr-only')} type="radio" {...inputProps} />
-      <span className={cn('ox-radio-card divide-y', cardLabelStyles, className)}>
+      <span
+        className={cn('ox-radio-card divide-y max-1000:w-full', cardLabelStyles, className)}
+      >
         {children}
       </span>
     </label>

--- a/app/ui/lib/SideModal.tsx
+++ b/app/ui/lib/SideModal.tsx
@@ -66,7 +66,7 @@ export function SideModal({
                 initial={{ x: animate ? 40 : 0 }}
                 animate={{ x: 0 }}
                 transition={{ type: 'spring', duration: 0.4, bounce: 0 }}
-                className="ox-side-modal bg-raise shadow-modal pointer-events-auto fixed top-0 right-0 bottom-0 z-(--z-side-modal) m-0 flex w-lg flex-col justify-between p-0"
+                className="ox-side-modal bg-raise shadow-modal 1000:w-lg pointer-events-auto fixed top-0 right-0 bottom-0 z-(--z-side-modal) m-0 flex w-full flex-col justify-between p-0"
               />
             }
           >

--- a/app/ui/lib/Toast.tsx
+++ b/app/ui/lib/Toast.tsx
@@ -64,7 +64,7 @@ export const Toast = ({
   return (
     <div
       className={cn(
-        'shadow-toast relative flex w-96 items-start overflow-hidden rounded-lg border border-current/10 p-4',
+        'shadow-toast relative flex w-96 max-w-[calc(100vw-2rem)] items-start overflow-hidden rounded-lg border border-current/10 p-4',
         'bg-accent text-accent *:text-accent',
         themeClass[variant]
       )}

--- a/app/ui/styles/components/Tabs.css
+++ b/app/ui/styles/components/Tabs.css
@@ -11,6 +11,16 @@
   @apply mb-8 flex bg-transparent;
 }
 
+/* let long tab lists scroll horizontally on small screens instead of
+   overflowing the page */
+@media (max-width: 999px) {
+  .ox-tabs-list {
+    -webkit-overflow-scrolling: touch;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+}
+
 .ox-tabs-list:after {
   @apply border-secondary block w-full border-b;
   content: '';

--- a/app/ui/styles/components/side-modal.css
+++ b/app/ui/styles/components/side-modal.css
@@ -10,6 +10,12 @@
   --content-gutter: 2rem;
 }
 
+@media (max-width: 999px) {
+  .ox-side-modal {
+    --content-gutter: 1.5rem;
+  }
+}
+
 .ox-side-modal > :not(.body, button, footer),
 .ox-side-modal > .body > * {
   margin-left: var(--content-gutter);

--- a/app/ui/styles/index.css
+++ b/app/ui/styles/index.css
@@ -169,6 +169,7 @@
 
   body {
     @apply text-default bg-default font-sans;
+    overscroll-behavior-y: none;
   }
 
   /* https://github.com/tailwindlabs/tailwindcss/blob/v2.2.4/src/plugins/css/preflight.css#L57 */

--- a/app/ui/styles/index.css
+++ b/app/ui/styles/index.css
@@ -132,7 +132,7 @@
     /* overridden by PreviewBannerLayout when the banner is enabled */
     --preview-banner-height: 0px;
 
-    @media (max-width: 767px) {
+    @media (max-width: 999px) {
       --content-gutter: 1.5rem;
     }
 

--- a/test/e2e/breadcrumbs.e2e.ts
+++ b/test/e2e/breadcrumbs.e2e.ts
@@ -94,3 +94,98 @@ test('breadcrumbs', async ({ page }) => {
   await expect(page.getByRole('dialog', { name: 'Add IP range' })).toBeVisible()
   await expectCrumbs(page, poolCrumbs)
 })
+
+test('mobile breadcrumbs keep top-bar actions visible and expose the full path', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 404, height: 800 })
+  await page.goto('/projects/mock-project/instances/db1/networking')
+
+  const breadcrumbs = page.getByRole('navigation', { name: 'Breadcrumbs' })
+  await expect(breadcrumbs.getByRole('link', { name: 'Networking' })).toBeVisible()
+
+  // A long path must leave the persistent actions usable at narrow widths.
+  await expect(
+    page.getByRole('button', { name: 'Switch between system and silo' })
+  ).toBeInViewport({ ratio: 1 })
+  await expect(page.getByRole('button', { name: 'User menu' })).toBeInViewport({ ratio: 1 })
+
+  await page.setViewportSize({ width: 650, height: 800 })
+  await expect
+    .poll(() => breadcrumbs.getByRole('link').allTextContents())
+    .toEqual(expect.arrayContaining(['db1', 'Networking']))
+
+  await page.setViewportSize({ width: 750, height: 800 })
+  await expect
+    .poll(() => breadcrumbs.getByRole('link').allTextContents())
+    .toEqual(expect.arrayContaining(['Instances', 'db1', 'Networking']))
+
+  await page.setViewportSize({ width: 404, height: 800 })
+
+  await breadcrumbs.getByRole('button', { name: 'Show full breadcrumb path' }).click()
+  const menuItems = page.getByRole('menuitem')
+  await expect(menuItems).toHaveText([
+    'Projects',
+    'mock-project',
+    'Instances',
+    'db1',
+    'Networking',
+  ])
+
+  await page.getByRole('menuitem', { name: 'Instances' }).click()
+  await expect(page).toHaveURL('/projects/mock-project/instances')
+})
+
+test('long breadcrumbs collapse without displacing top-bar actions', async ({ page }) => {
+  await page.setViewportSize({ width: 650, height: 800 })
+  await page.goto('/projects/other-project/instances/failed-cooled-restart-never/settings')
+
+  const breadcrumbs = page.getByRole('navigation', { name: 'Breadcrumbs' })
+  const visibleCrumbs = breadcrumbs.getByRole('link')
+  await expect(visibleCrumbs.last()).toHaveText('Settings')
+  for (const crumb of await visibleCrumbs.all()) {
+    if (await crumb.getAttribute('aria-current')) continue
+    await expect
+      .poll(() => crumb.evaluate((element) => element.scrollWidth === element.clientWidth))
+      .toBe(true)
+  }
+  await expect(
+    page.getByRole('button', { name: 'Switch between system and silo' })
+  ).toBeInViewport({ ratio: 1 })
+  await expect(page.getByRole('button', { name: 'User menu' })).toBeInViewport({ ratio: 1 })
+
+  await breadcrumbs.getByRole('button', { name: 'Show full breadcrumb path' }).click()
+  const longMenuItem = page.getByRole('menuitem', {
+    name: 'failed-cooled-restart-never',
+  })
+  await expect(longMenuItem).toBeVisible()
+  await expect
+    .poll(() =>
+      longMenuItem.evaluate((element) => {
+        const { left, right } = element.getBoundingClientRect()
+        return left >= 0 && right <= window.innerWidth
+      })
+    )
+    .toBe(true)
+})
+
+test('desktop breadcrumbs collapse whole leading crumbs instead of shrinking each one', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1024, height: 800 })
+  await page.goto('/projects/mock-project/vpcs/default/routers/mock-system-router')
+
+  const breadcrumbs = page.getByRole('navigation', { name: 'Breadcrumbs' })
+  await expect(
+    breadcrumbs.getByRole('button', { name: 'Show full breadcrumb path' })
+  ).toBeVisible()
+
+  const visibleCrumbs = breadcrumbs.getByRole('link')
+  await expect(visibleCrumbs.last()).toHaveText('Routes')
+  for (const crumb of await visibleCrumbs.all()) {
+    if (await crumb.getAttribute('aria-current')) continue
+    await expect
+      .poll(() => crumb.evaluate((element) => element.scrollWidth === element.clientWidth))
+      .toBe(true)
+  }
+})

--- a/test/e2e/mobile-layout.e2e.ts
+++ b/test/e2e/mobile-layout.e2e.ts
@@ -1,0 +1,123 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
+ */
+
+import { clickRowAction, expect, test } from './utils'
+
+test('mobile user menu identifies the current user', async ({ page }) => {
+  await page.setViewportSize({ width: 404, height: 800 })
+  await page.goto('/projects')
+
+  await page.getByRole('button', { name: 'User menu' }).click()
+
+  const menu = page.getByRole('menu')
+  await expect(menu.getByText('Hannah Arendt')).toBeVisible()
+  // username is not an interactive item
+  await expect(menu.getByRole('menuitem', { name: 'Hannah Arendt' })).toHaveCount(0)
+})
+
+test('mobile sidebar opens as an overlay and closes on dismiss or navigation', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 404, height: 800 })
+  await page.goto('/projects/mock-project/instances/db1/networking')
+
+  const toggle = page.getByRole('button', { name: 'Toggle sidebar' })
+  const disksLink = page
+    .locator('nav[aria-label="Sidebar navigation"]')
+    .getByRole('link', { name: 'Disks', exact: true })
+  const userName = page
+    .getByRole('button', { name: 'User menu' })
+    .getByText('Hannah Arendt')
+
+  await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+  await expect(disksLink).not.toBeInViewport()
+  await expect(userName).toBeHidden()
+
+  // The instance tab list is wider than a phone and should scroll within the page.
+  const tabList = page.getByRole('tablist')
+  await expect
+    .poll(() =>
+      tabList.evaluate((element) => ({
+        overflowX: getComputedStyle(element).overflowX,
+        overflows: element.scrollWidth > element.clientWidth,
+      }))
+    )
+    .toEqual({ overflowX: 'auto', overflows: true })
+
+  await toggle.click()
+  await expect(toggle).toHaveAttribute('aria-expanded', 'true')
+  await expect(disksLink).toBeInViewport()
+
+  // Click the scrim to the right of the sidebar.
+  await page.mouse.click(390, 100)
+  await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+  await expect(disksLink).not.toBeInViewport()
+
+  await toggle.click()
+  await disksLink.click()
+  await expect(page).toHaveURL('/projects/mock-project/disks')
+  await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+  await expect(disksLink).not.toBeInViewport()
+
+  // Just below the desktop breakpoint, the drawer and hidden username persist.
+  await page.setViewportSize({ width: 999, height: 800 })
+  await expect(toggle).toBeVisible()
+  await expect(disksLink).not.toBeInViewport()
+  await expect(userName).toBeHidden()
+
+  // At the desktop breakpoint the persistent sidebar replaces the toggle and
+  // the username reappears.
+  await page.setViewportSize({ width: 1000, height: 800 })
+  await expect(toggle).toBeHidden()
+  await expect(disksLink).toBeInViewport()
+  await expect(userName).toBeVisible()
+})
+
+test('mobile dialogs and toasts stay within the viewport', async ({ page }) => {
+  await page.setViewportSize({ width: 320, height: 800 })
+  await page.goto('/projects/mock-project/disks')
+
+  await page.getByRole('link', { name: 'disk-1', exact: true }).click()
+  const sideModal = page.getByRole('dialog', { name: 'Disk details' })
+  await expect(sideModal).toBeVisible()
+  await expect
+    .poll(() =>
+      sideModal.evaluate((element) => {
+        const { left, right, width } = element.getBoundingClientRect()
+        return { left, right, width }
+      })
+    )
+    .toEqual({ left: 0, right: 320, width: 320 })
+  await page.keyboard.press('Escape')
+  await expect(sideModal).toBeHidden()
+
+  await clickRowAction(page, 'disk-3', 'Delete')
+  const confirmModal = page.getByRole('dialog', { name: 'Delete disk' })
+  await expect(confirmModal).toBeVisible()
+  await expect
+    .poll(() =>
+      confirmModal.evaluate((element) => {
+        const { left, right, width } = element.getBoundingClientRect()
+        return { left, right, width }
+      })
+    )
+    .toEqual({ left: 16, right: 304, width: 288 })
+
+  await confirmModal.getByRole('button', { name: 'Confirm' }).click()
+  await expect(page.getByTestId('Toasts').getByText('Disk disk-3 deleted')).toBeVisible()
+
+  const toast = page.locator('.shadow-toast')
+  await expect
+    .poll(() =>
+      toast.evaluate((element) => {
+        const { left, right, width } = element.getBoundingClientRect()
+        return { left, right, width }
+      })
+    )
+    .toEqual({ left: 16, right: 304, width: 288 })
+})

--- a/test/visual/regression.e2e.ts
+++ b/test/visual/regression.e2e.ts
@@ -222,7 +222,8 @@ test.describe('Visual Regression', { tag: '@visual' }, () => {
 
   test('serial console', async ({ page }) => {
     await page.goto(`${p}/instances/db1/serial-console`, { waitUntil: 'networkidle' })
-    await expect(page.getByText('Serial Console')).toBeVisible()
+    // role-scoped: getByText also matches the hidden breadcrumb measurement copy
+    await expect(page.getByRole('link', { name: 'Serial Console' })).toBeVisible()
     await expect(page).toHaveScreenshot('serial-console.png', fullPage)
   })
 


### PR DESCRIPTION
#3178 was meant to redo part of #2087 as a stepping stone to a proper mobile layout, but then we didn't follow up, which means the mobile layout actually got worse — it's really bad! This is an attempt at some quick fixes to make it tolerable without breaking anything for desktop users. As long as nothing on desktop sizes is affected, even if there are flaws it's hard for it to be worse than the status quo. I think it feels really good, and a thorough review by Fable 5.1 didn't turn up any regressions at desktop sizes.

## 🤖 Summary

Makes the console usable below 1000px, which is the existing `1000:` breakpoint from the design system. Above that width the layout is unchanged apart from the items called out at the end.

### Navigation

- **Sidebar becomes an overlay on small screens.** A hamburger toggle in the top bar opens it over the content with a scrim. It closes on scrim click and on any navigation, including navigations from breadcrumbs or quick actions. Open state lives in a small zustand store (`app/stores/mobile-nav.ts`) so the top bar and sidebar can share it. `PageSkeleton` renders the sidebar closed so there is no flash of an open drawer during load.
- **Top bar collapses to a single cell.** The home button cell only exists at desktop width. The shared class strings in `app/layouts/helpers.tsx` are used by both `TopBar` and `PageSkeleton` so the two can't drift.
- **Breadcrumbs collapse instead of overflowing.** When the path doesn't fit, leading crumbs are folded into a "…" menu listing the full path, keeping the silo picker and user menu in view. Widths are measured from an invisible copy of the crumbs so the longest complete suffix that fits can be chosen; the current crumb is the last to give way and truncates with an ellipsis as a final fallback. This applies at all widths, so long paths on desktop also collapse rather than pushing the right-side controls off screen.
- **User menu shows the username inside the menu** on small screens, where it is hidden from the trigger to save space.

### Components

- `Modal`, `SideModal`, `Toast`, and `ErrorPage` are capped to the viewport width with a gutter so they no longer run edge to edge or overflow.
- Tab lists scroll horizontally below the breakpoint instead of overflowing the page.
- `CardBlock.Header` actions, `DisksTableField` buttons, `Radio` cards, and `DateTimeRangePicker` stack or stretch to full width on small screens.
- Serial console terminal uses the full width and hides the scroll buttons on small screens; the footer height becomes content-driven.
- Side modal gutter shrinks to 1.5rem below the breakpoint.

### Changes that also affect desktop

- `--content-gutter` shrinks below 1000px rather than 768px, so windows between 768 and 999px get the narrower gutter. This aligns the gutter with the layout breakpoint used everywhere else.
- `overscroll-behavior-y: none` on `body` prevents pull-to-refresh and scroll chaining behind the sidebar overlay. On macOS this also removes the vertical rubber-band bounce.
- `DropdownMenu.Content` defaults `collisionPadding` to 12px (Base UI default is 5px) so menus keep a consistent margin from the viewport edge.

### Tests

- New `test/e2e/mobile-layout.e2e.ts` covers the sidebar overlay open/close/navigate flow, the breakpoint transition at 999/1000px, the username in the user menu, and modal/toast bounds at 320px.
- `test/e2e/breadcrumbs.e2e.ts` adds cases for collapsed breadcrumbs at 404, 650, 750, and 1024px, including the full-path menu.
- The serial console visual regression test is scoped to a role locator because `getByText` now also matches the hidden breadcrumb measurement copy.
