### PR TITLE
Add `ms` back to content, fix header overflow

### DIFF
--- a/app/pages/system/AuditLog.tsx
+++ b/app/pages/system/AuditLog.tsx
@@ -330,7 +330,7 @@ const COLUMNS = [
   { title: 'Actor ID', className: 'col-actor-id' },
   { title: 'Auth Method', className: 'col-auth-method' },
   { title: 'Silo ID', className: 'col-silo-id' },
-  { title: 'Duration (ms)', className: 'col-duration' },
+  { title: 'Duration', className: 'col-duration' },
 ] as const
 
 const HeaderCell = classed.div`text-mono-sm text-tertiary`
@@ -441,6 +441,7 @@ const Row = memo(function Row({
           {msFormat.format(
             differenceInMilliseconds(new Date(log.timeCompleted), log.timeStarted)
           )}
+          <span className="text-tertiary ml-0.5">ms</span>
         </div>
       </div>
     </div>
@@ -867,8 +868,8 @@ const ExpandedItem = ({
           <PropertiesTable.Row label="Duration">
             {msFormat.format(
               differenceInMilliseconds(new Date(item.timeCompleted), item.timeStarted)
-            )}{' '}
-            ms
+            )}
+            <span className="text-tertiary ml-0.5">ms</span>
           </PropertiesTable.Row>
         </PropertiesTable>
       </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,7 @@
         "vitest-browser-react": "^2.2.0"
       },
       "engines": {
-        "node": ">=22"
+        "node": "^24.15.0"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {


### PR DESCRIPTION
Before:
<img width="130" height="292" alt="image" src="https://github.com/user-attachments/assets/85f4aff5-a33f-4083-aeb0-a47bbd99fe77" />


After:
<img width="128" height="269" alt="image" src="https://github.com/user-attachments/assets/0593e209-fb99-4e16-813c-e9d38ba52707" />
