### PR TITLE
More responsiveness touch-ups

### DIFF
--- a/app/components/CopyCode.tsx
+++ b/app/components/CopyCode.tsx
@@ -98,7 +98,12 @@ export function EquivalentCliCommand({ project, instance }: EquivProps) {
 
   return (
     <>
-      <Button variant="secondary" size="sm" onClick={() => setIsOpen(true)}>
+      <Button
+        variant="secondary"
+        size="sm"
+        className="max-1000:hidden"
+        onClick={() => setIsOpen(true)}
+      >
         CLI Command
       </Button>
       <CopyCodeModal

--- a/app/components/ErrorPage.tsx
+++ b/app/components/ErrorPage.tsx
@@ -40,7 +40,7 @@ export function ErrorPage({ children }: Props) {
         </Link>
         <SignOutButton className="mt-4 mr-6" />
       </div>
-      <div className="bg-raise! shadow-modal max-1000:w-[calc(100%-var(--content-gutter)*2)] absolute top-1/2 left-1/2 flex w-96 -translate-x-1/2 -translate-y-1/2 flex-col items-center justify-center space-y-4 rounded-lg p-8">
+      <div className="bg-raise! shadow-modal max-1000:w-[calc(100%-var(--content-gutter)*2)] absolute top-1/2 left-1/2 flex max-w-96 -translate-x-1/2 -translate-y-1/2 flex-col items-center justify-center space-y-4 rounded-lg p-8">
         <div className="my-2 flex h-12 w-12 items-center justify-center">
           <div className="bg-destructive-inverse absolute h-10 w-10 rounded-full opacity-40 motion-safe:animate-[ping_2s_cubic-bezier(0,0,0.2,1)_infinite]" />
           <Error12Icon className="text-error light:text-error-secondary relative h-8 w-8" />

--- a/app/components/Pagination.tsx
+++ b/app/components/Pagination.tsx
@@ -17,7 +17,7 @@ const Tunnel = tunnel()
 export function Pagination(props: UIPaginationProps) {
   return (
     <Tunnel.In>
-      <UIPagination className="gutter h-14 py-5" {...props} />
+      <UIPagination className="gutter py-4" {...props} />
     </Tunnel.In>
   )
 }

--- a/app/components/RouteTabs.tsx
+++ b/app/components/RouteTabs.tsx
@@ -38,6 +38,22 @@ const selectTab = (e: React.KeyboardEvent<HTMLDivElement>) => {
   }
 }
 
+function RouteTabList({
+  className,
+  children,
+}: {
+  className?: string
+  children: ReactNode
+}) {
+  return (
+    // Keyboard nav is handled on the tablist; individual tabs take focus.
+    // oxlint-disable-next-line jsx-a11y/interactive-supports-focus
+    <div role="tablist" className={className} onKeyDown={selectTab}>
+      {children}
+    </div>
+  )
+}
+
 export interface RouteTabsProps {
   children: ReactNode
   fullWidth?: boolean
@@ -54,23 +70,24 @@ export function RouteTabs({
   tabListClassName,
 }: RouteTabsProps) {
   /* TODO: Add aria-describedby for active tab */
+  const tabList = (
+    <RouteTabList
+      className={cn(sideTabs ? 'ox-side-tabs-list' : 'ox-tabs-list', tabListClassName)}
+    >
+      {children}
+    </RouteTabList>
+  )
+
   return (
     <div
       className={cn(sideTabs ? 'ox-side-tabs flex' : 'ox-tabs', {
         'full-width': !sideTabs && fullWidth,
       })}
     >
-      {/* eslint-disable-next-line jsx-a11y/interactive-supports-focus */}
-      <div
-        role="tablist"
-        className={cn(sideTabs ? 'ox-side-tabs-list' : 'ox-tabs-list', tabListClassName)}
-        onKeyDown={selectTab}
-      >
-        {children}
-      </div>
+      {sideTabs ? tabList : <div className="ox-tabs-list-wrap">{tabList}</div>}
 
       <div
-        className={cn('ox-tabs-panel @container', { 'ml-5 grow': sideTabs })}
+        className={cn('ox-tabs-panel @container', { 'grow 1000:ml-5': sideTabs })}
         role="tabpanel"
         tabIndex={0}
       >

--- a/app/components/TimeSeriesChart.tsx
+++ b/app/components/TimeSeriesChart.tsx
@@ -481,7 +481,7 @@ const MetricsMessage = ({
       </div>
     </div>
     <div
-      className="bg-accent absolute inset-x-0 top-1 bottom-12"
+      className="bg-accent absolute inset-x-0 bottom-12"
       style={{
         background:
           'radial-gradient(200% 100% at 50% 100%, var(--surface-default) 0%, var(--surface-secondary) 100%)',

--- a/app/components/TopBar.tsx
+++ b/app/components/TopBar.tsx
@@ -62,13 +62,13 @@ function MobileNavToggle() {
   return (
     // full-height cell with a right border so the toggle reads as its own
     // region, mirroring the desktop home button cell
-    <div className="border-secondary 1000:hidden -ml-3 flex h-(--top-bar-height) shrink-0 items-center border-r px-1.5">
+    <div className="border-secondary 1000:hidden -ml-3 flex h-(--top-bar-height) shrink-0 items-center border-r">
       <button
         type="button"
         onClick={toggleMobileNav}
         aria-label="Toggle sidebar"
         aria-expanded={isOpen}
-        className="hover:bg-hover flex h-10 w-10 items-center justify-center rounded-md"
+        className="hover:bg-hover flex h-full w-10 items-center justify-center"
       >
         <Icon className="text-secondary" />
       </button>

--- a/app/components/form/fields/DisksTableField.tsx
+++ b/app/components/form/fields/DisksTableField.tsx
@@ -75,25 +75,23 @@ export function DisksTableField({
           emptyState={{ title: 'No disks', body: 'Add a disk to see it here' }}
         />
 
-        <div className="max-1000:flex-col flex gap-3">
-          <Button
-            size="sm"
-            className="max-1000:w-full"
-            onClick={() => setShowDiskCreate(true)}
-            disabled={disabled}
-          >
-            Create new disk
-          </Button>
-          <Button
-            variant="secondary"
-            size="sm"
-            className="max-1000:w-full"
-            onClick={() => setShowDiskAttach(true)}
-            disabled={disabled}
-          >
-            Attach existing disk
-          </Button>
-        </div>
+        <Button
+          size="sm"
+          className="max-1000:w-full"
+          onClick={() => setShowDiskCreate(true)}
+          disabled={disabled}
+        >
+          Create new disk
+        </Button>
+        <Button
+          variant="secondary"
+          size="sm"
+          className="max-1000:w-full"
+          onClick={() => setShowDiskAttach(true)}
+          disabled={disabled}
+        >
+          Attach existing disk
+        </Button>
       </div>
 
       {showDiskCreate && (

--- a/app/components/oxql-metrics/OxqlMetric.tsx
+++ b/app/components/oxql-metrics/OxqlMetric.tsx
@@ -124,7 +124,13 @@ export function OxqlMetric({ title, description, unit, ...queryObj }: OxqlMetric
 export const MetricHeader = ({ children }: { children: ReactNode }) => {
   // If header has only one child, align it to the end of the container
   const justify = Children.count(children) === 1 ? 'justify-end' : 'justify-between'
-  return <div className={`flex flex-wrap gap-2 ${justify}`}>{children}</div>
+  return (
+    <div
+      className={`max-1000:flex-col max-1000:[&>*]:w-full flex flex-wrap gap-2 ${justify}`}
+    >
+      {children}
+    </div>
+  )
 }
 export const MetricCollection = classed.div`mt-3 flex flex-col gap-4`
 

--- a/app/pages/SiloUtilizationPage.tsx
+++ b/app/pages/SiloUtilizationPage.tsx
@@ -96,13 +96,13 @@ export default function SiloUtilizationPage() {
 
       <Divider className="my-8" />
 
-      <div className="mb-3 flex flex-wrap justify-between gap-3">
-        <div className="flex gap-2">
+      <div className="max-1000:flex-col mb-3 flex flex-wrap justify-between gap-3">
+        <div className="max-1000:w-full max-1000:flex-col flex gap-2">
           {intervalPicker}
 
           <Listbox
             selected={filterId}
-            className="w-52"
+            className="max-1000:w-full w-52"
             label="Filter by project"
             hideLabel
             name="filter-id"
@@ -110,7 +110,7 @@ export default function SiloUtilizationPage() {
             onChange={setFilterId}
           />
         </div>
-        <div className="flex items-center gap-2">{dateTimeRangePicker}</div>
+        <div className="max-1000:w-full flex items-center gap-2">{dateTimeRangePicker}</div>
       </div>
 
       <div className="mb-3 space-y-4">

--- a/app/pages/project/instances/CpuMetricsTab.tsx
+++ b/app/pages/project/instances/CpuMetricsTab.tsx
@@ -62,9 +62,9 @@ export default function CpuMetricsTab() {
   return (
     <>
       <MetricHeader>
-        <div className="flex gap-2">
+        <div className="max-1000:w-full flex gap-2">
           <Listbox
-            className="w-52"
+            className="max-1000:w-full w-52"
             aria-label="Choose state"
             name="disk-name"
             selected={selectedState}

--- a/app/pages/project/instances/DiskMetricsTab.tsx
+++ b/app/pages/project/instances/DiskMetricsTab.tsx
@@ -98,9 +98,9 @@ function DiskMetrics({ disks, instance }: { disks: Disk[]; instance: Instance })
   return (
     <>
       <MetricHeader>
-        <div className="flex gap-2">
+        <div className="max-1000:w-full flex gap-2">
           <Listbox
-            className="w-52"
+            className="max-1000:w-full w-52"
             aria-label="Choose disk"
             name="disk-name"
             selected={selectedDisk}

--- a/app/pages/project/instances/MetricsTab.tsx
+++ b/app/pages/project/instances/MetricsTab.tsx
@@ -56,7 +56,7 @@ export default function MetricsTab() {
   // Find the relevant <Outlet> in RouteTabs
   return (
     <MetricsContext.Provider value={context}>
-      <RouteTabs sideTabs tabListClassName="mt-14">
+      <RouteTabs sideTabs tabListClassName="max-1000:mb-4 1000:mt-14">
         <Tab to={pb.instanceCpuMetrics({ project, instance })}>CPU</Tab>
         <Tab to={pb.instanceDiskMetrics({ project, instance })}>Disk</Tab>
         <Tab to={pb.instanceNetworkMetrics({ project, instance })}>Network</Tab>

--- a/app/pages/project/instances/NetworkMetricsTab.tsx
+++ b/app/pages/project/instances/NetworkMetricsTab.tsx
@@ -100,9 +100,9 @@ function NetworkMetrics({ nics }: { nics: InstanceNetworkInterface[] }) {
   return (
     <>
       <MetricHeader>
-        <div className="flex gap-2">
+        <div className="max-1000:w-full flex gap-2">
           <Listbox
-            className="w-52"
+            className="max-1000:w-full w-52"
             aria-label="Choose network interface"
             name="nic-name"
             selected={selectedNic}

--- a/app/pages/project/instances/NetworkingTab.tsx
+++ b/app/pages/project/instances/NetworkingTab.tsx
@@ -696,24 +696,22 @@ export default function NetworkingTab() {
     <div className="space-y-5">
       <CardBlock>
         <CardBlock.Header title="External IPs" titleId="attached-ips-label">
-          <div className="flex gap-3">
-            <Button
-              size="sm"
-              onClick={() => setAttachEphemeralModalOpen(true)}
-              disabled={!!ephemeralDisabledReason}
-              disabledReason={ephemeralDisabledReason}
-            >
-              Attach ephemeral IP
-            </Button>
-            <Button
-              size="sm"
-              onClick={() => setAttachFloatingModalOpen(true)}
-              disabled={!!floatingDisabledReason}
-              disabledReason={floatingDisabledReason}
-            >
-              Attach floating IP
-            </Button>
-          </div>
+          <Button
+            size="sm"
+            onClick={() => setAttachEphemeralModalOpen(true)}
+            disabled={!!ephemeralDisabledReason}
+            disabledReason={ephemeralDisabledReason}
+          >
+            Attach ephemeral IP
+          </Button>
+          <Button
+            size="sm"
+            onClick={() => setAttachFloatingModalOpen(true)}
+            disabled={!!floatingDisabledReason}
+            disabledReason={floatingDisabledReason}
+          >
+            Attach floating IP
+          </Button>
         </CardBlock.Header>
 
         <CardBlock.Body>

--- a/app/pages/system/UtilizationPage.tsx
+++ b/app/pages/system/UtilizationPage.tsx
@@ -128,13 +128,13 @@ const MetricsTab = () => {
 
   return (
     <>
-      <div className="mt-8 mb-3 flex flex-wrap justify-between gap-3">
-        <div className="flex gap-2">
+      <div className="max-1000:flex-col mt-8 mb-3 flex flex-wrap justify-between gap-3">
+        <div className="max-1000:w-full max-1000:flex-col flex gap-2">
           {intervalPicker}
 
           <Listbox
             selected={filterId}
-            className="w-52"
+            className="max-1000:w-full w-52"
             label="Filter by silo"
             hideLabel
             name="filter-id"
@@ -142,7 +142,7 @@ const MetricsTab = () => {
             onChange={setFilterId}
           />
         </div>
-        <div className="flex items-center gap-2">{dateTimeRangePicker}</div>
+        <div className="max-1000:w-full flex items-center gap-2">{dateTimeRangePicker}</div>
       </div>
       <div className="mb-4 space-y-4">
         <SystemMetric

--- a/app/ui/lib/CardBlock.tsx
+++ b/app/ui/lib/CardBlock.tsx
@@ -45,7 +45,7 @@ type HeaderProps = {
 }
 
 CardBlock.Header = ({ title, description, children, titleId }: HeaderProps) => (
-  <header className="text-secondary flex items-start justify-between px-5 pb-4">
+  <header className="text-secondary max-800:flex-col flex items-start justify-between gap-4 px-5 pb-4">
     <div className="flex flex-col gap-0.5">
       <div className="text-sans-semi-lg text-raise" id={titleId}>
         {title}
@@ -53,7 +53,9 @@ CardBlock.Header = ({ title, description, children, titleId }: HeaderProps) => (
       {description && <div className="text-secondary">{description}</div>}
     </div>
 
-    <div className="max-1000:flex-col flex gap-2">{children}</div>
+    <div className="max-800:flex-col max-800:[&>.ox-button]:w-full! max-800:w-full flex gap-2">
+      {children}
+    </div>
   </header>
 )
 

--- a/app/ui/lib/DateRangePicker.tsx
+++ b/app/ui/lib/DateRangePicker.tsx
@@ -69,7 +69,7 @@ export function DateRangePicker(props: DateRangePickerProps) {
               : 'border-default ring-accent-secondary'
           )}
         >
-          <div className="text-sans-md relative flex w-[16rem] items-center px-3">
+          <div className="text-sans-md max-1000:sr-only 1000:w-[16rem] relative flex items-center px-3">
             <div className="truncate">{label}</div>
             {state.isInvalid && (
               <div className="text-error absolute top-0 right-2 bottom-0 flex items-center">
@@ -77,8 +77,8 @@ export function DateRangePicker(props: DateRangePickerProps) {
               </div>
             )}
           </div>
-          <div className="border-default -ml-px flex h-[calc(100%-12px)] w-10 items-center justify-center rounded-r-md border-l outline-hidden">
-            <Calendar16Icon className="text-secondary h-4 w-4" />
+          <div className="border-default max-1000:ml-0 1000:-ml-px 1000:border-l flex h-[calc(100%-12px)] w-10 items-center justify-center rounded-r-md outline-hidden">
+            <Calendar16Icon className="text-secondary h-4 w-4" aria-hidden />
           </div>
         </button>
       </div>

--- a/app/ui/lib/PageHeader.tsx
+++ b/app/ui/lib/PageHeader.tsx
@@ -9,17 +9,22 @@ import type { ReactElement } from 'react'
 
 import { classed } from '~/util/classed'
 
-export const PageHeader = classed.header`mb-16 mt-12 flex items-center justify-between max-1000:mt-8`
+import { Truncate } from './Truncate'
+
+// Title is allowed to shrink (`min-w-0`); actions keep their intrinsic width so
+// long names ellipsize instead of shoving buttons off-screen. Below 500px the
+// actions stack above the title and each row can use the full width.
+export const PageHeader = classed.header`mb-16 mt-12 flex w-full min-w-0 justify-between gap-4 max-500:flex-col max-500:*:last:order-0 max-500:*:first:order-1 500:items-center 500:[&>h1]:flex-1 500:[&>:not(h1)]:shrink-0 max-1000:mt-8`
 
 interface PageTitleProps {
   icon?: ReactElement
-  children: React.ReactNode
+  children: string
 }
 export const PageTitle = ({ children: title, icon }: PageTitleProps) => {
   return (
-    <h1 className="text-sans-3xl text-accent-secondary light:text-accent-tertiary inline-flex items-center space-x-2">
+    <h1 className="text-sans-3xl text-accent-secondary light:text-accent-tertiary flex min-w-0 items-center gap-2 [&>svg]:shrink-0">
       {icon}
-      <span className="text-accent light:text-raise">{title}</span>
+      <Truncate text={title} className="text-accent light:text-raise min-w-0 flex-1" />
     </h1>
   )
 }

--- a/app/ui/lib/PropertiesTable.tsx
+++ b/app/ui/lib/PropertiesTable.tsx
@@ -46,13 +46,15 @@ export function PropertiesTable({
       aria-label="Properties table"
       className={cn(
         className,
-        'properties-table bg-default border-default min-w-min basis-6/12 rounded-lg border',
-        '*:border-secondary *:border-t *:pr-6 *:pl-3 [&>*:nth-child(-n+2)]:border-t-0!',
-        'grid grid-cols-[minmax(min-content,1fr)_3fr]',
-        {
-          '1000:grid-cols-[minmax(min-content,1fr)_3fr_minmax(min-content,1fr)_3fr] 1000:[&>*:nth-child(-n+4)]:border-t-0! 1000:[&>*:nth-child(4n-2)]:border-r':
-            columns === 2,
-        }
+        'properties-table bg-default border-default w-full min-w-0 basis-6/12 rounded-lg border 1000:min-w-min',
+        '*:border-secondary *:border-t *:pr-6 *:pl-3 [&>*:nth-child(1)]:border-t-0!',
+        // stack label above value below the layout breakpoint so long IDs don't overflow
+        'grid grid-cols-1',
+        'max-1000:[&>*:nth-child(odd)]:pt-2 max-1000:[&>*:nth-child(odd)]:pb-1',
+        'max-1000:[&>*:nth-child(even)]:border-t-0 max-1000:[&>*:nth-child(even)]:pb-2',
+        columns === 2
+          ? '1000:grid-cols-[minmax(min-content,1fr)_3fr_minmax(min-content,1fr)_3fr] 1000:[&>*:nth-child(-n+4)]:border-t-0! 1000:[&>*:nth-child(4n-2)]:border-r'
+          : '1000:grid-cols-[minmax(min-content,1fr)_3fr] 1000:[&>*:nth-child(-n+2)]:border-t-0!'
       )}
     >
       {children}
@@ -69,7 +71,7 @@ PropertiesTable.Row = ({ label, children }: PropertiesTableRowProps) => (
     <span className="text-mono-sm text-secondary flex items-center whitespace-nowrap">
       {label}
     </span>
-    <div className="text-sans-md text-default flex h-[38px] items-center overflow-hidden pr-4 whitespace-nowrap">
+    <div className="text-sans-md text-default max-1000:h-auto flex h-[38px] items-center overflow-hidden pr-4 whitespace-nowrap">
       {children}
     </div>
   </>

--- a/app/ui/lib/Tabs.tsx
+++ b/app/ui/lib/Tabs.tsx
@@ -23,7 +23,9 @@ export const Tabs = {
     </BaseTabs.Tab>
   ),
   List: ({ className, ...props }: BaseTabs.List.Props) => (
-    <BaseTabs.List {...props} className={cn('ox-tabs-list', className)} />
+    <div className="ox-tabs-list-wrap">
+      <BaseTabs.List {...props} className={cn('ox-tabs-list', className)} />
+    </div>
   ),
   Content: ({ className, ...props }: BaseTabs.Panel.Props) => (
     <BaseTabs.Panel {...props} className={cn('ox-tabs-panel', className)} />

--- a/app/ui/styles/components/Tabs.css
+++ b/app/ui/styles/components/Tabs.css
@@ -11,7 +11,7 @@
 .ox-tabs-list-wrap {
   position: sticky;
   top: calc(var(--top-bar-height) + var(--preview-banner-height));
-  z-index: var(--z-top-bar);
+  z-index: var(--z-sticky);
   @apply bg-default light:bg-raise;
 }
 

--- a/app/ui/styles/components/Tabs.css
+++ b/app/ui/styles/components/Tabs.css
@@ -6,9 +6,18 @@
  * Copyright Oxide Computer Company
  */
 
+/* Sticky lives on a wrapper so the list can overflow-x without becoming
+   its own scroll container (which would prevent sticking). */
+.ox-tabs-list-wrap {
+  position: sticky;
+  top: calc(var(--top-bar-height) + var(--preview-banner-height));
+  z-index: var(--z-top-bar);
+  @apply bg-default light:bg-raise;
+}
+
 /* Tab list container styles */
 .ox-tabs-list {
-  @apply mb-8 flex bg-transparent;
+  @apply flex;
 }
 
 /* let long tab lists scroll horizontally on small screens instead of
@@ -21,9 +30,29 @@
   }
 }
 
+.ox-tabs > .ox-tabs-panel {
+  @apply mt-8;
+}
+
+/* forms can have multiple tab lists on one page; keep those in flow */
+.ox-form .ox-tabs-list-wrap {
+  position: static;
+  top: auto;
+  z-index: auto;
+  background-color: transparent;
+}
+
 .ox-tabs-list:after {
-  @apply border-secondary block w-full border-b;
+  @apply border-secondary block w-full flex-grow border-b;
   content: '';
+}
+
+@media (max-width: 999px) {
+  .ox-tabs-list:after {
+    width: var(--content-gutter);
+    min-width: max-content;
+    flex-shrink: 0;
+  }
 }
 
 /* Panel styles */
@@ -77,13 +106,28 @@
 }
 
 .ox-tabs.full-width .ox-tabs-list:before {
-  @apply border-secondary block w-10 min-w-max flex-shrink-0 border-b;
+  @apply border-secondary block min-w-max flex-shrink-0 border-b;
+  width: var(--content-gutter);
   content: '';
 }
 
 /* Side tabs styles */
+.ox-side-tabs {
+  @apply max-1000:flex-col flex;
+}
+
 .ox-side-tabs-list {
   @apply sticky top-10 flex w-[180px] flex-shrink-0 flex-col gap-0.5 self-start;
+}
+
+@media (max-width: 999px) {
+  .ox-side-tabs-list {
+    position: static;
+    top: auto;
+    width: 100%;
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
 }
 
 .ox-side-tabs-list .ox-tab {

--- a/app/ui/styles/index.css
+++ b/app/ui/styles/index.css
@@ -165,11 +165,11 @@
   body,
   #root {
     height: 100%;
+    overscroll-behavior-y: none; /* open for discussion but makes it feel more app-like */
   }
 
   body {
     @apply text-default bg-default font-sans;
-    overscroll-behavior-y: none;
   }
 
   /* https://github.com/tailwindlabs/tailwindcss/blob/v2.2.4/src/plugins/css/preflight.css#L57 */

--- a/app/ui/styles/vars.css
+++ b/app/ui/styles/vars.css
@@ -16,6 +16,7 @@
   --z-side-modal-overlay: 25;
   --z-top-bar-dropdown: 20;
   --z-top-bar: 15;
+  --z-sticky: 12;
   --z-popover: 10;
   --z-content-dropdown: 10;
   --z-content: 0;

--- a/test/e2e/mobile-layout.e2e.ts
+++ b/test/e2e/mobile-layout.e2e.ts
@@ -121,3 +121,96 @@ test('mobile dialogs and toasts stay within the viewport', async ({ page }) => {
     )
     .toEqual({ left: 16, right: 304, width: 288 })
 })
+
+test('properties table stacks label above value on small screens', async ({ page }) => {
+  await page.goto('/projects/mock-project/instances/db1')
+  const props = page.getByLabel('Properties table')
+  const label = props.getByText('cpu', { exact: true })
+  const value = props.getByText('2 vCPUs')
+  const columnCount = () =>
+    props.evaluate(
+      (element) => getComputedStyle(element).gridTemplateColumns.split(' ').length
+    )
+
+  await page.setViewportSize({ width: 404, height: 800 })
+  await expect.poll(columnCount).toBe(1)
+  const stacked = await Promise.all([label.boundingBox(), value.boundingBox()])
+  expect(stacked[0]).toBeTruthy()
+  expect(stacked[1]).toBeTruthy()
+  expect(stacked[0]!.y).toBeLessThan(stacked[1]!.y)
+
+  await page.setViewportSize({ width: 1000, height: 800 })
+  await expect.poll(columnCount).toBe(4)
+  const sideBySide = await Promise.all([label.boundingBox(), value.boundingBox()])
+  expect(sideBySide[0]).toBeTruthy()
+  expect(sideBySide[1]).toBeTruthy()
+  expect(sideBySide[0]!.x).toBeLessThan(sideBySide[1]!.x)
+})
+
+test('date range picker is icon-only on small screens', async ({ page }) => {
+  await page.goto('/projects/mock-project/instances/db1/metrics/cpu')
+  const picker = page.getByLabel('Choose a date range', { exact: true })
+  const button = picker.getByRole('button')
+
+  await page.setViewportSize({ width: 404, height: 800 })
+  await expect
+    .poll(() => button.evaluate((element) => element.getBoundingClientRect().width))
+    .toBeLessThan(50)
+
+  await page.setViewportSize({ width: 1000, height: 800 })
+  await expect
+    .poll(() => button.evaluate((element) => element.getBoundingClientRect().width))
+    .toBeGreaterThan(200)
+})
+
+test('metrics filters go full width on small screens', async ({ page }) => {
+  await page.goto('/system/utilization?tab=metrics')
+  const listbox = page.getByRole('button', { name: 'Filter by silo' })
+
+  await page.setViewportSize({ width: 404, height: 800 })
+  await expect
+    .poll(() => listbox.evaluate((element) => element.getBoundingClientRect().width))
+    .toBeGreaterThan(300)
+
+  await page.setViewportSize({ width: 1000, height: 800 })
+  await expect
+    .poll(() =>
+      listbox.evaluate((element) => Math.round(element.getBoundingClientRect().width))
+    )
+    .toBe(208)
+})
+
+test('tab list sticks under the top bar', async ({ page }) => {
+  // Short viewport so the page can scroll far enough for the tabs to hit the
+  // stick point (stacked properties above the tabs eat most of an 800px frame).
+  await page.setViewportSize({ width: 404, height: 480 })
+  await page.goto('/projects/mock-project/instances/db1/storage')
+
+  const tabList = page.getByRole('tablist')
+  const wrap = page.locator('.ox-tabs-list-wrap')
+  await expect
+    .poll(() => wrap.evaluate((element) => getComputedStyle(element).position))
+    .toBe('sticky')
+
+  await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight))
+  await expect
+    .poll(async () => {
+      const box = await tabList.boundingBox()
+      const top = await wrap.evaluate((element) =>
+        parseFloat(getComputedStyle(element).top)
+      )
+      return box ? Math.abs(box.y - top) < 2 : false
+    })
+    .toBe(true)
+})
+
+test('CLI command is hidden on small screens', async ({ page }) => {
+  await page.goto('/projects/mock-project/instances/db1/connect')
+  const cli = page.getByRole('button', { name: 'CLI Command' })
+
+  await page.setViewportSize({ width: 404, height: 800 })
+  await expect(cli).toBeHidden()
+
+  await page.setViewportSize({ width: 1000, height: 800 })
+  await expect(cli).toBeVisible()
+})


### PR DESCRIPTION
Adding back some fixes from the very first PR (#2087) and more general improvements.

We can also log any other responsive funkiness to fix here.

---

**1. Date range picker** — below 1000px the date text is screen-reader-only and the control is the calendar icon.

<img width="483" height="554" alt="image" src="https://github.com/user-attachments/assets/52f8a405-8d28-4132-95c9-3abeca300e4d" />

**2. Properties table** — labels stack above values so long IDs don’t overflow. Two-column tables still sit side-by-side from 1000px up.

<img width="480" height="236" alt="image" src="https://github.com/user-attachments/assets/5f03f75d-4d26-4098-94dd-d0d0b4cc1a7b" />

**4. Sticky tabs** — page tab lists stick under the top bar. Sticky is on a wrapper so it doesn’t fight horizontal scroll. Form tab lists (instance create) stay in flow.

<img width="484" height="225" alt="image" src="https://github.com/user-attachments/assets/5346d7d4-4834-44b2-9a12-adcfcb03c80b" />

**5. Metrics / utilization filters** — toolbars stack and listboxes go full width. Instance metrics side tabs (CPU / Disk / Network) move to a horizontal row so they don’t eat half the phone.

**6. CLI command** — hidden below 1000px on Connect and the serial console footer.

**7. Adjust menu icon button size** — fills cell and narrower

<img width="431" height="87" alt="image" src="https://github.com/user-attachments/assets/6e4b0a4b-969c-47d0-879a-cfa9423be9ab" />

**8. Fix error message container width**

**9. Tighter pagination footer density**

**10. Improve card header button wrapping**
<img width="481" height="349" alt="image" src="https://github.com/user-attachments/assets/09dd3154-9fe9-40de-8d42-8547e6942f9f" />

**11. Improve page header wrapping and truncation**
<img width="506" height="162" alt="image" src="https://github.com/user-attachments/assets/34f73385-0c9f-4beb-9b46-74eebee92d00" />
<img width="472" height="148" alt="image" src="https://github.com/user-attachments/assets/1ae99998-a091-426b-829e-4ff683adc8da" />

**12. Avoid sticky tab bar overlapping main top bar and disable overscroll bounce**

---

Todo:

- [ ] Can't see disk name in mini-table (additional disks)
