### PR TITLE
Update docs links

### DIFF
--- a/app/components/form/fields/SshKeysField.tsx
+++ b/app/components/form/fields/SshKeysField.tsx
@@ -22,6 +22,7 @@ import { Message } from '~/ui/lib/Message'
 import { TextInputHint } from '~/ui/lib/TextInput'
 import { isSubset } from '~/util/array'
 import { ALL_ISH } from '~/util/consts'
+import { links } from '~/util/links'
 
 import { CheckboxField } from './CheckboxField'
 import { ErrorMessage } from './ErrorMessage'
@@ -36,11 +37,7 @@ const CloudInitMessage = () => (
     content={
       <>
         If your image supports the cidata volume and{' '}
-        <a
-          target="_blank"
-          href="https://cloudinit.readthedocs.io/en/latest/"
-          rel="noreferrer"
-        >
+        <a target="_blank" href={links.cloudInit} rel="noreferrer">
           cloud-init
         </a>
         , the keys above will be added to your instance. Keys are added when the instance is

--- a/app/util/links.ts
+++ b/app/util/links.ts
@@ -11,8 +11,9 @@ const remoteAccess = 'https://docs.oxide.computer/guides/remote-access'
 // URLs used in inline prose links where the label is chosen to fit the
 // surrounding sentence. For links with a canonical label, use docLinks instead.
 export const links = {
-  cloudInitFormat: 'https://cloudinit.readthedocs.io/en/latest/explanation/format.html',
-  cloudInitExamples: 'https://cloudinit.readthedocs.io/en/latest/reference/examples.html',
+  cloudInit: 'https://docs.cloud-init.io/',
+  cloudInitFormat: 'https://docs.cloud-init.io/en/latest/explanation/format.html',
+  cloudInitExamples: 'https://docs.cloud-init.io/en/latest/reference/examples.html',
   firewallRulesDocs:
     'https://docs.oxide.computer/guides/configuring-guest-networking#_firewall_rules',
   preparingImagesDocs:
@@ -45,7 +46,7 @@ export const docLinks = {
     linkText: 'Audit Log',
   },
   deviceTokens: {
-    href: 'https://docs.oxide.computer/guides/working-with-api-and-sdk#_device_token_setup',
+    href: 'https://docs.oxide.computer/guides/user-settings#_access_tokens',
     linkText: 'Access Tokens',
   },
   externalSubnets: {
@@ -93,7 +94,7 @@ export const docLinks = {
     linkText: 'Instance Actions',
   },
   oxql: {
-    href: 'https://docs.oxide.computer/guides/operator/system-metrics#_oxql_quickstart',
+    href: 'https://docs.oxide.computer/guides/metrics/oxql-tutorial#_oxql_quick_start',
     linkText: 'OxQL',
   },
   keyConceptsProjects: {
@@ -117,7 +118,7 @@ export const docLinks = {
     linkText: 'Resource Management',
   },
   scim: {
-    href: 'https://docs.oxide.computer/guides/operator/identity-providers#_saml_authentication_scim_user_provisioning',
+    href: 'https://docs.oxide.computer/guides/operator/identity-providers#scim',
     linkText: 'SCIM',
   },
   serialConsole: {
@@ -133,7 +134,7 @@ export const docLinks = {
     linkText: 'VPC Subnet Routing',
   },
   sleds: {
-    href: 'https://docs.oxide.computer/guides/architecture/service-processors#_server_sled',
+    href: 'https://docs.oxide.computer/guides/architecture/rack-components#_server_sled',
     linkText: 'Server Sleds',
   },
   snapshots: {
@@ -145,7 +146,7 @@ export const docLinks = {
     linkText: 'SSH',
   },
   sshKeys: {
-    href: 'https://docs.oxide.computer/guides/user-settings#_ssh_keys',
+    href: 'https://docs.oxide.computer/guides/user-settings#manage-ssh-keys',
     linkText: 'SSH Keys',
   },
   storage: {
@@ -161,11 +162,11 @@ export const docLinks = {
     linkText: 'Subnet Pools',
   },
   systemMetrics: {
-    href: 'https://docs.oxide.computer/guides/operator/system-metrics',
-    linkText: 'Metrics',
+    href: 'https://docs.oxide.computer/guides/operator/resource-management#_calculating_utilization',
+    linkText: 'Utilization',
   },
   systemSiloCreate: {
-    href: 'https://docs.oxide.computer/guides/system/completing-rack-config#_create_silo',
+    href: 'https://docs.oxide.computer/guides/system/completing-rack-config#_create_a_silo',
     linkText: 'Create Silo',
   },
   systemSilo: {


### PR DESCRIPTION
This updates a few links (both to docs.oxide.computer URLs and to a couple of external URLs). Nothing major.

Also one label change, where the "Metrics" link label now reads **"Utilization"**, as
    A. the page linking to it is now called "Utilization"
and
    B. the docs themselves are now titled "Calculating Utilization"